### PR TITLE
fix: increase SSH deploy timeout to 20m for docker pull

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -443,6 +443,8 @@ jobs:
           key: ${{ steps.doppler-deploy.outputs.PROD_VPS_SSH_KEY }}
           port: ${{ steps.doppler-deploy.outputs.PROD_VPS_PORT || 22 }}
           envs: VERSION_TAG,MCP_GITHUB_TOKEN,DOPPLER_TOKEN
+          command_timeout: 20m
+          timeout: 25m
           script: |
             set -e  # Exit on any error
             cd /opt/aishacrm


### PR DESCRIPTION
## Fix: Deploy SSH timeout causing `Run Command Timeout`

The `Deploy to Production VPS` step was timing out mid-pull because `appleboy/ssh-action` has a default command timeout that's too short for pulling 5 Docker images sequentially (especially the backend image with Chromium at ~400MB+).

### Changes
- Added `command_timeout: 20m` — max time for the entire deploy script
- Added `timeout: 25m` — max time for SSH connection + script

### Evidence
```
out: bcbe1416a2a7: Pulling fs layer
out: 6587e54f9edd: Pulling fs layer
...
2026/02/20 21:32:02 Run Command Timeout
```

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 11 failed — [View all](https://hub.continue.dev/inbox/pr/andreibyf/aishacrm-2/227?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->