### PR TITLE
fix(permissions): Wave 6 archive guard hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Wave 6 archive permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.archive-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/archive` so archive operations are allowed only when `getAccessLevel(...)` is `full` for all selected records. The endpoint now rejects mixed/unauthorized archive batches and includes regression coverage to keep full-access checks from regressing.
+
 - **Wave 5 bulk-assign assignment-history canonical mapping (`backend/lib/bulkAssign.js`, `backend/__tests__/routes/bulkAssign.test.js`):** Fixed `TABLE_TO_ENTITY` mapping for bulk assignment history so BizDev bulk assignments use canonical `entity_type='bizdev_source'` (instead of non-standard `bizdevsource`) and added explicit canonical mappings for `opportunity`/`activity` parity. Added regression assertions to lock canonical mapping keys and prevent future history query mismatches.
 
 - **Wave 4 bulk-delete permission hardening (`backend/routes/leads.v2.js`, `backend/__tests__/routes/teamVisibility.bulk-delete-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/v2/leads/bulk-delete` so records are only deletable when `getAccessLevel(...)` is `full` for every selected lead. The endpoint now rejects bulk deletions that include unauthorized records, closing a parity gap where bulk delete bypassed route-level write checks. Added a regression test to lock the guard logic in place.

--- a/backend/__tests__/routes/teamVisibility.archive-guards.test.js
+++ b/backend/__tests__/routes/teamVisibility.archive-guards.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('team visibility archive guards', () => {
+  it('bizdev archive enforces full-access record checks', () => {
+    const bizdevRoutePath = path.resolve(process.cwd(), 'backend/routes/bizdevsources.js');
+    const source = fs.readFileSync(bizdevRoutePath, 'utf8');
+
+    assert.match(
+      source,
+      /router\.post\('\/archive'[\s\S]*getVisibilityScope\(req\.user, supabase\)/,
+      'archive should resolve visibility scope for authenticated users',
+    );
+
+    assert.match(
+      source,
+      /router\.post\('\/archive'[\s\S]*getAccessLevel\(/,
+      'archive should evaluate per-record access levels',
+    );
+
+    assert.match(
+      source,
+      /router\.post\('\/archive'[\s\S]*access !== 'full'/,
+      'archive should reject records without full write access',
+    );
+  });
+});

--- a/backend/routes/bizdevsources.js
+++ b/backend/routes/bizdevsources.js
@@ -1311,6 +1311,37 @@ export default function createBizDevSourceRoutes(pgPool) {
 
       const tenant_id = incomingTenantId;
 
+      // ── Two-tier write access check for archive ──
+      if (req.user) {
+        const { data: currentRecords, error: currentErr } = await supabase
+          .from('bizdev_sources')
+          .select('id, assigned_to, assigned_to_team')
+          .eq('tenant_id', tenant_id)
+          .in('id', bizdev_source_ids);
+
+        if (currentErr) throw new Error(currentErr.message);
+
+        if (currentRecords?.length) {
+          const scope = await getVisibilityScope(req.user, supabase);
+          const unauthorized = currentRecords.filter((record) => {
+            const access = getAccessLevel(
+              scope,
+              record.assigned_to_team,
+              record.assigned_to,
+              req.user.id,
+            );
+            return access !== 'full';
+          });
+
+          if (unauthorized.length > 0) {
+            return res.status(403).json({
+              status: 'error',
+              message: 'You do not have permission to archive one or more selected records',
+            });
+          }
+        }
+      }
+
       // Update sources to mark as archived
       const placeholders = bizdev_source_ids.map((_, i) => `$${i + 2}`).join(',');
       const updateResult = await pgPool.query(


### PR DESCRIPTION
## Summary
- harden `/api/bizdevsources/archive` with per-record team visibility full-access checks
- reject archive operations when any selected record is not writable under `getAccessLevel`
- add regression coverage for archive guard enforcement

## Files
- backend/routes/bizdevsources.js
- backend/__tests__/routes/teamVisibility.archive-guards.test.js
- CHANGELOG.md

## Validation
- CI=true CI_BACKEND_TESTS=false node --test backend/__tests__/routes/teamVisibility.archive-guards.test.js backend/__tests__/routes/teamVisibility.bulk-delete-guards.test.js backend/__tests__/routes/teamVisibility.write-guards.test.js backend/__tests__/routes/bulkAssign.test.js
- docker exec aishacrm-backend npm test
