### PR TITLE
feat: Implement AI Email Template Support

### DIFF
--- a/backend/__tests__/services/templateEmailDraftService.test.js
+++ b/backend/__tests__/services/templateEmailDraftService.test.js
@@ -1,0 +1,333 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { generateTemplateDrivenEmailDraft } from '../../services/templateEmailDraftService.js';
+
+function createSupabaseStub({
+  template = null,
+  relatedEntities = {},
+  notes = [],
+  links = [],
+  messages = [],
+} = {}) {
+  const calls = {
+    executeSendEmailAction: [],
+    notifications: [],
+    tableQueries: [],
+    rpcCalls: [],
+  };
+
+  const notesTable = {
+    select() { return this; },
+    eq() { return this; },
+    order() { return this; },
+    limit() { return Promise.resolve({ data: notes, error: null }); },
+  };
+
+  const linksTable = {
+    select() { return this; },
+    eq() { return this; },
+    limit() { return Promise.resolve({ data: links, error: null }); },
+  };
+
+  const messagesTable = {
+    select() { return this; },
+    eq() { return this; },
+    in() { return this; },
+    order() { return this; },
+    limit() { return Promise.resolve({ data: messages, error: null }); },
+  };
+
+  const notificationsTable = {
+    insert(payload) { calls.notifications.push(payload); return this; },
+    select() { return this; },
+    async single() {
+      return { data: { id: `notification-${calls.notifications.length}` }, error: null };
+    },
+  };
+
+  const emailTemplateTable = {
+    select() { return this; },
+    or() { return this; },
+    eq() { return this; },
+    async maybeSingle() {
+      return { data: template, error: null };
+    },
+  };
+
+  return {
+    calls,
+    from(table) {
+      if (table === 'email_template') return emailTemplateTable;
+      if (table === 'note') return notesTable;
+      if (table === 'communications_entity_links') return linksTable;
+      if (table === 'communications_messages') return messagesTable;
+      if (table === 'notifications') return notificationsTable;
+      if (['leads', 'contacts', 'accounts', 'opportunities', 'bizdev_sources'].includes(table)) {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          async maybeSingle() {
+            return { data: relatedEntities[table] || null, error: null };
+          },
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+    rpc(name, params) {
+      calls.rpcCalls.push({ name, params });
+      return Promise.resolve({ data: null, error: null });
+    },
+  };
+}
+
+function createExecuteSendEmailAction(calls) {
+  return async (_supabase, _tenantId, _entityType, _entityId, emailPayload, _genMeta) => {
+    calls.executeSendEmailAction.push(emailPayload);
+    return {
+      status: emailPayload.require_approval ? 'pending_approval' : 'completed',
+      suggestion_id: 'suggestion-001',
+      activity_id: 'activity-001',
+      tokens: 42,
+    };
+  };
+}
+
+const TEMPLATE = {
+  id: 'tpl-001',
+  tenant_id: null,
+  name: 'Professional Follow-Up',
+  description: 'A follow-up email after a meeting',
+  category: 'follow_up',
+  subject_template: 'Following up on our conversation, {{first_name}}',
+  body_prompt:
+    'Write a professional follow-up email to {{first_name}} at {{company}}. Topic: {{meeting_topic}}. Tone: warm but professional.',
+  entity_types: ['lead', 'contact'],
+  variables: [
+    { name: 'meeting_topic', type: 'text', description: 'Meeting topic', required: false, default: 'our recent discussion' },
+  ],
+  is_system: true,
+  is_active: true,
+  usage_count: 5,
+};
+
+const ENTITY = {
+  id: 'lead-001',
+  first_name: 'Alice',
+  last_name: 'Smith',
+  company: 'Acme Corp',
+  email: 'alice@acme.com',
+};
+
+test('generates email draft from template with variable substitution', async () => {
+  const supabase = createSupabaseStub({
+    template: TEMPLATE,
+    relatedEntities: { leads: ENTITY },
+    notes: [{ id: 'n1', title: 'Call notes', content: 'Discussed pricing tiers.' }],
+  });
+
+  const result = await generateTemplateDrivenEmailDraft(
+    {
+      tenantId: 'tenant-001',
+      templateId: 'tpl-001',
+      entityType: 'lead',
+      entityId: 'lead-001',
+      variables: { meeting_topic: 'pricing discussion' },
+      requireApproval: true,
+      user: { id: 'user-001', first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com' },
+    },
+    {
+      supabase,
+      executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+    },
+  );
+
+  assert.equal(result.recipient_email, 'alice@acme.com');
+  assert.equal(result.subject, 'Following up on our conversation, Alice');
+  assert.equal(result.template.id, 'tpl-001');
+  assert.equal(result.template.name, 'Professional Follow-Up');
+  assert.ok(result.response.includes('Professional Follow-Up'));
+  assert.ok(result.response.includes('alice@acme.com'));
+  assert.equal(result.generation_result.status, 'pending_approval');
+
+  // Verify CARE was called with substituted prompt
+  const emailPayload = supabase.calls.executeSendEmailAction[0];
+  assert.ok(emailPayload.body_prompt.includes('Alice'));
+  assert.ok(emailPayload.body_prompt.includes('Acme Corp'));
+  assert.ok(emailPayload.body_prompt.includes('pricing discussion'));
+  assert.equal(emailPayload.source, 'template_ai_email');
+  assert.equal(emailPayload.activity_metadata.template_ai_email.template_id, 'tpl-001');
+});
+
+test('uses variable defaults when user does not provide a value', async () => {
+  const supabase = createSupabaseStub({
+    template: TEMPLATE,
+    relatedEntities: { leads: ENTITY },
+  });
+
+  const result = await generateTemplateDrivenEmailDraft(
+    {
+      tenantId: 'tenant-001',
+      templateId: 'tpl-001',
+      entityType: 'lead',
+      entityId: 'lead-001',
+      variables: {}, // No user variables — should use default
+      user: { id: 'user-001', first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com' },
+    },
+    {
+      supabase,
+      executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+    },
+  );
+
+  const emailPayload = supabase.calls.executeSendEmailAction[0];
+  // Default: "our recent discussion"
+  assert.ok(emailPayload.body_prompt.includes('our recent discussion'));
+});
+
+test('rejects entity type not supported by template', async () => {
+  const supabase = createSupabaseStub({
+    template: TEMPLATE, // Only supports lead, contact
+    relatedEntities: { accounts: { id: 'acc-001', name: 'Test Corp', email: 'test@corp.com' } },
+  });
+
+  await assert.rejects(
+    () =>
+      generateTemplateDrivenEmailDraft(
+        {
+          tenantId: 'tenant-001',
+          templateId: 'tpl-001',
+          entityType: 'account',
+          entityId: 'acc-001',
+          user: { id: 'user-001', email: 'bob@example.com' },
+        },
+        {
+          supabase,
+          executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+        },
+      ),
+    (err) => {
+      assert.equal(err.code, 'template_entity_type_mismatch');
+      return true;
+    },
+  );
+});
+
+test('rejects when template not found', async () => {
+  const supabase = createSupabaseStub({ template: null });
+
+  await assert.rejects(
+    () =>
+      generateTemplateDrivenEmailDraft(
+        {
+          tenantId: 'tenant-001',
+          templateId: 'nonexistent',
+          entityType: 'lead',
+          entityId: 'lead-001',
+          user: { id: 'user-001', email: 'bob@example.com' },
+        },
+        {
+          supabase,
+          executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+        },
+      ),
+    (err) => {
+      assert.equal(err.code, 'template_not_found');
+      return true;
+    },
+  );
+});
+
+test('rejects missing required variables', async () => {
+  const templateWithRequired = {
+    ...TEMPLATE,
+    variables: [
+      { name: 'deal_size', type: 'text', description: 'Deal size', required: true },
+    ],
+  };
+
+  const supabase = createSupabaseStub({
+    template: templateWithRequired,
+    relatedEntities: { leads: ENTITY },
+  });
+
+  await assert.rejects(
+    () =>
+      generateTemplateDrivenEmailDraft(
+        {
+          tenantId: 'tenant-001',
+          templateId: 'tpl-001',
+          entityType: 'lead',
+          entityId: 'lead-001',
+          variables: {}, // Missing required 'deal_size'
+          user: { id: 'user-001', email: 'bob@example.com' },
+        },
+        {
+          supabase,
+          executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+        },
+      ),
+    (err) => {
+      assert.equal(err.code, 'template_variable_validation_failed');
+      assert.ok(err.message.includes('deal_size'));
+      return true;
+    },
+  );
+});
+
+test('includes additional prompt when provided', async () => {
+  const supabase = createSupabaseStub({
+    template: TEMPLATE,
+    relatedEntities: { leads: ENTITY },
+  });
+
+  await generateTemplateDrivenEmailDraft(
+    {
+      tenantId: 'tenant-001',
+      templateId: 'tpl-001',
+      entityType: 'lead',
+      entityId: 'lead-001',
+      variables: {},
+      additionalPrompt: 'Mention the holiday discount',
+      user: { id: 'user-001', first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com' },
+    },
+    {
+      supabase,
+      executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+    },
+  );
+
+  const emailPayload = supabase.calls.executeSendEmailAction[0];
+  assert.ok(emailPayload.body_prompt.includes('Mention the holiday discount'));
+});
+
+test('auto-resolves CRM entity fields as variables (first_name, company, sender_name)', async () => {
+  const supabase = createSupabaseStub({
+    template: {
+      ...TEMPLATE,
+      entity_types: null, // Allow all
+    },
+    relatedEntities: { leads: ENTITY },
+  });
+
+  const result = await generateTemplateDrivenEmailDraft(
+    {
+      tenantId: 'tenant-001',
+      templateId: 'tpl-001',
+      entityType: 'lead',
+      entityId: 'lead-001',
+      variables: {},
+      user: { id: 'user-001', first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com' },
+    },
+    {
+      supabase,
+      executeSendEmailAction: createExecuteSendEmailAction(supabase.calls),
+    },
+  );
+
+  // Subject uses auto-resolved {{first_name}} from CRM entity
+  assert.equal(result.subject, 'Following up on our conversation, Alice');
+  // Body prompt uses auto-resolved {{company}}
+  const bodyPrompt = supabase.calls.executeSendEmailAction[0].body_prompt;
+  assert.ok(bodyPrompt.includes('Acme Corp'));
+});

--- a/backend/migrations/146_email_templates.sql
+++ b/backend/migrations/146_email_templates.sql
@@ -1,0 +1,149 @@
+-- Migration 146: Email Templates
+-- Adds email_template table for reusable AI email templates that combine
+-- structured template input with live CRM and thread context.
+
+CREATE TABLE IF NOT EXISTS email_template (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID,                          -- NULL for system templates, UUID for tenant-specific
+  name VARCHAR(255) NOT NULL,
+  description TEXT,
+  category VARCHAR(100) DEFAULT 'general', -- general, follow_up, introduction, proposal, etc.
+
+  -- Template content with {{variable}} placeholders
+  subject_template TEXT NOT NULL,           -- e.g. "Follow up: {{company}} partnership"
+  body_prompt TEXT NOT NULL,                -- AI prompt with placeholders and instructions
+
+  -- Allowed entity types this template applies to (NULL = all)
+  entity_types TEXT[] DEFAULT NULL,         -- e.g. '{lead,contact,account}'
+
+  -- Template variables definition
+  -- Each: { name, type, description, required, default }
+  variables JSONB NOT NULL DEFAULT '[]',
+
+  -- Metadata
+  is_system BOOLEAN DEFAULT false,
+  is_active BOOLEAN DEFAULT true,
+  usage_count INTEGER DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_email_template_tenant ON email_template(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_email_template_category ON email_template(category);
+CREATE INDEX IF NOT EXISTS idx_email_template_active ON email_template(is_active);
+CREATE INDEX IF NOT EXISTS idx_email_template_system ON email_template(is_system);
+
+-- Enable RLS
+ALTER TABLE email_template ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies: system templates readable by all, tenant templates scoped
+DROP POLICY IF EXISTS email_template_select ON email_template;
+CREATE POLICY email_template_select ON email_template
+  FOR SELECT USING (
+    is_system = true
+    OR tenant_id::text = current_setting('app.tenant_id', true)
+  );
+
+DROP POLICY IF EXISTS email_template_insert ON email_template;
+CREATE POLICY email_template_insert ON email_template
+  FOR INSERT WITH CHECK (
+    tenant_id::text = current_setting('app.tenant_id', true)
+  );
+
+DROP POLICY IF EXISTS email_template_update ON email_template;
+CREATE POLICY email_template_update ON email_template
+  FOR UPDATE USING (
+    tenant_id::text = current_setting('app.tenant_id', true)
+    AND is_system = false
+  );
+
+DROP POLICY IF EXISTS email_template_delete ON email_template;
+CREATE POLICY email_template_delete ON email_template
+  FOR DELETE USING (
+    tenant_id::text = current_setting('app.tenant_id', true)
+    AND is_system = false
+  );
+
+-- Seed a few system templates
+INSERT INTO email_template (id, tenant_id, name, description, category, subject_template, body_prompt, entity_types, variables, is_system, is_active)
+VALUES
+  (
+    'a0000000-0000-0000-0000-000000000001',
+    NULL,
+    'Professional Follow-Up',
+    'A polished follow-up email after an initial meeting or call',
+    'follow_up',
+    'Following up on our conversation, {{first_name}}',
+    'Write a professional follow-up email to {{first_name}} at {{company}}. Reference our recent conversation and express continued interest. Tone: warm but professional. Keep it concise — under 150 words.',
+    '{lead,contact}',
+    '[{"name":"meeting_topic","type":"text","description":"Brief topic of the previous meeting","required":false,"default":"our recent discussion"}]',
+    true,
+    true
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000002',
+    NULL,
+    'Introduction Email',
+    'Introduce yourself or your company to a new prospect',
+    'introduction',
+    'Introduction from {{sender_name}} — {{company}}',
+    'Write a friendly introduction email to {{first_name}} at {{company}}. Briefly introduce who we are and why we are reaching out. Mention any relevant context from CRM notes. Tone: approachable and genuine. Under 200 words.',
+    '{lead,bizdev_source}',
+    '[{"name":"value_proposition","type":"text","description":"Key value proposition to highlight","required":false,"default":""}]',
+    true,
+    true
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000003',
+    NULL,
+    'Thank You After Meeting',
+    'Send a thank-you email after a meeting or demo',
+    'follow_up',
+    'Thank you for your time, {{first_name}}',
+    'Write a genuine thank-you email to {{first_name}} at {{company}} after a meeting. Reference any specific topics discussed from CRM notes. Include a brief mention of next steps if applicable. Tone: sincere and professional. Under 120 words.',
+    '{lead,contact,account}',
+    '[{"name":"next_steps","type":"text","description":"Agreed next steps from the meeting","required":false,"default":""}]',
+    true,
+    true
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000004',
+    NULL,
+    'Proposal Follow-Up',
+    'Follow up after sending a proposal or quote',
+    'proposal',
+    'Regarding your proposal — {{company}}',
+    'Write a follow-up email to {{first_name}} at {{company}} regarding a proposal we sent. Ask if they have any questions, gently nudge toward a decision without being pushy. Reference any recent communications for context. Tone: confident but not aggressive. Under 150 words.',
+    '{contact,account,opportunity}',
+    '[{"name":"proposal_date","type":"text","description":"When the proposal was sent","required":false,"default":"recently"}]',
+    true,
+    true
+  ),
+  (
+    'a0000000-0000-0000-0000-000000000005',
+    NULL,
+    'Re-Engagement',
+    'Reach out to a quiet or dormant contact',
+    'outreach',
+    'It has been a while, {{first_name}}',
+    'Write a re-engagement email to {{first_name}} at {{company}} who we have not heard from in a while. Be warm and curious — ask how things are going. Avoid being guilt-trippy. Offer value or a reason to reconnect. Tone: friendly and low-pressure. Under 120 words.',
+    '{lead,contact}',
+    '[]',
+    true,
+    true
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- RPC function to atomically increment usage count
+CREATE OR REPLACE FUNCTION increment_email_template_usage(template_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE email_template
+  SET usage_count = usage_count + 1, updated_at = NOW()
+  WHERE id = template_id;
+END;
+$$;

--- a/backend/routes/ai.js
+++ b/backend/routes/ai.js
@@ -49,6 +49,7 @@ import {
 } from '../lib/intentClassifier.js';
 import { getVisibilityScope, getAccessLevel } from '../lib/teamVisibility.js';
 import { generateChatDrivenEmailDraft } from '../services/chatDrivenEmailDraftService.js';
+import { generateTemplateDrivenEmailDraft } from '../services/templateEmailDraftService.js';
 import {
   normalizeEmailEntityType,
   buildEntityTableName,
@@ -525,6 +526,100 @@ export default function createAIRoutes(pgPool) {
       return res.status(error.statusCode || 500).json({
         status: 'error',
         code: error.code || 'chat_ai_email_generation_failed',
+        message: error.message,
+      });
+    }
+  });
+
+  // POST /api/ai/draft-from-template — Generate email draft from a reusable template
+  router.post('/draft-from-template', async (req, res) => {
+    try {
+      const tenantIdentifier = getTenantId(req);
+      const tenantRecord = await resolveTenantRecord(tenantIdentifier);
+
+      if (!tenantRecord?.id) {
+        return res.status(400).json({ status: 'error', message: 'Valid tenant_id required' });
+      }
+
+      const authCheck = validateUserTenantAccess(req, tenantIdentifier, tenantRecord);
+      if (!authCheck.authorized) {
+        logger.warn('[AI Security] Template draft blocked - unauthorized tenant access');
+        return res
+          .status(authCheck.status || 403)
+          .json({ status: 'error', message: authCheck.error });
+      }
+
+      const {
+        template_id: templateId,
+        entity_type: entityType,
+        entity_id: entityId,
+        variables,
+        additional_prompt: additionalPrompt,
+        require_approval: requireApproval,
+        conversation_id: conversationId,
+      } = req.body || {};
+
+      if (!templateId || !entityType || !entityId) {
+        return res.status(400).json({
+          status: 'error',
+          message: 'template_id, entity_type, and entity_id are required',
+        });
+      }
+
+      // Ownership / visibility check
+      if (req.user) {
+        const supabaseCheck = getSupabaseClient();
+        const normalizedType = normalizeEmailEntityType(entityType);
+        const tableName = buildEntityTableName(normalizedType);
+
+        if (!tableName) {
+          return res.status(400).json({ status: 'error', message: 'Unsupported entity_type' });
+        }
+
+        const { data: record, error: recordError } = await supabaseCheck
+          .from(tableName)
+          .select('id, assigned_to, assigned_to_team')
+          .eq('tenant_id', tenantRecord.id)
+          .eq('id', entityId)
+          .maybeSingle();
+
+        if (recordError) throw new Error(recordError.message);
+        if (!record) return res.status(404).json({ status: 'error', message: 'Record not found' });
+
+        const scope = await getVisibilityScope(req.user, supabaseCheck);
+        const access = getAccessLevel(
+          scope,
+          record.assigned_to_team,
+          record.assigned_to,
+          req.user.id,
+        );
+
+        if (access !== 'full') {
+          return res.status(403).json({
+            status: 'error',
+            message: 'You do not have permission to draft AI emails for this record',
+          });
+        }
+      }
+
+      const result = await generateTemplateDrivenEmailDraft({
+        tenantId: tenantRecord.id,
+        templateId,
+        entityType,
+        entityId,
+        variables,
+        additionalPrompt,
+        requireApproval,
+        conversationId,
+        user: req.user,
+      });
+
+      return res.json({ status: 'success', response: result.response, data: result });
+    } catch (error) {
+      logger.error('[AI draft-from-template] Error:', error);
+      return res.status(error.statusCode || 500).json({
+        status: 'error',
+        code: error.code || 'template_email_generation_failed',
         message: error.message,
       });
     }

--- a/backend/routes/email-templates.v2.js
+++ b/backend/routes/email-templates.v2.js
@@ -1,0 +1,268 @@
+/**
+ * Email Templates API Routes (V2)
+ *
+ * CRUD for reusable AI email templates with {{variable}} placeholders.
+ * Templates combine structured prompts with live CRM context at generation time.
+ */
+
+import express from 'express';
+import { getSupabaseClient } from '../lib/supabase-db.js';
+import logger from '../lib/logger.js';
+
+const ALLOWED_CATEGORIES = [
+  'general',
+  'follow_up',
+  'introduction',
+  'proposal',
+  'outreach',
+  'thank_you',
+  'update',
+];
+
+function validateTemplatePayload(body) {
+  const errors = [];
+  if (!body.name || typeof body.name !== 'string' || !body.name.trim()) {
+    errors.push('name is required');
+  }
+  if (!body.subject_template || typeof body.subject_template !== 'string' || !body.subject_template.trim()) {
+    errors.push('subject_template is required');
+  }
+  if (!body.body_prompt || typeof body.body_prompt !== 'string' || !body.body_prompt.trim()) {
+    errors.push('body_prompt is required');
+  }
+  if (body.category && !ALLOWED_CATEGORIES.includes(body.category)) {
+    errors.push(`category must be one of: ${ALLOWED_CATEGORIES.join(', ')}`);
+  }
+  if (body.variables !== undefined) {
+    if (!Array.isArray(body.variables)) {
+      errors.push('variables must be an array');
+    } else {
+      for (const v of body.variables) {
+        if (!v.name || typeof v.name !== 'string') {
+          errors.push('each variable must have a name string');
+          break;
+        }
+      }
+    }
+  }
+  if (body.entity_types !== undefined && body.entity_types !== null) {
+    if (!Array.isArray(body.entity_types)) {
+      errors.push('entity_types must be an array or null');
+    }
+  }
+  return errors;
+}
+
+export default function createEmailTemplateRoutes(_pgPool) {
+  const router = express.Router();
+
+  // GET /api/v2/email-templates — List templates
+  router.get('/', async (req, res) => {
+    try {
+      const tenantId = req.tenant?.id;
+      if (!tenantId) return res.status(400).json({ status: 'error', message: 'Tenant required' });
+
+      const { category, entity_type, is_active = 'true' } = req.query;
+      const supabase = getSupabaseClient();
+
+      let query = supabase
+        .from('email_template')
+        .select('id, name, description, category, subject_template, body_prompt, entity_types, variables, is_system, is_active, usage_count, created_at, updated_at')
+        .or(`tenant_id.eq.${tenantId},is_system.eq.true`)
+        .order('is_system', { ascending: false })
+        .order('usage_count', { ascending: false })
+        .order('name', { ascending: true });
+
+      if (is_active !== 'all') {
+        query = query.eq('is_active', is_active === 'true');
+      }
+      if (category) {
+        query = query.eq('category', category);
+      }
+
+      const { data, error } = await query;
+      if (error) throw new Error(error.message);
+
+      let templates = data || [];
+
+      // Filter by entity_type if provided (client-side since it's an array column)
+      if (entity_type) {
+        templates = templates.filter(
+          (t) => !t.entity_types || t.entity_types.includes(entity_type),
+        );
+      }
+
+      return res.json({
+        status: 'success',
+        data: templates,
+        meta: {
+          total: templates.length,
+          categories: [...new Set(templates.map((t) => t.category))],
+        },
+      });
+    } catch (error) {
+      logger.error('[email-templates] GET / error:', error);
+      return res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+
+  // GET /api/v2/email-templates/:id — Get single template
+  router.get('/:id', async (req, res) => {
+    try {
+      const tenantId = req.tenant?.id;
+      if (!tenantId) return res.status(400).json({ status: 'error', message: 'Tenant required' });
+
+      const { id } = req.params;
+      const supabase = getSupabaseClient();
+
+      const { data, error } = await supabase
+        .from('email_template')
+        .select('*')
+        .or(`tenant_id.eq.${tenantId},is_system.eq.true`)
+        .eq('id', id)
+        .maybeSingle();
+
+      if (error) throw new Error(error.message);
+      if (!data) return res.status(404).json({ status: 'error', message: 'Template not found' });
+
+      return res.json({ status: 'success', data });
+    } catch (error) {
+      logger.error('[email-templates] GET /:id error:', error);
+      return res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+
+  // POST /api/v2/email-templates — Create tenant template
+  router.post('/', async (req, res) => {
+    try {
+      const tenantId = req.tenant?.id;
+      if (!tenantId) return res.status(400).json({ status: 'error', message: 'Tenant required' });
+
+      const errors = validateTemplatePayload(req.body);
+      if (errors.length > 0) {
+        return res.status(400).json({ status: 'error', message: errors.join('; ') });
+      }
+
+      const supabase = getSupabaseClient();
+
+      const { data, error } = await supabase
+        .from('email_template')
+        .insert({
+          tenant_id: tenantId,
+          name: req.body.name.trim(),
+          description: req.body.description?.trim() || null,
+          category: req.body.category || 'general',
+          subject_template: req.body.subject_template.trim(),
+          body_prompt: req.body.body_prompt.trim(),
+          entity_types: req.body.entity_types || null,
+          variables: req.body.variables || [],
+          is_system: false,
+          is_active: true,
+        })
+        .select('*')
+        .single();
+
+      if (error) throw new Error(error.message);
+
+      logger.info({ tenantId, templateId: data.id }, '[email-templates] Template created');
+      return res.status(201).json({ status: 'success', data });
+    } catch (error) {
+      logger.error('[email-templates] POST / error:', error);
+      return res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+
+  // PUT /api/v2/email-templates/:id — Update tenant template
+  router.put('/:id', async (req, res) => {
+    try {
+      const tenantId = req.tenant?.id;
+      if (!tenantId) return res.status(400).json({ status: 'error', message: 'Tenant required' });
+
+      const { id } = req.params;
+      const supabase = getSupabaseClient();
+
+      // Verify it's a tenant-owned template (not system)
+      const { data: existing, error: lookupError } = await supabase
+        .from('email_template')
+        .select('id, is_system, tenant_id')
+        .eq('id', id)
+        .eq('tenant_id', tenantId)
+        .maybeSingle();
+
+      if (lookupError) throw new Error(lookupError.message);
+      if (!existing) return res.status(404).json({ status: 'error', message: 'Template not found or not editable' });
+      if (existing.is_system) return res.status(403).json({ status: 'error', message: 'System templates cannot be edited' });
+
+      const updateFields = {};
+      if (req.body.name !== undefined) updateFields.name = req.body.name.trim();
+      if (req.body.description !== undefined) updateFields.description = req.body.description?.trim() || null;
+      if (req.body.category !== undefined) {
+        if (!ALLOWED_CATEGORIES.includes(req.body.category)) {
+          return res.status(400).json({ status: 'error', message: `category must be one of: ${ALLOWED_CATEGORIES.join(', ')}` });
+        }
+        updateFields.category = req.body.category;
+      }
+      if (req.body.subject_template !== undefined) updateFields.subject_template = req.body.subject_template.trim();
+      if (req.body.body_prompt !== undefined) updateFields.body_prompt = req.body.body_prompt.trim();
+      if (req.body.entity_types !== undefined) updateFields.entity_types = req.body.entity_types;
+      if (req.body.variables !== undefined) updateFields.variables = req.body.variables;
+      if (req.body.is_active !== undefined) updateFields.is_active = req.body.is_active;
+      updateFields.updated_at = new Date().toISOString();
+
+      const { data, error } = await supabase
+        .from('email_template')
+        .update(updateFields)
+        .eq('id', id)
+        .eq('tenant_id', tenantId)
+        .select('*')
+        .single();
+
+      if (error) throw new Error(error.message);
+
+      logger.info({ tenantId, templateId: id }, '[email-templates] Template updated');
+      return res.json({ status: 'success', data });
+    } catch (error) {
+      logger.error('[email-templates] PUT /:id error:', error);
+      return res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+
+  // DELETE /api/v2/email-templates/:id — Delete tenant template
+  router.delete('/:id', async (req, res) => {
+    try {
+      const tenantId = req.tenant?.id;
+      if (!tenantId) return res.status(400).json({ status: 'error', message: 'Tenant required' });
+
+      const { id } = req.params;
+      const supabase = getSupabaseClient();
+
+      // Verify ownership and not system
+      const { data: existing, error: lookupError } = await supabase
+        .from('email_template')
+        .select('id, is_system')
+        .eq('id', id)
+        .eq('tenant_id', tenantId)
+        .maybeSingle();
+
+      if (lookupError) throw new Error(lookupError.message);
+      if (!existing) return res.status(404).json({ status: 'error', message: 'Template not found' });
+      if (existing.is_system) return res.status(403).json({ status: 'error', message: 'System templates cannot be deleted' });
+
+      const { error } = await supabase
+        .from('email_template')
+        .delete()
+        .eq('id', id)
+        .eq('tenant_id', tenantId);
+
+      if (error) throw new Error(error.message);
+
+      logger.info({ tenantId, templateId: id }, '[email-templates] Template deleted');
+      return res.json({ status: 'success', message: 'Template deleted' });
+    } catch (error) {
+      logger.error('[email-templates] DELETE /:id error:', error);
+      return res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+
+  return router;
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -210,6 +210,7 @@ import createWorkflowV2Routes from './routes/workflows.v2.js';
 import createDocumentV2Routes from './routes/documents.v2.js';
 import createCommunicationsV2Routes from './routes/communications.v2.js';
 import createWorkflowTemplateRoutes from './routes/workflow-templates.js';
+import createEmailTemplateRoutes from './routes/email-templates.v2.js';
 import createNotificationRoutes from './routes/notifications.js';
 import createSystemLogRoutes from './routes/system-logs.js';
 import createAuditLogRoutes from './routes/audit-logs.js';
@@ -427,6 +428,13 @@ logger.debug('Mounting /api/v2/teams routes');
 app.use('/api/v2/teams', defaultLimiter, authenticateRequest, createTeamsV2Routes(measuredPgPool));
 logger.debug('Mounting /api/workflow-templates routes');
 app.use('/api/workflow-templates', defaultLimiter, createWorkflowTemplateRoutes(measuredPgPool));
+logger.debug('Mounting /api/v2/email-templates routes');
+app.use(
+  '/api/v2/email-templates',
+  defaultLimiter,
+  authenticateRequest,
+  createEmailTemplateRoutes(measuredPgPool),
+);
 app.use('/api/notifications', defaultLimiter, createNotificationRoutes(measuredPgPool));
 app.use('/api/system-logs', defaultLimiter, createSystemLogRoutes(measuredPgPool));
 app.use(

--- a/backend/services/templateEmailDraftService.js
+++ b/backend/services/templateEmailDraftService.js
@@ -1,0 +1,276 @@
+/**
+ * Template-Driven Email Draft Service
+ *
+ * Generates AI email drafts from reusable templates by:
+ * 1. Loading the template + substituting {{variables}} with user inputs + CRM context
+ * 2. Loading live CRM entity data, notes, and communications
+ * 3. Merging everything into a rich prompt for the AI engine
+ * 4. Routing through the CARE playbook for approval/delivery
+ */
+
+import { getSupabaseClient } from '../lib/supabase-db.js';
+import {
+  buildServiceError,
+  cleanString,
+  normalizeEmailEntityType,
+  loadRelatedEntityContext,
+  loadRecentNotes,
+  loadRecentCommunications,
+  formatContextBlock,
+  createAiEmailDraftNotification,
+} from './aiEmailDraftingSupport.js';
+import logger from '../lib/logger.js';
+
+/**
+ * Build variable context from CRM entity for automatic substitution.
+ * These are always available without the user providing them.
+ */
+function buildAutoVariables(entity, entityType, user) {
+  const vars = {};
+
+  if (entity) {
+    vars.first_name = entity.first_name || entity.name || '';
+    vars.last_name = entity.last_name || '';
+    vars.company = entity.company || entity.name || '';
+    vars.email = entity.email || '';
+    vars.entity_type = entityType || '';
+  }
+
+  if (user) {
+    vars.sender_name = [user.first_name, user.last_name].filter(Boolean).join(' ') || 'AiSHA';
+    vars.sender_email = user.email || '';
+  }
+
+  return vars;
+}
+
+/**
+ * Substitute {{variable}} placeholders in a string.
+ * Uses merged context: user-provided values override auto-resolved CRM values.
+ */
+function substituteVariables(text, variables) {
+  if (!text || typeof text !== 'string') return text;
+
+  return text.replace(/\{\{(\w+)\}\}/g, (match, varName) => {
+    const value = variables[varName];
+    if (value !== undefined && value !== null && value !== '') {
+      return String(value);
+    }
+    return match; // Keep placeholder if no value
+  });
+}
+
+/**
+ * Validate user-provided variable values against the template's variable definitions.
+ */
+function validateTemplateVariables(templateVariables, providedValues) {
+  const errors = [];
+
+  for (const varDef of templateVariables || []) {
+    const value = providedValues?.[varDef.name];
+    const isEmpty = value === undefined || value === null || value === '';
+
+    if (varDef.required && isEmpty && !varDef.default) {
+      errors.push(`Missing required variable: ${varDef.name}`);
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Resolve final variable values: defaults → auto (CRM) → user-provided.
+ */
+function resolveVariables(templateVariables, userValues, autoValues) {
+  const resolved = { ...autoValues };
+
+  // Apply defaults from template variable definitions
+  for (const varDef of templateVariables || []) {
+    if (varDef.default && !resolved[varDef.name]) {
+      resolved[varDef.name] = varDef.default;
+    }
+  }
+
+  // User-provided values override everything
+  if (userValues && typeof userValues === 'object') {
+    for (const [key, value] of Object.entries(userValues)) {
+      if (value !== undefined && value !== null && value !== '') {
+        resolved[key] = String(value);
+      }
+    }
+  }
+
+  return resolved;
+}
+
+export async function generateTemplateDrivenEmailDraft(
+  {
+    tenantId,
+    templateId,
+    entityType,
+    entityId,
+    variables: userVariables = {},
+    additionalPrompt,
+    requireApproval = true,
+    conversationId,
+    user,
+  },
+  { supabase = getSupabaseClient(), executeSendEmailAction } = {},
+) {
+  // Lazy-load CARE executor to avoid module-level Redis queue init
+  if (!executeSendEmailAction) {
+    const { executeCareSendEmailAction } = await import('../lib/care/carePlaybookExecutor.js');
+    executeSendEmailAction = executeCareSendEmailAction;
+  }
+  // 1. Load the template
+  const { data: template, error: templateError } = await supabase
+    .from('email_template')
+    .select('*')
+    .or(`tenant_id.eq.${tenantId},is_system.eq.true`)
+    .eq('id', templateId)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (templateError) {
+    throw buildServiceError(500, 'template_lookup_failed', templateError.message);
+  }
+  if (!template) {
+    throw buildServiceError(404, 'template_not_found', 'Email template not found or inactive');
+  }
+
+  // 2. Validate entity type compatibility
+  const normalizedEntityType = normalizeEmailEntityType(entityType);
+  if (!normalizedEntityType || !entityId) {
+    throw buildServiceError(
+      400,
+      'template_email_invalid_context',
+      'Template email drafting requires a supported entity context',
+    );
+  }
+
+  if (template.entity_types && !template.entity_types.includes(normalizedEntityType)) {
+    throw buildServiceError(
+      400,
+      'template_entity_type_mismatch',
+      `Template "${template.name}" does not support entity type "${normalizedEntityType}". Supported: ${template.entity_types.join(', ')}`,
+    );
+  }
+
+  // 3. Validate user-provided variables
+  const variableErrors = validateTemplateVariables(template.variables, userVariables);
+  if (variableErrors.length > 0) {
+    throw buildServiceError(400, 'template_variable_validation_failed', variableErrors.join('; '));
+  }
+
+  // 4. Load CRM context
+  const contextRecord = {
+    tenant_id: tenantId,
+    related_to: normalizedEntityType,
+    related_id: entityId,
+    related_email: null,
+  };
+
+  const [{ recipientEmail, entity }, notes, communications] = await Promise.all([
+    loadRelatedEntityContext(supabase, contextRecord),
+    loadRecentNotes(supabase, tenantId, contextRecord),
+    loadRecentCommunications(supabase, tenantId, contextRecord),
+  ]);
+
+  if (!recipientEmail) {
+    throw buildServiceError(
+      400,
+      'template_email_missing_recipient',
+      'Unable to resolve recipient email for this record',
+    );
+  }
+
+  // 5. Build merged variable context and substitute
+  const autoVars = buildAutoVariables(entity, normalizedEntityType, user);
+  const resolvedVars = resolveVariables(template.variables, userVariables, autoVars);
+  const resolvedSubject = substituteVariables(template.subject_template, resolvedVars);
+  const resolvedBodyPrompt = substituteVariables(template.body_prompt, resolvedVars);
+
+  // 6. Build full prompt with CRM context
+  const promptContext = formatContextBlock(contextRecord, entity, notes, communications);
+  const promptParts = [resolvedBodyPrompt];
+  if (additionalPrompt) {
+    promptParts.push(`Additional instructions: ${cleanString(additionalPrompt)}`);
+  }
+  if (promptContext) {
+    promptParts.push(promptContext);
+  }
+  const mergedPrompt = promptParts.join('\n\n');
+
+  // 7. Generate via CARE playbook
+  const requestedAt = new Date().toISOString();
+  const sourceRecord = {
+    id: entityId,
+    type: 'template_ai_email',
+    related_to: normalizedEntityType,
+    related_id: entityId,
+  };
+
+  const generationResult = await executeSendEmailAction(
+    supabase,
+    tenantId,
+    normalizedEntityType,
+    entityId,
+    {
+      to: recipientEmail,
+      subject: resolvedSubject,
+      body_prompt: mergedPrompt,
+      use_ai_generation: true,
+      require_approval: requireApproval !== false,
+      source: 'template_ai_email',
+      activity_metadata: {
+        template_ai_email: {
+          template_id: template.id,
+          template_name: template.name,
+          conversation_id: conversationId || null,
+          generated_by_user_id: user?.id || null,
+          variables_used: Object.keys(resolvedVars),
+        },
+      },
+    },
+    {
+      status: 'completed',
+      timestamp: requestedAt,
+      template_id: template.id,
+      conversation_id: conversationId || null,
+    },
+  );
+
+  // 8. Increment usage count (fire-and-forget)
+  supabase
+    .rpc('increment_email_template_usage', { template_id: templateId })
+    .then(() => {})
+    .catch((err) => logger.warn({ err, templateId }, '[templateEmailDraft] Failed to increment usage count'));
+
+  // 9. Create notification
+  await createAiEmailDraftNotification(supabase, {
+    tenantId,
+    source: 'template_ai_email',
+    sourceRecord,
+    generationResult,
+    recipientEmail,
+    userEmail: user?.email,
+  });
+
+  const responseMessage =
+    generationResult.status === 'pending_approval'
+      ? `I drafted an email using the "${template.name}" template for ${recipientEmail} and sent it for approval.`
+      : `I drafted an email using the "${template.name}" template for ${recipientEmail} and queued it for delivery.`;
+
+  return {
+    response: responseMessage,
+    recipient_email: recipientEmail,
+    subject: resolvedSubject,
+    template: { id: template.id, name: template.name, category: template.category },
+    generation_result: generationResult,
+    context_summary: {
+      notes_count: notes.length,
+      communications_count: communications.length,
+      variables_resolved: Object.keys(resolvedVars).length,
+    },
+  };
+}

--- a/src/api/emailTemplates.js
+++ b/src/api/emailTemplates.js
@@ -1,0 +1,109 @@
+/**
+ * Email Template API helpers
+ */
+import { getBackendUrl } from '@/api/backendUrl';
+
+async function getHeaders() {
+  const headers = { 'Content-Type': 'application/json' };
+  const tenantId =
+    typeof localStorage !== 'undefined'
+      ? localStorage.getItem('selected_tenant_id') || localStorage.getItem('tenant_id')
+      : '';
+  if (tenantId) headers['x-tenant-id'] = tenantId;
+
+  // Dynamic import to avoid circular dependency
+  const { getAuthorizationHeader } = await import('@/api/functions');
+  const auth = await getAuthorizationHeader();
+  if (auth) headers.Authorization = auth;
+  return headers;
+}
+
+export async function fetchEmailTemplates({ category, entityType } = {}) {
+  const url = new URL(`${getBackendUrl()}/api/v2/email-templates`);
+  if (category) url.searchParams.set('category', category);
+  if (entityType) url.searchParams.set('entity_type', entityType);
+
+  const resp = await fetch(url.toString(), {
+    method: 'GET',
+    headers: await getHeaders(),
+    credentials: 'include',
+  });
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json.message || 'Failed to fetch templates');
+  return json.data || [];
+}
+
+export async function fetchEmailTemplate(id) {
+  const resp = await fetch(`${getBackendUrl()}/api/v2/email-templates/${id}`, {
+    method: 'GET',
+    headers: await getHeaders(),
+    credentials: 'include',
+  });
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json.message || 'Failed to fetch template');
+  return json.data;
+}
+
+export async function createEmailTemplate(payload) {
+  const resp = await fetch(`${getBackendUrl()}/api/v2/email-templates`, {
+    method: 'POST',
+    headers: await getHeaders(),
+    credentials: 'include',
+    body: JSON.stringify(payload),
+  });
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json.message || 'Failed to create template');
+  return json.data;
+}
+
+export async function updateEmailTemplate(id, payload) {
+  const resp = await fetch(`${getBackendUrl()}/api/v2/email-templates/${id}`, {
+    method: 'PUT',
+    headers: await getHeaders(),
+    credentials: 'include',
+    body: JSON.stringify(payload),
+  });
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json.message || 'Failed to update template');
+  return json.data;
+}
+
+export async function deleteEmailTemplate(id) {
+  const resp = await fetch(`${getBackendUrl()}/api/v2/email-templates/${id}`, {
+    method: 'DELETE',
+    headers: await getHeaders(),
+    credentials: 'include',
+  });
+  const json = await resp.json();
+  if (!resp.ok) throw new Error(json.message || 'Failed to delete template');
+  return json;
+}
+
+export async function draftFromTemplate({
+  tenantId,
+  templateId,
+  entityType,
+  entityId,
+  variables,
+  additionalPrompt,
+  requireApproval = true,
+  conversationId,
+}) {
+  const resp = await fetch(`${getBackendUrl()}/api/ai/draft-from-template`, {
+    method: 'POST',
+    headers: await getHeaders(),
+    credentials: 'include',
+    body: JSON.stringify({
+      tenant_id: tenantId,
+      template_id: templateId,
+      entity_type: entityType,
+      entity_id: entityId,
+      variables: variables || {},
+      additional_prompt: additionalPrompt,
+      require_approval: requireApproval,
+      conversation_id: conversationId,
+    }),
+  });
+  const json = await resp.json();
+  return { status: resp.status, data: json };
+}

--- a/src/components/ai/AishaEntityChatModal.jsx
+++ b/src/components/ai/AishaEntityChatModal.jsx
@@ -8,12 +8,14 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Loader2, Send, CheckCircle2, Circle, Clock, ExternalLink } from 'lucide-react';
+import { Loader2, Send, CheckCircle2, Circle, Clock, ExternalLink, FileText } from 'lucide-react';
 import { toast } from 'sonner';
 import { getBackendUrl } from '@/api/backendUrl';
 import { processChatEmailDraft } from '@/api/functions';
+import { draftFromTemplate } from '@/api/emailTemplates';
 import { useTenant } from '@/components/shared/tenantContext';
 import { useUser } from '@/components/shared/useUser';
+import EmailTemplatePicker from './EmailTemplatePicker';
 
 const EMAIL_DRAFT_PATTERNS = [
   /\bdraft\b.*\bemail\b/i,
@@ -41,6 +43,7 @@ export default function AishaEntityChatModal({
   const [taskResult, setTaskResult] = useState(null);
   const [draftRun, setDraftRun] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const { selectedTenantId } = useTenant();
   const { user } = useUser();
   // Use selectedTenantId (for superadmins) or fallback to user's tenant_id (for tenant admins)
@@ -152,6 +155,51 @@ export default function AishaEntityChatModal({
     }
   };
 
+  const handleTemplateSelect = async ({ templateId, variables, additionalPrompt }) => {
+    setIsLoading(true);
+    try {
+      const result = await draftFromTemplate({
+        tenantId,
+        templateId,
+        entityType,
+        entityId,
+        variables,
+        additionalPrompt,
+        requireApproval: true,
+      });
+
+      const payload = result?.data || {};
+      if (result?.status >= 400 || payload?.status === 'error') {
+        throw new Error(payload?.message || 'Failed to draft email from template');
+      }
+
+      const draftData = payload?.data || {};
+      const generationResult = draftData?.generation_result || {};
+      setDraftRun({
+        status: generationResult?.status || 'completed',
+        result:
+          payload?.response || draftData?.response || 'AiSHA drafted an email using the template.',
+        recipientEmail: draftData?.recipient_email || null,
+        subject: draftData?.subject || null,
+      });
+      setShowTemplatePicker(false);
+      setTaskId(null);
+      setTaskStatus(null);
+      setTaskResult(null);
+
+      toast.success(
+        generationResult?.status === 'pending_approval'
+          ? 'Template email draft sent for approval'
+          : 'Template email draft generated',
+      );
+    } catch (error) {
+      console.error('Template draft error:', error);
+      toast.error(error.message || 'Failed to generate template draft');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const startPolling = (id) => {
     if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
 
@@ -234,61 +282,80 @@ export default function AishaEntityChatModal({
 
         <div className="py-4">
           {!hasRunResult ? (
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <p className="text-sm text-slate-400">
-                  What would you like me to do with this {entityType}?
-                </p>
-                <Input
-                  value={input}
-                  onChange={(e) => setInput(e.target.value)}
-                  placeholder="e.g., Generate next steps, Draft an email..."
-                  className="bg-slate-800 border-slate-700 text-slate-100 placeholder:text-slate-500"
-                  autoFocus
-                />
-              </div>
+            showTemplatePicker ? (
+              <EmailTemplatePicker
+                entityType={entityType}
+                onSelect={handleTemplateSelect}
+                onCancel={() => setShowTemplatePicker(false)}
+                isLoading={isLoading}
+              />
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-sm text-slate-400">
+                    What would you like me to do with this {entityType}?
+                  </p>
+                  <Input
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    placeholder="e.g., Generate next steps, Draft an email..."
+                    className="bg-slate-800 border-slate-700 text-slate-100 placeholder:text-slate-500"
+                    autoFocus
+                  />
+                </div>
 
-              {/* Quick suggestion chips */}
-              <div className="flex flex-wrap gap-2">
-                {[
-                  'Create a note and set up a meeting for tomorrow',
-                  'Draft a follow-up email',
-                  'Summarise this record and suggest next steps',
-                ].map((suggestion) => (
-                  <button
-                    key={suggestion}
-                    type="button"
-                    onClick={() => setInput(suggestion)}
-                    className="text-xs px-3 py-1.5 rounded-full bg-slate-800 border border-slate-600 text-slate-300 hover:border-blue-500 hover:text-blue-300 transition-colors"
+                {/* Quick suggestion chips */}
+                <div className="flex flex-wrap gap-2">
+                  {[
+                    'Create a note and set up a meeting for tomorrow',
+                    'Draft a follow-up email',
+                    'Summarise this record and suggest next steps',
+                  ].map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      onClick={() => setInput(suggestion)}
+                      className="text-xs px-3 py-1.5 rounded-full bg-slate-800 border border-slate-600 text-slate-300 hover:border-blue-500 hover:text-blue-300 transition-colors"
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={openOffice}
+                      className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors"
+                    >
+                      <ExternalLink className="w-3.5 h-3.5" />
+                      Watch in Office
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowTemplatePicker(true)}
+                      className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-blue-300 transition-colors border border-slate-600 hover:border-blue-500 px-2.5 py-1 rounded-full"
+                    >
+                      <FileText className="w-3.5 h-3.5" />
+                      Use Template
+                    </button>
+                  </div>
+                  <Button
+                    type="submit"
+                    disabled={isLoading || !input.trim()}
+                    className="bg-blue-600 hover:bg-blue-500 text-white"
                   >
-                    {suggestion}
-                  </button>
-                ))}
-              </div>
-
-              <div className="flex items-center justify-between">
-                <button
-                  type="button"
-                  onClick={openOffice}
-                  className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-300 transition-colors"
-                >
-                  <ExternalLink className="w-3.5 h-3.5" />
-                  Watch in Office
-                </button>
-                <Button
-                  type="submit"
-                  disabled={isLoading || !input.trim()}
-                  className="bg-blue-600 hover:bg-blue-500 text-white"
-                >
-                  {isLoading ? (
-                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                  ) : (
-                    <Send className="w-4 h-4 mr-2" />
-                  )}
-                  Start Task
-                </Button>
-              </div>
-            </form>
+                    {isLoading ? (
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    ) : (
+                      <Send className="w-4 h-4 mr-2" />
+                    )}
+                    Start Task
+                  </Button>
+                </div>
+              </form>
+            )
           ) : (
             <div className="space-y-4">
               {/* Status + Watch in Office */}
@@ -374,6 +441,7 @@ export default function AishaEntityChatModal({
                 setTaskResult(null);
                 setDraftRun(null);
                 setInput('');
+                setShowTemplatePicker(false);
               }}
               variant="outline"
               className="border-slate-700 hover:bg-slate-800 text-slate-400"

--- a/src/components/ai/EmailTemplatePicker.jsx
+++ b/src/components/ai/EmailTemplatePicker.jsx
@@ -1,0 +1,250 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Loader2, FileText, ChevronLeft, Send } from 'lucide-react';
+import { fetchEmailTemplates } from '@/api/emailTemplates';
+
+/**
+ * EmailTemplatePicker — two-step flow:
+ * 1. Browse/select a template (filtered by entity type)
+ * 2. Fill in template variables + optional additional prompt → submit
+ */
+export default function EmailTemplatePicker({
+  entityType,
+  onSelect,
+  onCancel,
+  isLoading: externalLoading,
+}) {
+  const [templates, setTemplates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [variableValues, setVariableValues] = useState({});
+  const [additionalPrompt, setAdditionalPrompt] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetchEmailTemplates({ entityType })
+      .then((data) => {
+        if (!cancelled) setTemplates(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType]);
+
+  const handleSelectTemplate = (template) => {
+    setSelected(template);
+    // Pre-fill defaults
+    const defaults = {};
+    for (const v of template.variables || []) {
+      if (v.default) defaults[v.name] = v.default;
+    }
+    setVariableValues(defaults);
+    setAdditionalPrompt('');
+  };
+
+  const handleBack = () => {
+    setSelected(null);
+    setVariableValues({});
+    setAdditionalPrompt('');
+  };
+
+  const handleSubmit = () => {
+    onSelect({
+      templateId: selected.id,
+      templateName: selected.name,
+      variables: variableValues,
+      additionalPrompt: additionalPrompt.trim() || undefined,
+    });
+  };
+
+  const categoryLabels = {
+    general: 'General',
+    follow_up: 'Follow-Up',
+    introduction: 'Introduction',
+    proposal: 'Proposal',
+    outreach: 'Outreach',
+    thank_you: 'Thank You',
+    update: 'Update',
+  };
+
+  // Step 2: Variable form for selected template
+  if (selected) {
+    const userVars = (selected.variables || []).filter((v) => v.name);
+    return (
+      <div className="space-y-3">
+        <button
+          onClick={handleBack}
+          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          disabled={externalLoading}
+        >
+          <ChevronLeft className="h-3.5 w-3.5" />
+          Back to templates
+        </button>
+
+        <div className="rounded-md border p-3 bg-muted/30">
+          <p className="text-sm font-medium">{selected.name}</p>
+          {selected.description && (
+            <p className="text-xs text-muted-foreground mt-0.5">{selected.description}</p>
+          )}
+          <p className="text-xs text-muted-foreground mt-1 italic">
+            Subject: {selected.subject_template}
+          </p>
+        </div>
+
+        {userVars.length > 0 && (
+          <div className="space-y-2">
+            {userVars.map((v) => (
+              <div key={v.name}>
+                <Label className="text-xs">
+                  {v.description || v.name}
+                  {v.required && <span className="text-destructive ml-0.5">*</span>}
+                </Label>
+                <Input
+                  className="h-8 text-sm mt-1"
+                  placeholder={v.default || v.description || v.name}
+                  value={variableValues[v.name] || ''}
+                  onChange={(e) =>
+                    setVariableValues((prev) => ({ ...prev, [v.name]: e.target.value }))
+                  }
+                  disabled={externalLoading}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div>
+          <Label className="text-xs">Additional instructions (optional)</Label>
+          <Input
+            className="h-8 text-sm mt-1"
+            placeholder="Any extra context or tone adjustments..."
+            value={additionalPrompt}
+            onChange={(e) => setAdditionalPrompt(e.target.value)}
+            disabled={externalLoading}
+          />
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onCancel}
+            disabled={externalLoading}
+          >
+            Cancel
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSubmit}
+            disabled={externalLoading}
+          >
+            {externalLoading ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                Generating...
+              </>
+            ) : (
+              <>
+                <Send className="mr-1.5 h-3.5 w-3.5" />
+                Generate Draft
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Step 1: Template list
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-6">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-destructive py-4 text-center">
+        Failed to load templates: {error}
+      </div>
+    );
+  }
+
+  if (templates.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground py-4 text-center">
+        No email templates available for this entity type.
+      </div>
+    );
+  }
+
+  // Group by category
+  const grouped = {};
+  for (const t of templates) {
+    const cat = t.category || 'general';
+    if (!grouped[cat]) grouped[cat] = [];
+    grouped[cat].push(t);
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">Choose a template</p>
+        <Button size="sm" variant="ghost" onClick={onCancel} className="text-xs h-7">
+          Cancel
+        </Button>
+      </div>
+
+      <div className="space-y-2 max-h-64 overflow-y-auto">
+        {Object.entries(grouped).map(([category, catTemplates]) => (
+          <div key={category}>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-1">
+              {categoryLabels[category] || category}
+            </p>
+            {catTemplates.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => handleSelectTemplate(t)}
+                className="w-full text-left rounded-md border p-2.5 hover:bg-accent/50 transition-colors mb-1.5"
+              >
+                <div className="flex items-start gap-2">
+                  <FileText className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium truncate">
+                      {t.name}
+                      {t.is_system && (
+                        <span className="ml-1.5 text-[10px] bg-muted text-muted-foreground px-1 py-0.5 rounded">
+                          System
+                        </span>
+                      )}
+                    </p>
+                    {t.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                        {t.description}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements reusable AI email templates that combine structured template input with live CRM and thread context. Users can browse templates, fill in variables, and generate AI-powered email drafts — all from the existing AiSHA entity chat modal.

**Trello Card:** https://trello.com/c/nMu5vWiL

---

## Changes

### Database (Migration 146)
- **`email_template` table** with full RLS policies (tenant-scoped reads/writes, system templates visible to all)
- **5 seed system templates**: Professional Follow-Up, Introduction Email, Thank You After Meeting, Proposal Follow-Up, Re-Engagement
- **`increment_email_template_usage` RPC** for fire-and-forget usage tracking
- Indexes on `tenant_id` and `category`

### Backend
- **CRUD V2 routes** (`/api/v2/email-templates`): GET list (filtered by entity_type, category, is_active), GET single, POST create, PUT update, DELETE — with system template protection and input validation
- **Template drafting service** (`templateEmailDraftService.js`):
  - `{{variable}}` substitution with three-layer resolution: template defaults → auto CRM fields → user overrides
  - Auto-resolved variables: `first_name`, `last_name`, `company`, `email`, `sender_name`, `sender_email` from CRM entity data
  - Full CRM context loading (entity, notes, communications)
  - CARE playbook routing for approval/delivery
  - Lazy CARE import to avoid module-level Redis queue init (test-friendly)
- **`POST /api/ai/draft-from-template`** endpoint with auth, tenant validation, entity visibility/access checks

### Frontend
- **API helpers** (`src/api/emailTemplates.js`): fetch, create, update, delete templates + draft-from-template
- **EmailTemplatePicker component**: Two-step UI — browse templates grouped by category → fill variables with defaults → generate draft
- **AishaEntityChatModal integration**: "Use Template" pill button, state management, template draft handler

### Tests
- **7 unit tests** covering: happy path with variable substitution, variable defaults, entity type mismatch rejection, template not found, required variable validation, additional prompt inclusion, auto CRM variable resolution

---

## Architecture Decisions

1. **Three-layer variable resolution** (defaults → auto → user): Reduces manual input while allowing full override
2. **Lazy CARE import**: Dynamic `import()` instead of static to avoid Redis queue initialization during testing
3. **Entity type compatibility**: Templates can declare supported entity types; `null` means "all types"
4. **System template protection**: System templates cannot be edited or deleted by tenants
5. **Dependency injection pattern**: `executeSendEmailAction` is injectable for clean unit testing

## Files Changed (9)

| File | Type | Description |
|------|------|-------------|
| `backend/migrations/146_email_templates.sql` | New | Table, RLS, seeds, RPC |
| `backend/routes/email-templates.v2.js` | New | CRUD V2 routes |
| `backend/services/templateEmailDraftService.js` | New | Template drafting engine |
| `backend/routes/ai.js` | Modified | Added draft-from-template endpoint |
| `backend/server.js` | Modified | Route registration |
| `src/api/emailTemplates.js` | New | Frontend API helpers |
| `src/components/ai/EmailTemplatePicker.jsx` | New | Template picker UI |
| `src/components/ai/AishaEntityChatModal.jsx` | Modified | Template picker integration |
| `backend/__tests__/services/templateEmailDraftService.test.js` | New | 7 unit tests |