### PR TITLE
ci: add pep/ to allowed backend import paths in docker-release guard

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -184,7 +184,7 @@ jobs:
           echo "Scanning backend imports for repo-root paths..."
           MATCHES=$(grep -RInE --exclude-dir node_modules --exclude-dir __tests__ --exclude-dir tests "from ['\"](\.\./){2,}|require\(['\"](\.\./){2,}" backend || true)
           if [ -n "$MATCHES" ]; then
-            echo "$MATCHES" | grep -v "braid-llm-kit" | grep -v "shared/" > /tmp/bad-imports.txt || true
+            echo "$MATCHES" | grep -v "braid-llm-kit" | grep -v "shared/" | grep -v "pep/" > /tmp/bad-imports.txt || true
             if [ -s /tmp/bad-imports.txt ]; then
               echo "ERROR: Found backend imports to repo-root paths not allowed in the backend image:"
               cat /tmp/bad-imports.txt


### PR DESCRIPTION
## Fix

The `docker-release.yml` import guard scans backend imports for `../../` paths that escape the backend directory. It already excludes `braid-llm-kit` and `shared/` (both are `COPY`'d into the Docker image), but was missing `pep/`.

PEP compiler/runtime is explicitly copied into the backend image:
```dockerfile
COPY pep ./pep
COPY pep /pep
```

This adds `pep/` to the grep exclusion list, fixing the CI failure on:
- `backend/routes/pep.js` → `../../pep/compiler/resolver.js`, `emitter.js`, `llmParser.js`
- `backend/routes/cashflow.js` → `../../pep/runtime/pepRuntime.js`

## Note on Doppler secrets
The workflow also requires these GitHub repo settings:
- **Secret:** `DOPPLER_TOKEN`
- **Variables:** `DOPPLER_PROJECT`, `DOPPLER_CONFIG`

These must be configured in GitHub repo Settings → Secrets and variables → Actions.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 11 failed — [View all](https://hub.continue.dev/inbox/pr/andreibyf/aishacrm-2/223?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->