### PR TITLE
fix(permissions): Wave 7 promote guard hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Wave 7 promote permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.promote-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/:id/promote` so promotion is allowed only when `getAccessLevel(...)` is `full` for the source record. The endpoint now returns 403 for unauthorized promote attempts and includes regression coverage to keep the full-access gate from regressing.
+
 - **Wave 6 archive permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.archive-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/archive` so archive operations are allowed only when `getAccessLevel(...)` is `full` for all selected records. The endpoint now rejects mixed/unauthorized archive batches and includes regression coverage to keep full-access checks from regressing.
 
 - **Wave 5 bulk-assign assignment-history canonical mapping (`backend/lib/bulkAssign.js`, `backend/__tests__/routes/bulkAssign.test.js`):** Fixed `TABLE_TO_ENTITY` mapping for bulk assignment history so BizDev bulk assignments use canonical `entity_type='bizdev_source'` (instead of non-standard `bizdevsource`) and added explicit canonical mappings for `opportunity`/`activity` parity. Added regression assertions to lock canonical mapping keys and prevent future history query mismatches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Wave 7 promote permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.promote-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/:id/promote` so promotion is allowed only when `getAccessLevel(...)` is `full` for the source record. The endpoint now returns 403 for unauthorized promote attempts and includes regression coverage to keep the full-access gate from regressing.
+- **Wave 7 promote permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.promote-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/:id/promote` so promotion is allowed only when `getAccessLevel(...)` is `full` for the source record. Authorization now evaluates assignment fields from the same transaction-locked row (`SELECT ... FOR UPDATE`) used for promotion, eliminating stale-read race windows. The endpoint returns 403 for unauthorized promote attempts and includes regression coverage to keep the full-access gate from regressing.
 
 - **Wave 6 archive permission hardening (`backend/routes/bizdevsources.js`, `backend/__tests__/routes/teamVisibility.archive-guards.test.js`):** Added per-record team-visibility enforcement to `POST /api/bizdevsources/archive` so archive operations are allowed only when `getAccessLevel(...)` is `full` for all selected records. The endpoint now rejects mixed/unauthorized archive batches and includes regression coverage to keep full-access checks from regressing.
 

--- a/backend/__tests__/routes/teamVisibility.promote-guards.test.js
+++ b/backend/__tests__/routes/teamVisibility.promote-guards.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('team visibility promote guards', () => {
+  it('bizdev promote enforces full-access record checks', () => {
+    const bizdevRoutePath = path.resolve(process.cwd(), 'backend/routes/bizdevsources.js');
+    const source = fs.readFileSync(bizdevRoutePath, 'utf8');
+
+    assert.match(
+      source,
+      /router\.post\([\s\S]*'\/:id\/promote'[\s\S]*getVisibilityScope\(req\.user, supabase\)/,
+      'promote should resolve visibility scope for authenticated users',
+    );
+
+    assert.match(
+      source,
+      /router\.post\([\s\S]*'\/:id\/promote'[\s\S]*getAccessLevel\(/,
+      'promote should evaluate per-record access levels',
+    );
+
+    assert.match(
+      source,
+      /router\.post\([\s\S]*'\/:id\/promote'[\s\S]*access !== 'full'/,
+      'promote should reject records without full write access',
+    );
+  });
+});

--- a/backend/__tests__/routes/teamVisibility.promote-guards.test.js
+++ b/backend/__tests__/routes/teamVisibility.promote-guards.test.js
@@ -22,6 +22,12 @@ describe('team visibility promote guards', () => {
 
     assert.match(
       source,
+      /router\.post\([\s\S]*'\/:id\/promote'[\s\S]*FOR UPDATE[\s\S]*getAccessLevel\([\s\S]*bizdevSource\.assigned_to_team[\s\S]*bizdevSource\.assigned_to/,
+      'promote should evaluate access from locked row assignment state',
+    );
+
+    assert.match(
+      source,
       /router\.post\([\s\S]*'\/:id\/promote'[\s\S]*access !== 'full'/,
       'promote should reject records without full write access',
     );

--- a/backend/routes/bizdevsources.js
+++ b/backend/routes/bizdevsources.js
@@ -986,6 +986,37 @@ export default function createBizDevSourceRoutes(pgPool) {
           return res.status(400).json({ status: 'error', message: 'tenant_id is required' });
         }
 
+        // ── Two-tier write access check for promote ──
+        if (req.user) {
+          const { data: currentRecord, error: currentErr } = await supabase
+            .from('bizdev_sources')
+            .select('id, assigned_to, assigned_to_team')
+            .eq('id', id)
+            .eq('tenant_id', tenant_id)
+            .maybeSingle();
+
+          if (currentErr) throw new Error(currentErr.message);
+
+          if (!currentRecord) {
+            return res.status(404).json({ status: 'error', message: 'BizDev source not found' });
+          }
+
+          const scope = await getVisibilityScope(req.user, supabase);
+          const access = getAccessLevel(
+            scope,
+            currentRecord.assigned_to_team,
+            currentRecord.assigned_to,
+            req.user.id,
+          );
+
+          if (access !== 'full') {
+            return res.status(403).json({
+              status: 'error',
+              message: 'You do not have permission to promote this record',
+            });
+          }
+        }
+
         if (supportsTx) {
           client = await pgPool.connect();
         } else {

--- a/backend/routes/bizdevsources.js
+++ b/backend/routes/bizdevsources.js
@@ -986,35 +986,11 @@ export default function createBizDevSourceRoutes(pgPool) {
           return res.status(400).json({ status: 'error', message: 'tenant_id is required' });
         }
 
-        // ── Two-tier write access check for promote ──
+        // Prepare user visibility scope up front, but defer record-based access
+        // until after SELECT ... FOR UPDATE so authz uses locked assignment state.
+        let visibilityScope = null;
         if (req.user) {
-          const { data: currentRecord, error: currentErr } = await supabase
-            .from('bizdev_sources')
-            .select('id, assigned_to, assigned_to_team')
-            .eq('id', id)
-            .eq('tenant_id', tenant_id)
-            .maybeSingle();
-
-          if (currentErr) throw new Error(currentErr.message);
-
-          if (!currentRecord) {
-            return res.status(404).json({ status: 'error', message: 'BizDev source not found' });
-          }
-
-          const scope = await getVisibilityScope(req.user, supabase);
-          const access = getAccessLevel(
-            scope,
-            currentRecord.assigned_to_team,
-            currentRecord.assigned_to,
-            req.user.id,
-          );
-
-          if (access !== 'full') {
-            return res.status(403).json({
-              status: 'error',
-              message: 'You do not have permission to promote this record',
-            });
-          }
+          visibilityScope = await getVisibilityScope(req.user, supabase);
         }
 
         if (supportsTx) {
@@ -1037,6 +1013,25 @@ export default function createBizDevSourceRoutes(pgPool) {
         }
 
         const bizdevSource = sourceResult.rows[0];
+
+        // ── Two-tier write access check for promote (locked row) ──
+        if (req.user) {
+          const access = getAccessLevel(
+            visibilityScope,
+            bizdevSource.assigned_to_team,
+            bizdevSource.assigned_to,
+            req.user.id,
+          );
+
+          if (access !== 'full') {
+            if (supportsTx) await client.query('ROLLBACK').catch(() => {});
+            return res.status(403).json({
+              status: 'error',
+              message: 'You do not have permission to promote this record',
+            });
+          }
+        }
+
         logger.debug('[Promote] BizDev Source fetched:', {
           company_name: bizdevSource.company_name,
           contact_person: bizdevSource.contact_person,


### PR DESCRIPTION
## Summary
- harden `POST /api/bizdevsources/:id/promote` with per-record team visibility full-access checks
- reject promote operations when user lacks `full` access on the source record
- add regression coverage for promote guard enforcement

## Files
- backend/routes/bizdevsources.js
- backend/__tests__/routes/teamVisibility.promote-guards.test.js
- CHANGELOG.md

## Validation
- CI=true CI_BACKEND_TESTS=false node --test backend/__tests__/routes/teamVisibility.promote-guards.test.js backend/__tests__/routes/teamVisibility.archive-guards.test.js backend/__tests__/routes/teamVisibility.bulk-delete-guards.test.js backend/__tests__/routes/teamVisibility.write-guards.test.js backend/__tests__/routes/bulkAssign.test.js
- docker exec aishacrm-backend npm test
