### PR TITLE
refactor: Migrate AISuggestions from pushState to useSearchParams

### DIFF
--- a/src/pages/AISuggestions.jsx
+++ b/src/pages/AISuggestions.jsx
@@ -1,38 +1,25 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useTenant } from '@/components/shared/tenantContext';
 import { useUser } from '@/components/shared/useUser.js';
 import SuggestionQueue from '@/components/ai/SuggestionQueue';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
-function getFocusedSuggestionFromLocation() {
-  const params = new URLSearchParams(window.location.search);
-  return params.get('suggestion') || null;
-}
-
 export default function AISuggestionsPage() {
   const { selectedTenantId } = useTenant();
   const { user } = useUser();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const tenantId = selectedTenantId || user?.tenant_id || null;
-  const [focusSuggestionId, setFocusSuggestionId] = useState(() => getFocusedSuggestionFromLocation());
-
-  useEffect(() => {
-    const handlePopState = () => {
-      setFocusSuggestionId(getFocusedSuggestionFromLocation());
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
+  const focusSuggestionId = searchParams.get('suggestion') || null;
 
   const handleClearFocus = useCallback(() => {
-    const params = new URLSearchParams(window.location.search);
-    params.delete('suggestion');
-    const nextSearch = params.toString();
-    const nextUrl = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ''}`;
-    window.history.pushState({}, '', nextUrl);
-    setFocusSuggestionId(null);
-  }, []);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('suggestion');
+      return next;
+    });
+  }, [setSearchParams]);
 
   if (!tenantId) {
     return (


### PR DESCRIPTION
## Summary

Migrates `AISuggestions.jsx` from `window.location` / `history.pushState` to React Router's `useSearchParams` hook, as identified in PR #407 review.

## Changes

**Before:**
- `window.location.search` to read `?suggestion=` param
- `history.pushState()` to clear the param
- Manual `popstate` event listener + `useEffect` cleanup
- Local `useState` for `focusSuggestionId`
- Standalone `getFocusedSuggestionFromLocation()` helper

**After:**
- `useSearchParams()` from `react-router-dom`
- `setSearchParams()` to clear the param (router-aware navigation)
- `focusSuggestionId` derived directly from `searchParams.get('suggestion')`
- No manual event listeners needed — React Router handles URL state

## Benefits
- Proper integration with React Router navigation lifecycle
- Back/forward browser navigation handled natively by the router
- 13 fewer lines of code
- No `window` global access

## File Changed
- `src/pages/AISuggestions.jsx` — 10 insertions, 23 deletions