### PR TITLE
fix: deduplicate Dockerfile COPY/symlink for pep/ and braid-llm-kit

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,9 +50,12 @@ COPY shared /shared
 # Copy PEP runtime to root level for cashflow route imports (../../pep from /app/routes/)
 COPY pep /pep
 
+# Also copy PEP to /app/pep for local imports within the backend
+COPY pep ./pep
+
 # Symlink /backend → /app so pepRuntime.js can resolve ../../backend/lib/braid/execution.js
 # (pepRuntime.js sits at /pep/runtime/ and uses a relative import to backend)
-RUN ln -s /app /backend
+RUN ln -sf /app /backend
 
 # Cache-busting mechanism for braid-llm-kit
 # This ARG will be set to the git commit SHA during GitHub Actions build
@@ -63,37 +66,18 @@ RUN echo "Cache bust value: ${CACHE_BUST}" > /tmp/cache-bust.txt
 # Copy braid-llm-kit to /app for route imports (../../braid-llm-kit from /app/routes/)
 COPY braid-llm-kit ./braid-llm-kit
 
-# Copy PEP compiler — lands at /app/pep/ inside the container
-COPY pep ./pep
-# Also copy to root /pep for ../../pep imports from /app/routes/
-COPY pep /pep
-
-# Symlink /backend → /app so pepRuntime's ../../backend/lib/... resolves correctly
-RUN ln -s /app /backend
-
 # Copy braid-llm-kit to root level for lib/braid imports (../../../braid-llm-kit from /app/lib/braid/)
 COPY braid-llm-kit /braid-llm-kit
-
-# Copy PEP runtime to root level for route imports (../../pep from /app/routes/)
-COPY pep /pep
 
 # Verify braid-llm-kit was copied correctly in both locations
 RUN ls -la ./braid-llm-kit/sdk/index.js || { echo "ERROR: /app/braid-llm-kit/sdk/index.js not found!"; exit 1; }
 RUN ls -la /braid-llm-kit/sdk/index.js || { echo "ERROR: /braid-llm-kit/sdk/index.js not found!"; exit 1; }
+
 # Verify PEP runtime is reachable
 RUN ls -la /pep/runtime/pepRuntime.js || { echo "ERROR: /pep/runtime/pepRuntime.js not found!"; exit 1; }
 
-# Verify PEP runtime exists
-RUN ls -la /pep/runtime/pepRuntime.js || { echo "ERROR: /pep/runtime/pepRuntime.js not found!"; exit 1; }
-
-# Symlink /backend → /app so that pep/runtime imports (../../backend/lib/...) resolve correctly
-RUN ln -s /app /backend
-
 # Verify shared contracts exist for agent registry imports
 RUN ls -la /shared/contracts/agents.js || { echo "ERROR: /shared/contracts/agents.js not found!"; exit 1; }
-
-# Verify PEP runtime exists for cashflow route imports
-RUN ls -la /pep/runtime/pepRuntime.js || { echo "ERROR: /pep/runtime/pepRuntime.js not found!"; exit 1; }
 
 # Copy entrypoint script and make it executable
 COPY backend/docker-entrypoint.sh ./entrypoint.sh


### PR DESCRIPTION
## Fix: Deduplicate Dockerfile COPY/symlink lines

The merge of `feature/pep-phase3-report-queries` introduced duplicate instructions:
- `COPY pep /pep` appeared 3 times
- `RUN ln -s /app /backend` appeared 3 times (causing build failure on 2nd/3rd)
- Duplicate verification steps

### Changes
- Consolidated to single `COPY pep /pep`, `COPY pep ./pep`, and one `ln -sf` (force flag)
- Kept all necessary copy targets (`/pep`, `./pep`, `/braid-llm-kit`, `./braid-llm-kit`)
- Single verification block

### Tested
- Docker build succeeds
- Backend starts cleanly with 197 endpoints, health check passing

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 11 failed — [View all](https://hub.continue.dev/inbox/pr/andreibyf/aishacrm-2/226?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->