### PR TITLE
fix(monitoring): repair LLM/AI Tools monitor gaps — persist logs + pre-populate tool registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Migration 151 RLS tenant-isolation pattern (`backend/migrations/151_llm_activity_logs.sql`):** The initial draft used `current_setting('app.current_tenant_id', true)::uuid`, but the repo was standardized to the JWT-based helper `public.current_tenant_id()` (see migration `rls_fix_high3_standardize_tenant_isolation_pattern`). The session GUC is never `SET` in current middleware, so the SELECT policy would have returned zero rows. Migration 151 now uses `public.current_tenant_id()` to match the rest of the system.
+
+- **Migration 151 retention was never enforced (`backend/migrations/151_llm_activity_logs.sql`):** `cleanup_llm_activity_logs()` existed but was not scheduled — the 90-day retention claim was inaccurate. Added a pg_cron job (`llm_activity_logs_cleanup`, daily at 03:15 UTC) that invokes the cleanup function, with explicit `GRANT EXECUTE ... TO service_role` and idempotent re-registration (unschedule-then-schedule guarded by a `pg_cron` extension check).
+
+- **Migration 151 primary key collision risk (`backend/migrations/151_llm_activity_logs.sql`):** The original `TEXT PRIMARY KEY` of `llm-<ts>-<6-char-rand>` could collide across concurrent MCP containers; failures would be silently swallowed by the fire-and-forget insert path. Switched to `UUID PRIMARY KEY DEFAULT gen_random_uuid()` and moved the original in-memory id to a new `external_id` column for cross-referencing with the real-time monitor buffer.
+
+- **Migration 151 index strategy (`backend/migrations/151_llm_activity_logs.sql`):** Replaced five single-column indexes (four of them redundant vs dashboard query patterns) with three composite indexes that match the actual access paths: `(tenant_id, created_at DESC)`, `(tenant_id, status, created_at DESC)`, and `(provider, created_at DESC)`, plus the global `(created_at DESC)`.
+
+- **LLM cost estimation ignored model (`backend/lib/aiEngine/activityLogger.js`):** Pricing was keyed on provider only, so `gpt-4o-mini` traffic was billed at `gpt-4o` rates (~10× overstatement) and `claude-haiku`/`opus` collapsed into a single Anthropic rate. Introduced `MODEL_COST_RATES` model-aware lookup (`resolveModelRates(provider, model)`) covering current OpenAI, Anthropic, and Groq model families, with provider-level defaults for unknown models.
+
+- **AI Tools registry fallback reported unused tools as "healthy" (`backend/routes/braidMetrics.js`):** `buildRegistryFallback` previously set `healthScore: 100, healthStatus: 'healthy'` on every registry-only tool, skewing the overall health average for fresh deployments and conflating never-called with validated-healthy. Unused tools now carry `healthScore: null, healthStatus: 'unused'` and are excluded from `overallHealth` / `problemTools` aggregation. The bogus `policy = category` assignment was also removed (policy now reflects the declared tool policy or null).
+
 - **LLM Monitor "By Provider" / "By Status" cards always empty (`backend/lib/aiEngine/activityLogger.js`):** Stats were computed exclusively from the 5-minute window, so cards were blank whenever no recent activity existed. Now falls back to the full in-memory buffer when the 5-minute window is empty, and always exposes `allTime.byProvider` / `allTime.byStatus` / `allTime.byCapability` in the stats response for buffer-wide breakdowns.
 
 - **LLM Monitor "Avg Duration" showing "-" when idle (`backend/lib/aiEngine/activityLogger.js`):** Same 5-minute window bug — now falls back to all-buffer durations when the recent window has no entries.
 
-- **AI Tools Monitor showing "0 tools monitored" before first tool call (`backend/routes/braidMetrics.js`):** `getToolMetrics` queries `braid_audit_log` which is empty on a fresh instance. The `/api/braid/metrics/tools` handler now pre-populates from the static `TOOL_GRAPH` registry (all ~126 tools) when the audit log returns no results, and merges registry entries for any tool not yet in the audit log when some data exists. Tools with no call history are shown as healthy with 0 calls.
+- **AI Tools Monitor showing "0 tools monitored" before first tool call (`backend/routes/braidMetrics.js`):** `getToolMetrics` queries `braid_audit_log` which is empty on a fresh instance. The `/api/braid/metrics/tools` handler now pre-populates from the static `TOOL_GRAPH` registry (all ~126 tools) when the audit log returns no results, and merges registry entries for any tool not yet in the audit log when some data exists. Registry-only tools surface as `unused` rather than `healthy`.
 
 ### Added
 
-- **LLM call cost estimation (`backend/lib/aiEngine/activityLogger.js`, `src/components/settings/LLMActivityMonitor.jsx`):** `getLLMActivityStats()` now returns `tokenUsage.allTime.estimatedCostUSD` computed from per-provider input/output token rates (Anthropic, OpenAI, Groq, Local). A new "Est. Cost (buffer)" stat card is displayed in the LLM Monitor header row, showing 4 decimal places.
+- **LLM activity DB-persist observability counters (`backend/lib/aiEngine/activityLogger.js`):** Fire-and-forget inserts now track `{attempts, successes, errors, lastError, lastErrorAt}` exposed via `getLLMActivityStats().persistence` and a new `getPersistCounters()` export. Ops can now detect sustained persistence failures without greping application logs.
 
-- **LLM activity log DB persistence (`backend/migrations/151_llm_activity_logs.sql`, `backend/lib/aiEngine/activityLogger.js`):** All LLM calls are now persisted to a `llm_activity_logs` table (90-day retention) via a non-blocking fire-and-forget insert. Server restarts no longer wipe the activity history. RLS enforced — service role writes, authenticated users read their own tenant's logs.
+- **LLM activity logger test seams (`backend/lib/aiEngine/activityLogger.js`):** Added `__setSupabaseClientForTest`, `__resetSupabaseClientForTest`, `__resetPersistCountersForTest`, `buildPersistPayload`, `resolveModelRates`, and `MODEL_COST_RATES` exports so persistence, payload shape, and cost resolution can be unit-tested without a live Supabase client.
+
+- **LLM call cost estimation (`backend/lib/aiEngine/activityLogger.js`, `src/components/settings/LLMActivityMonitor.jsx`):** `getLLMActivityStats()` returns `tokenUsage.allTime.estimatedCostUSD` computed from model-aware input/output token rates. A "Est. Cost (buffer)" stat card is displayed in the LLM Monitor header row with 4 decimal places.
+
+- **LLM activity log DB persistence (`backend/migrations/151_llm_activity_logs.sql`, `backend/lib/aiEngine/activityLogger.js`):** All LLM calls are persisted to a `llm_activity_logs` table (90-day retention, pg_cron enforced) via a non-blocking fire-and-forget insert. Server restarts no longer wipe activity history. RLS: service role writes; authenticated users read their own tenant's logs via `public.current_tenant_id()`.
+
+- **Expanded test coverage for LLM activity logger (`backend/__tests__/ai/activityLogger.test.js`):** Added tests for model-aware cost resolution across OpenAI/Anthropic/Groq/local, for the DB persist payload shape (including tenant `unknown` → null and tools_called normalization), and for persist-counter behavior under insert success, explicit error, and missing-client cases.
 
 - **AI Tools Monitor registry-aware status banners (`src/components/settings/BraidSDKMonitor.jsx`):** Tool Health tab now shows a contextual info banner distinguishing between "registry-only" state (no calls yet) and "audit+registry" state (some tools have real call data), with counts for each.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **LLM Monitor "By Provider" / "By Status" cards always empty (`backend/lib/aiEngine/activityLogger.js`):** Stats were computed exclusively from the 5-minute window, so cards were blank whenever no recent activity existed. Now falls back to the full in-memory buffer when the 5-minute window is empty, and always exposes `allTime.byProvider` / `allTime.byStatus` / `allTime.byCapability` in the stats response for buffer-wide breakdowns.
+
+- **LLM Monitor "Avg Duration" showing "-" when idle (`backend/lib/aiEngine/activityLogger.js`):** Same 5-minute window bug — now falls back to all-buffer durations when the recent window has no entries.
+
+- **AI Tools Monitor showing "0 tools monitored" before first tool call (`backend/routes/braidMetrics.js`):** `getToolMetrics` queries `braid_audit_log` which is empty on a fresh instance. The `/api/braid/metrics/tools` handler now pre-populates from the static `TOOL_GRAPH` registry (all ~126 tools) when the audit log returns no results, and merges registry entries for any tool not yet in the audit log when some data exists. Tools with no call history are shown as healthy with 0 calls.
+
+### Added
+
+- **LLM call cost estimation (`backend/lib/aiEngine/activityLogger.js`, `src/components/settings/LLMActivityMonitor.jsx`):** `getLLMActivityStats()` now returns `tokenUsage.allTime.estimatedCostUSD` computed from per-provider input/output token rates (Anthropic, OpenAI, Groq, Local). A new "Est. Cost (buffer)" stat card is displayed in the LLM Monitor header row, showing 4 decimal places.
+
+- **LLM activity log DB persistence (`backend/migrations/151_llm_activity_logs.sql`, `backend/lib/aiEngine/activityLogger.js`):** All LLM calls are now persisted to a `llm_activity_logs` table (90-day retention) via a non-blocking fire-and-forget insert. Server restarts no longer wipe the activity history. RLS enforced — service role writes, authenticated users read their own tenant's logs.
+
+- **AI Tools Monitor registry-aware status banners (`src/components/settings/BraidSDKMonitor.jsx`):** Tool Health tab now shows a contextual info banner distinguishing between "registry-only" state (no calls yet) and "audit+registry" state (some tools have real call data), with counts for each.
+
+### Changed
+
+- **LLM Monitor "By Provider" / "By Status" cards use buffer-wide data (`src/components/settings/LLMActivityMonitor.jsx`):** Cards now source from `stats.allTime.byProvider` / `allTime.byStatus` (always populated from the full buffer) rather than the 5-minute window. A `(buffer)` label appears when data comes from outside the recent window.
+
+- **Tokens (buffer) card now shows prompt/completion breakdown instead of entry count (`src/components/settings/LLMActivityMonitor.jsx`):** More useful for cost analysis.
+
 ### Changed
 
 - **OpenReplay self-hosted defaults (`.env.example`, `src/components/admin/OpenReplayControl.jsx`, `docs/admin-guides/OPENREPLAY_SETUP_GUIDE.md`):** Switched project guidance from cloud-first to self-hosted-first for AiSHA deployments. Added default self-hosted dashboard/ingest sample values (`https://replay.aishacrm.com`) and updated setup documentation to prioritize CI/CD deployment flow.
 - **OpenReplay Docker runtime env wiring (`frontend-entrypoint.sh`):** Normalized OpenReplay runtime env names so `OPENREPLAY_*` secrets are promoted to `VITE_OPENREPLAY_*` before generating `env-config.js`, ensuring Dockerized frontend runtime config is consistent for the browser bundle.
+- **System admin runbook updates for OpenReplay assist (`docs/admin-guides/ADMIN_GUIDE.md`):** Added a dedicated section for support operators covering OpenReplay prerequisites, how to start an assist session from User Management, live control/consent flow, troubleshooting, and security/audit notes.
+- **Core documentation index and support-flow alignment (`README.md`, `docs/README.md`, `docs/admin-guides/OPENREPLAY_SETUP_GUIDE.md`):** Fixed stale doc links to current folder structure, added OpenReplay admin guides to the docs index, and updated assist instructions to match the current UI labels (`Start Assist` / `Start Assist Session`).
+- **User guidance refresh for navigation, buttons, and shortcuts (`docs/user-guides/USER_GUIDE.md`, `docs/user-guides/AI_ASSISTANT_GUIDE.md`, `docs/README.md`):** Reworked navigation and common-button guidance, removed unsupported shortcut claims, aligned AI assistant access text with current UI launcher behavior, and documented the online guide freshness workflow for `public/guides/` synchronization.
+- **Online user-guide download resiliency (`src/pages/Documentation.jsx`):** Updated the in-app documentation download flow to prefer backend-generated/current PDF sources and fall back to the latest published markdown guide when no PDF is reachable, reducing stale-guide failures from legacy hardcoded paths.
 
 - **Dashboard cache-first loading optimization (`src/pages/Dashboard.jsx`):** Moved cache check before `setLoading(true)` so cached data displays instantly without skeleton loaders. When cache exists, dashboard now shows data immediately with background refresh, eliminating the "obvious loading time" for repeat visits. Loading skeleton only appears when no cache is available (first visit or after cache expiration).
 

--- a/backend/__tests__/ai/activityLogger.test.js
+++ b/backend/__tests__/ai/activityLogger.test.js
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for LLM activity logger stats, persist payload shape,
+ * model-aware cost resolution, and persist error counting.
+ *
+ * IMPORTANT: Mocks for `getSupabaseClient` are installed before the module
+ * under test is imported, because ESM bindings are frozen after import.
+ */
+
+import { describe, it, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  logLLMActivity,
+  getLLMActivity,
+  getLLMActivityStats,
+  clearLLMActivity,
+  resolveModelRates,
+  buildPersistPayload,
+  getPersistCounters,
+  __resetPersistCountersForTest,
+  __setSupabaseClientForTest,
+  __resetSupabaseClientForTest,
+} from '../../lib/aiEngine/activityLogger.js';
+
+// Per-test state for the injected Supabase stub.
+let supabaseStub = null;
+let insertSpy = null;
+let insertResult = { error: null };
+
+function makeSupabaseStub() {
+  insertSpy = mock.fn(async () => insertResult);
+  return {
+    from: () => ({ insert: insertSpy }),
+  };
+}
+
+function waitForPersist() {
+  // Persist is fire-and-forget; flush the microtask queue.
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+// --- Tests ----------------------------------------------------------------
+
+describe('LLM Activity Logger stats', () => {
+  beforeEach(() => {
+    clearLLMActivity();
+    __resetPersistCountersForTest();
+    supabaseStub = null; // default: no supabase configured
+    insertResult = { error: null };
+    __setSupabaseClientForTest(() => supabaseStub);
+  });
+
+  afterEach(() => {
+    __resetSupabaseClientForTest();
+  });
+
+  it('falls back to buffer window and exposes allTime + estimated cost fields', () => {
+    const logSpy = mock.method(console, 'log', () => {});
+    const debugSpy = mock.method(console, 'debug', () => {});
+    try {
+      logLLMActivity({
+        tenantId: '00000000-0000-0000-0000-000000000001',
+        capability: 'chat_tools',
+        provider: 'openai',
+        model: 'gpt-4o',
+        status: 'success',
+        durationMs: 1200,
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 500,
+          total_tokens: 1500,
+        },
+      });
+
+      const entries = getLLMActivity({ limit: 1 });
+      entries[0].timestamp = new Date(Date.now() - 6 * 60 * 1000).toISOString();
+
+      const stats = getLLMActivityStats();
+
+      assert.equal(stats.windowLabel, 'buffer');
+      assert.equal(stats.last5Minutes, 0);
+      assert.equal(stats.totalEntries, 1);
+      assert.equal(stats.avgDurationMs, 1200);
+      assert.equal(stats.allTime.byProvider.openai, 1);
+      assert.equal(stats.allTime.byStatus.success, 1);
+      assert.equal(stats.allTime.byCapability.chat_tools, 1);
+
+      assert.equal(stats.tokenUsage.allTime.totalTokens, 1500);
+      assert.equal(stats.tokenUsage.allTime.promptTokens, 1000);
+      assert.equal(stats.tokenUsage.allTime.completionTokens, 500);
+      assert.equal(stats.tokenUsage.allTime.estimatedCostUSD, 0.0075); // gpt-4o rates
+    } finally {
+      logSpy.mock.restore();
+      debugSpy.mock.restore();
+    }
+  });
+
+  it('exposes persistence counters in stats payload', () => {
+    const logSpy = mock.method(console, 'log', () => {});
+    try {
+      const stats = getLLMActivityStats();
+      assert.ok(stats.persistence);
+      assert.equal(stats.persistence.attempts, 0);
+      assert.equal(stats.persistence.errors, 0);
+    } finally {
+      logSpy.mock.restore();
+    }
+  });
+});
+
+describe('resolveModelRates (model-aware cost lookup)', () => {
+  it('returns gpt-4o-mini rates when the model matches the mini variant', () => {
+    const rates = resolveModelRates('openai', 'gpt-4o-mini-2024-07-18');
+    assert.equal(rates.input, 0.00015);
+    assert.equal(rates.output, 0.0006);
+  });
+
+  it('returns gpt-4o rates for the canonical model', () => {
+    const rates = resolveModelRates('openai', 'gpt-4o');
+    assert.equal(rates.input, 0.0025);
+    assert.equal(rates.output, 0.01);
+  });
+
+  it('distinguishes claude haiku from sonnet and opus', () => {
+    assert.deepEqual(resolveModelRates('anthropic', 'claude-haiku-4-5'), {
+      input: 0.0008,
+      output: 0.004,
+    });
+    assert.deepEqual(resolveModelRates('anthropic', 'claude-sonnet-4-6'), {
+      input: 0.003,
+      output: 0.015,
+    });
+    assert.deepEqual(resolveModelRates('anthropic', 'claude-opus-4-6'), {
+      input: 0.015,
+      output: 0.075,
+    });
+  });
+
+  it('falls back to provider defaults for unknown models', () => {
+    const rates = resolveModelRates('anthropic', 'claude-unknown-future-model');
+    assert.equal(rates.input, 0.003);
+    assert.equal(rates.output, 0.015);
+  });
+
+  it('treats local provider as free', () => {
+    assert.deepEqual(resolveModelRates('local', 'qwen2.5-coder:3b'), {
+      input: 0,
+      output: 0,
+    });
+  });
+
+  it('falls back to openai defaults for unknown provider', () => {
+    const rates = resolveModelRates('unknown-vendor', 'whatever');
+    assert.equal(rates.input, 0.0025);
+    assert.equal(rates.output, 0.01);
+  });
+});
+
+describe('buildPersistPayload', () => {
+  it('maps buffer entry to DB column shape with external_id', () => {
+    const row = buildPersistPayload({
+      id: 'llm-123-abc',
+      tenantId: '00000000-0000-0000-0000-000000000001',
+      capability: 'chat_tools',
+      provider: 'openai',
+      model: 'gpt-4o',
+      nodeId: 'ai:chat:iter0',
+      containerId: 'backend-1',
+      status: 'success',
+      durationMs: 900,
+      error: null,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      toolsCalled: ['crm_search_accounts'],
+      intent: 'LEAD_CREATE',
+      taskId: 'task_1',
+      requestId: 'req_1',
+      attempt: 1,
+      totalAttempts: 1,
+      timestamp: '2026-04-14T00:00:00.000Z',
+    });
+
+    assert.equal(row.external_id, 'llm-123-abc');
+    assert.equal(row.tenant_id, '00000000-0000-0000-0000-000000000001');
+    assert.equal(row.provider, 'openai');
+    assert.equal(row.model, 'gpt-4o');
+    assert.deepEqual(row.tools_called, ['crm_search_accounts']);
+    assert.equal(row.created_at, '2026-04-14T00:00:00.000Z');
+    assert.ok(!('id' in row), 'PK is DB-generated (UUID default); payload must not include id');
+  });
+
+  it("normalizes tenant 'unknown' to null and non-array tools_called to []", () => {
+    const row = buildPersistPayload({
+      id: 'llm-x',
+      tenantId: 'unknown',
+      capability: 'chat_tools',
+      provider: 'openai',
+      model: 'gpt-4o',
+      toolsCalled: null,
+      timestamp: '2026-04-14T00:00:00.000Z',
+    });
+    assert.equal(row.tenant_id, null);
+    assert.deepEqual(row.tools_called, []);
+  });
+});
+
+describe('persistToDatabase (fire-and-forget)', () => {
+  beforeEach(() => {
+    clearLLMActivity();
+    __resetPersistCountersForTest();
+    supabaseStub = null;
+    insertResult = { error: null };
+    __setSupabaseClientForTest(() => supabaseStub);
+  });
+
+  afterEach(() => {
+    __resetSupabaseClientForTest();
+  });
+
+  it('increments attempts+successes when supabase insert succeeds', async () => {
+    const logSpy = mock.method(console, 'log', () => {});
+    try {
+      supabaseStub = makeSupabaseStub();
+      logLLMActivity({
+        tenantId: '00000000-0000-0000-0000-000000000001',
+        capability: 'chat_tools',
+        provider: 'openai',
+        model: 'gpt-4o',
+        status: 'success',
+        durationMs: 50,
+      });
+
+      await waitForPersist();
+      const counters = getPersistCounters();
+      assert.equal(counters.attempts, 1);
+      assert.equal(counters.successes, 1);
+      assert.equal(counters.errors, 0);
+      assert.equal(insertSpy.mock.callCount(), 1);
+
+      // Payload must be the buildPersistPayload shape.
+      const sent = insertSpy.mock.calls[0].arguments[0];
+      assert.equal(sent.provider, 'openai');
+      assert.equal(sent.model, 'gpt-4o');
+      assert.equal(sent.status, 'success');
+    } finally {
+      logSpy.mock.restore();
+    }
+  });
+
+  it('increments errors and records lastError when supabase returns an error', async () => {
+    const logSpy = mock.method(console, 'log', () => {});
+    const debugSpy = mock.method(console, 'debug', () => {});
+    try {
+      supabaseStub = makeSupabaseStub();
+      insertResult = { error: { message: 'permission denied' } };
+
+      logLLMActivity({
+        tenantId: '00000000-0000-0000-0000-000000000001',
+        capability: 'chat_tools',
+        provider: 'openai',
+        model: 'gpt-4o',
+        status: 'success',
+      });
+
+      await waitForPersist();
+      const counters = getPersistCounters();
+      assert.equal(counters.attempts, 1);
+      assert.equal(counters.successes, 0);
+      assert.equal(counters.errors, 1);
+      assert.equal(counters.lastError, 'permission denied');
+      assert.ok(counters.lastErrorAt);
+    } finally {
+      logSpy.mock.restore();
+      debugSpy.mock.restore();
+    }
+  });
+
+  it('does not count errors when supabase client is unavailable (silent skip)', async () => {
+    const logSpy = mock.method(console, 'log', () => {});
+    try {
+      supabaseStub = null; // getSupabaseClient() returns null
+      logLLMActivity({
+        tenantId: '00000000-0000-0000-0000-000000000001',
+        capability: 'chat_tools',
+        provider: 'openai',
+        model: 'gpt-4o',
+        status: 'success',
+      });
+      await waitForPersist();
+      const counters = getPersistCounters();
+      assert.equal(counters.attempts, 1);
+      assert.equal(counters.successes, 0);
+      assert.equal(counters.errors, 0);
+    } finally {
+      logSpy.mock.restore();
+    }
+  });
+});

--- a/backend/__tests__/routes/braidMetrics.helpers.test.js
+++ b/backend/__tests__/routes/braidMetrics.helpers.test.js
@@ -1,0 +1,72 @@
+/**
+ * Unit tests for registry fallback/merge helpers in braidMetrics route.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildRegistryFallback, mergeRegistryToolMetrics } from '../../routes/braidMetrics.js';
+
+const TOOL_GRAPH_FIXTURE = {
+  search_accounts: { category: 'ACCOUNTS', policy: 'read' },
+  create_lead: { category: 'LEADS', policy: 'write' },
+  health_check: {},
+};
+
+describe('braidMetrics registry merge helpers', () => {
+  it('buildRegistryFallback marks tools as unused with null health scores', () => {
+    const tools = buildRegistryFallback(TOOL_GRAPH_FIXTURE);
+    assert.equal(tools.length, 3);
+    assert.equal(tools[0].name, 'search_accounts');
+    assert.equal(tools[0].category, 'ACCOUNTS');
+    assert.equal(tools[0].policy, 'read');
+    assert.equal(tools[0].healthStatus, 'unused');
+    assert.equal(tools[0].healthScore, null);
+    assert.equal(tools[0].successRate, null);
+  });
+
+  it('defaults category to GENERAL and policy to null when missing', () => {
+    const tools = buildRegistryFallback(TOOL_GRAPH_FIXTURE);
+    const healthCheck = tools.find((t) => t.name === 'health_check');
+    assert.equal(healthCheck.category, 'GENERAL');
+    assert.equal(healthCheck.policy, null);
+  });
+
+  it('returns registry-only source when audit tools are empty', () => {
+    const merged = mergeRegistryToolMetrics([], TOOL_GRAPH_FIXTURE);
+    assert.equal(merged.fromRegistry, true);
+    assert.equal(merged.auditedTools, 0);
+    assert.equal(merged.tools.length, 3);
+    assert.ok(merged.tools.every((t) => t._fromRegistry === true));
+    assert.ok(merged.tools.every((t) => t.healthStatus === 'unused'));
+  });
+
+  it('merges missing registry tools when audit data is partial', () => {
+    const merged = mergeRegistryToolMetrics(
+      [
+        {
+          name: 'search_accounts',
+          category: 'ACCOUNTS',
+          calls: 10,
+          healthStatus: 'healthy',
+          healthScore: 99,
+        },
+      ],
+      TOOL_GRAPH_FIXTURE,
+    );
+
+    assert.equal(merged.fromRegistry, false);
+    assert.equal(merged.auditedTools, 1);
+    assert.equal(merged.tools.length, 3);
+    assert.ok(merged.tools.some((t) => t.name === 'search_accounts' && !t._fromRegistry));
+    assert.ok(
+      merged.tools.some(
+        (t) => t.name === 'create_lead' && t._fromRegistry === true && t.healthStatus === 'unused',
+      ),
+    );
+    assert.ok(
+      merged.tools.some(
+        (t) => t.name === 'health_check' && t._fromRegistry === true && t.healthStatus === 'unused',
+      ),
+    );
+  });
+});

--- a/backend/lib/aiEngine/activityLogger.js
+++ b/backend/lib/aiEngine/activityLogger.js
@@ -2,50 +2,184 @@
  * LLM Activity Logger
  *
  * Captures all LLM calls for real-time monitoring in Settings.
- * Dual-path: in-memory rolling buffer (fast, real-time) + async DB insert (persistent, 90-day).
- * DB insert is fire-and-forget — never blocks the LLM response path.
+ *
+ * Dual-path design:
+ *   1. In-memory rolling buffer (MAX_ENTRIES, newest first) — fast, real-time,
+ *      no DB round-trip. Source of truth for the LLMActivityMonitor UI.
+ *   2. Async Supabase insert into `llm_activity_logs` (migration 151) —
+ *      persistent, 90-day retention via pg_cron. Fire-and-forget; failures are
+ *      counted in `persistCounters` and never block the LLM response path.
+ *
+ * Cost estimation is model-aware (see MODEL_COST_RATES / resolveModelRates) —
+ * pricing is keyed by provider AND model substring so e.g. gpt-4o-mini isn't
+ * billed at gpt-4o rates, and Claude haiku/sonnet/opus are distinguished.
+ *
+ * Observability: getLLMActivityStats().persistence surfaces
+ *   { attempts, successes, errors, lastError, lastErrorAt }
+ * so ops can detect sustained DB-persist failures without log scraping.
+ *
+ * Testing: __setSupabaseClientForTest / __resetSupabaseClientForTest /
+ *   __resetPersistCountersForTest / buildPersistPayload / resolveModelRates
+ *   are exported for unit tests only — do not call from production code.
  */
 
-import { getSupabaseClient } from '../supabase-db.js';
+import { getSupabaseClient as getSupabaseClientReal } from '../supabase-db.js';
+
+// Test seam: tests inject a stub (or null) via __setSupabaseClientForTest.
+// Default resolver calls through to the real client factory.
+let supabaseResolver = () => getSupabaseClientReal();
+
+/**
+ * Test hook: replace the Supabase client resolver. Pass null to disable.
+ * Do not use in production code.
+ */
+export function __setSupabaseClientForTest(resolver) {
+  supabaseResolver = typeof resolver === 'function' ? resolver : () => resolver;
+}
+
+/**
+ * Test hook: restore the production Supabase client resolver.
+ */
+export function __resetSupabaseClientForTest() {
+  supabaseResolver = () => getSupabaseClientReal();
+}
 
 const MAX_ENTRIES = 500;
 const activityLog = [];
 
 /**
+ * Model-aware cost table (USD per 1K tokens).
+ * Keys are lowercased model substrings tested against `entry.model`.
+ * First match wins; `defaults` per provider catches unknown models.
+ *
+ * Sources: public vendor pricing pages. Update when providers reprice.
+ * Intentionally conservative — prefer under-reporting to over-reporting.
+ */
+export const MODEL_COST_RATES = {
+  openai: {
+    defaults: { input: 0.0025, output: 0.01 },
+    models: [
+      { match: 'gpt-4o-mini', input: 0.00015, output: 0.0006 },
+      { match: 'gpt-4o', input: 0.0025, output: 0.01 },
+      { match: 'gpt-4.1-mini', input: 0.0004, output: 0.0016 },
+      { match: 'gpt-4.1', input: 0.002, output: 0.008 },
+      { match: 'o4-mini', input: 0.0011, output: 0.0044 },
+      { match: 'o3-mini', input: 0.0011, output: 0.0044 },
+      { match: 'o3', input: 0.002, output: 0.008 },
+      { match: 'gpt-3.5', input: 0.0005, output: 0.0015 },
+    ],
+  },
+  anthropic: {
+    defaults: { input: 0.003, output: 0.015 },
+    models: [
+      { match: 'haiku', input: 0.0008, output: 0.004 },
+      { match: 'sonnet', input: 0.003, output: 0.015 },
+      { match: 'opus', input: 0.015, output: 0.075 },
+    ],
+  },
+  groq: {
+    defaults: { input: 0.0001, output: 0.0001 },
+    models: [
+      { match: 'llama-3.3-70b', input: 0.00059, output: 0.00079 },
+      { match: 'llama-3.1-70b', input: 0.00059, output: 0.00079 },
+      { match: 'llama-3.1-8b', input: 0.00005, output: 0.00008 },
+      { match: 'mixtral-8x7b', input: 0.00024, output: 0.00024 },
+    ],
+  },
+  local: {
+    defaults: { input: 0, output: 0 },
+    models: [],
+  },
+};
+
+/**
+ * Resolve per-1K token rates for a given provider+model.
+ * Falls back to provider defaults, then to openai defaults.
+ */
+export function resolveModelRates(provider, model) {
+  const providerKey = String(provider || '').toLowerCase();
+  const modelKey = String(model || '').toLowerCase();
+  const bucket = MODEL_COST_RATES[providerKey] || MODEL_COST_RATES.openai;
+  if (modelKey && bucket.models) {
+    const hit = bucket.models.find((m) => modelKey.includes(m.match));
+    if (hit) return { input: hit.input, output: hit.output };
+  }
+  return bucket.defaults || MODEL_COST_RATES.openai.defaults;
+}
+
+// Observability counters — exposed via getLLMActivityStats() so ops can detect
+// sustained DB-persist failures without reading application logs.
+const persistCounters = {
+  attempts: 0,
+  successes: 0,
+  errors: 0,
+  lastError: null,
+  lastErrorAt: null,
+};
+
+/**
+ * Test hook: reset persist counters (used by unit tests).
+ */
+export function __resetPersistCountersForTest() {
+  persistCounters.attempts = 0;
+  persistCounters.successes = 0;
+  persistCounters.errors = 0;
+  persistCounters.lastError = null;
+  persistCounters.lastErrorAt = null;
+}
+
+/**
+ * Build the row payload inserted into llm_activity_logs.
+ * Exported so tests can assert shape without a real Supabase client.
+ */
+export function buildPersistPayload(entry) {
+  return {
+    external_id: entry.id,
+    tenant_id: entry.tenantId && entry.tenantId !== 'unknown' ? entry.tenantId : null,
+    capability: entry.capability,
+    provider: entry.provider,
+    model: entry.model,
+    node_id: entry.nodeId,
+    container_id: entry.containerId,
+    status: entry.status,
+    duration_ms: entry.durationMs,
+    error: entry.error,
+    usage: entry.usage,
+    tools_called: Array.isArray(entry.toolsCalled) ? entry.toolsCalled : [],
+    intent: entry.intent,
+    task_id: entry.taskId,
+    request_id: entry.requestId,
+    attempt: entry.attempt,
+    total_attempts: entry.totalAttempts,
+    created_at: entry.timestamp,
+  };
+}
+
+/**
  * Non-blocking DB persist for one log entry.
  * Errors are caught and swallowed — DB issues must never affect LLM throughput.
+ * Failures are counted in `persistCounters` and surfaced via stats.
  */
 async function persistToDatabase(entry) {
+  persistCounters.attempts += 1;
   try {
-    const supabase = getSupabaseClient();
-    if (!supabase) return; // supabase not configured, skip silently
+    const supabase = supabaseResolver();
+    if (!supabase) return; // supabase not configured, skip silently (not counted as error)
 
-    const { error } = await supabase.from('llm_activity_logs').insert({
-      id: entry.id,
-      tenant_id: entry.tenantId !== 'unknown' ? entry.tenantId : null,
-      capability: entry.capability,
-      provider: entry.provider,
-      model: entry.model,
-      node_id: entry.nodeId,
-      container_id: entry.containerId,
-      status: entry.status,
-      duration_ms: entry.durationMs,
-      error: entry.error,
-      usage: entry.usage,
-      tools_called: entry.toolsCalled,
-      intent: entry.intent,
-      task_id: entry.taskId,
-      request_id: entry.requestId,
-      attempt: entry.attempt,
-      total_attempts: entry.totalAttempts,
-      created_at: entry.timestamp,
-    });
+    const { error } = await supabase.from('llm_activity_logs').insert(buildPersistPayload(entry));
 
     if (error) {
-      // Only log at debug level — DB persistence is best-effort
+      persistCounters.errors += 1;
+      persistCounters.lastError = error.message;
+      persistCounters.lastErrorAt = new Date().toISOString();
       console.debug('[LLMActivityLogger] DB persist skipped:', error.message);
+      return;
     }
+    persistCounters.successes += 1;
   } catch (err) {
+    persistCounters.errors += 1;
+    persistCounters.lastError = err.message;
+    persistCounters.lastErrorAt = new Date().toISOString();
     console.debug('[LLMActivityLogger] DB persist error (non-fatal):', err.message);
   }
 }
@@ -61,19 +195,29 @@ export function getNodeId() {
 /**
  * Log an LLM activity entry.
  *
+ * Side effects:
+ *   - Prepends the entry to the in-memory rolling buffer (trimmed to MAX_ENTRIES).
+ *   - Emits a structured JSON line to stdout tagged [AIEngine][LLM_CALL_*].
+ *   - Fires an async insert into `llm_activity_logs` via persistToDatabase
+ *     (never awaited). The caller MUST NOT rely on the DB row existing after
+ *     this function returns.
+ *
  * @param {Object} entry
- * @param {string} entry.tenantId - Tenant UUID
+ * @param {string} entry.tenantId - Tenant UUID. The literal string 'unknown' is
+ *   normalized to NULL in the DB row (used for unscoped/system calls).
  * @param {string} entry.capability - The capability used (chat_tools, json_strict, etc.)
  * @param {string} entry.provider - The LLM provider (openai, anthropic, groq, local)
- * @param {string} entry.model - The model name
+ * @param {string} entry.model - The model name. Used by resolveModelRates for
+ *   accurate per-1K cost estimation (e.g. gpt-4o-mini vs gpt-4o).
  * @param {string} [entry.nodeId] - Optional node/route identifier (e.g., "mcp:llm.generate_json")
  * @param {string} [entry.status] - "success" | "error" | "failover"
  * @param {number} [entry.durationMs] - Request duration in milliseconds
  * @param {string} [entry.error] - Error message if failed
- * @param {Object} [entry.usage] - Token usage { prompt_tokens, completion_tokens }
+ * @param {Object} [entry.usage] - Token usage { prompt_tokens, completion_tokens, total_tokens }
  * @param {number} [entry.attempt] - Which attempt in failover chain (1, 2, etc.)
  * @param {number} [entry.totalAttempts] - Total attempts in failover chain
- * @param {Array<string>} [entry.toolsCalled] - Array of tool names called during this request
+ * @param {Array<string>} [entry.toolsCalled] - Array of tool names called during
+ *   this request. Non-arrays are normalized to [] before DB insert.
  * @param {string} [entry.intent] - Classified intent code from intentClassifier (e.g., LEAD_CREATE, AI_SUGGEST_NEXT_ACTIONS)
  * @param {string} [entry.taskId] - Unique task identifier assigned at REQUESTED stage
  * @param {string} [entry.requestId] - Request-scoped correlation id ("req_<ts>_<rand9>")
@@ -243,15 +387,6 @@ export function getLLMActivityStats() {
     }
   }
 
-  // Token stats + cost estimates for all time (from buffer)
-  // Approximate cost per 1K tokens (input/output averaged) by provider+model
-  const COST_PER_1K = {
-    anthropic: { input: 0.003, output: 0.015 }, // claude-sonnet-4 approximate
-    openai: { input: 0.0025, output: 0.01 }, // gpt-4o approximate
-    groq: { input: 0.0001, output: 0.0001 }, // llama on groq
-    local: { input: 0, output: 0 },
-  };
-
   let allTimeTokens = 0;
   let allTimePromptTokens = 0;
   let allTimeCompletionTokens = 0;
@@ -265,7 +400,7 @@ export function getLLMActivityStats() {
       allTimeTokens += tt;
       allTimePromptTokens += pt;
       allTimeCompletionTokens += ct;
-      const rates = COST_PER_1K[entry.provider] || COST_PER_1K.openai;
+      const rates = resolveModelRates(entry.provider, entry.model);
       estimatedCostUSD += (pt / 1000) * rates.input + (ct / 1000) * rates.output;
     }
   }
@@ -302,7 +437,21 @@ export function getLLMActivityStats() {
         estimatedCostUSD: Math.round(estimatedCostUSD * 10000) / 10000, // 4 decimal places
       },
     },
+    persistence: {
+      attempts: persistCounters.attempts,
+      successes: persistCounters.successes,
+      errors: persistCounters.errors,
+      lastError: persistCounters.lastError,
+      lastErrorAt: persistCounters.lastErrorAt,
+    },
   };
+}
+
+/**
+ * Snapshot of DB-persist counters. Useful for ops endpoints and alerting.
+ */
+export function getPersistCounters() {
+  return { ...persistCounters };
 }
 
 /**
@@ -317,4 +466,8 @@ export default {
   getLLMActivity,
   getLLMActivityStats,
   clearLLMActivity,
+  getPersistCounters,
+  resolveModelRates,
+  buildPersistPayload,
+  MODEL_COST_RATES,
 };

--- a/backend/lib/aiEngine/activityLogger.js
+++ b/backend/lib/aiEngine/activityLogger.js
@@ -2,12 +2,53 @@
  * LLM Activity Logger
  *
  * Captures all LLM calls for real-time monitoring in Settings.
- * Stores entries in memory with a rolling buffer (last N entries).
- * Also outputs structured JSON logs for log aggregation (Loki, CloudWatch, etc.)
+ * Dual-path: in-memory rolling buffer (fast, real-time) + async DB insert (persistent, 90-day).
+ * DB insert is fire-and-forget — never blocks the LLM response path.
  */
+
+import { getSupabaseClient } from '../supabase-db.js';
 
 const MAX_ENTRIES = 500;
 const activityLog = [];
+
+/**
+ * Non-blocking DB persist for one log entry.
+ * Errors are caught and swallowed — DB issues must never affect LLM throughput.
+ */
+async function persistToDatabase(entry) {
+  try {
+    const supabase = getSupabaseClient();
+    if (!supabase) return; // supabase not configured, skip silently
+
+    const { error } = await supabase.from('llm_activity_logs').insert({
+      id: entry.id,
+      tenant_id: entry.tenantId !== 'unknown' ? entry.tenantId : null,
+      capability: entry.capability,
+      provider: entry.provider,
+      model: entry.model,
+      node_id: entry.nodeId,
+      container_id: entry.containerId,
+      status: entry.status,
+      duration_ms: entry.durationMs,
+      error: entry.error,
+      usage: entry.usage,
+      tools_called: entry.toolsCalled,
+      intent: entry.intent,
+      task_id: entry.taskId,
+      request_id: entry.requestId,
+      attempt: entry.attempt,
+      total_attempts: entry.totalAttempts,
+      created_at: entry.timestamp,
+    });
+
+    if (error) {
+      // Only log at debug level — DB persistence is best-effort
+      console.debug('[LLMActivityLogger] DB persist skipped:', error.message);
+    }
+  } catch (err) {
+    console.debug('[LLMActivityLogger] DB persist error (non-fatal):', err.message);
+  }
+}
 
 /**
  * Get the node/container ID from environment.
@@ -96,6 +137,9 @@ export function logLLMActivity(entry) {
       error: logEntry.error,
     }),
   );
+
+  // Fire-and-forget DB persist — never awaited, never blocks
+  persistToDatabase(logEntry);
 }
 
 /**
@@ -147,28 +191,42 @@ export function getLLMActivityStats() {
   const fiveMinutesAgo = now - 5 * 60 * 1000;
 
   const recentEntries = activityLog.filter((e) => new Date(e.timestamp).getTime() > fiveMinutesAgo);
-
   const lastMinute = activityLog.filter((e) => new Date(e.timestamp).getTime() > oneMinuteAgo);
 
-  // Count by provider
+  // Count by provider/capability/status — use 5-min window when available, else full buffer
+  const windowEntries = recentEntries.length > 0 ? recentEntries : activityLog;
+  const windowLabel = recentEntries.length > 0 ? 'last5min' : 'buffer';
+
   const byProvider = {};
   const byCapability = {};
   const byStatus = {};
 
-  for (const entry of recentEntries) {
+  for (const entry of windowEntries) {
     byProvider[entry.provider] = (byProvider[entry.provider] || 0) + 1;
     byCapability[entry.capability] = (byCapability[entry.capability] || 0) + 1;
     byStatus[entry.status] = (byStatus[entry.status] || 0) + 1;
   }
 
-  // Calculate average duration
-  const durations = recentEntries.filter((e) => e.durationMs).map((e) => e.durationMs);
+  // allTime breakdowns always from full buffer (for cards that always show buffer totals)
+  const allTimeByProvider = {};
+  const allTimeByStatus = {};
+  const allTimeByCapability = {};
+  for (const entry of activityLog) {
+    allTimeByProvider[entry.provider] = (allTimeByProvider[entry.provider] || 0) + 1;
+    allTimeByStatus[entry.status] = (allTimeByStatus[entry.status] || 0) + 1;
+    allTimeByCapability[entry.capability] = (allTimeByCapability[entry.capability] || 0) + 1;
+  }
+
+  // Average duration — prefer 5-min window, fall back to full buffer
+  const recentDurations = recentEntries.filter((e) => e.durationMs).map((e) => e.durationMs);
+  const allDurations = activityLog.filter((e) => e.durationMs).map((e) => e.durationMs);
+  const durationSource = recentDurations.length > 0 ? recentDurations : allDurations;
   const avgDuration =
-    durations.length > 0
-      ? Math.round(durations.reduce((a, b) => a + b, 0) / durations.length)
+    durationSource.length > 0
+      ? Math.round(durationSource.reduce((a, b) => a + b, 0) / durationSource.length)
       : null;
 
-  // Calculate token usage
+  // Token usage — 5-min window
   let totalPromptTokens = 0;
   let totalCompletionTokens = 0;
   let totalTokens = 0;
@@ -185,13 +243,30 @@ export function getLLMActivityStats() {
     }
   }
 
-  // Token stats for all time (from buffer)
+  // Token stats + cost estimates for all time (from buffer)
+  // Approximate cost per 1K tokens (input/output averaged) by provider+model
+  const COST_PER_1K = {
+    anthropic: { input: 0.003, output: 0.015 }, // claude-sonnet-4 approximate
+    openai: { input: 0.0025, output: 0.01 }, // gpt-4o approximate
+    groq: { input: 0.0001, output: 0.0001 }, // llama on groq
+    local: { input: 0, output: 0 },
+  };
+
   let allTimeTokens = 0;
+  let allTimePromptTokens = 0;
+  let allTimeCompletionTokens = 0;
+  let estimatedCostUSD = 0;
+
   for (const entry of activityLog) {
     if (entry.usage) {
-      allTimeTokens +=
-        entry.usage.total_tokens ||
-        (entry.usage.prompt_tokens || 0) + (entry.usage.completion_tokens || 0);
+      const pt = entry.usage.prompt_tokens || 0;
+      const ct = entry.usage.completion_tokens || 0;
+      const tt = entry.usage.total_tokens || pt + ct;
+      allTimeTokens += tt;
+      allTimePromptTokens += pt;
+      allTimeCompletionTokens += ct;
+      const rates = COST_PER_1K[entry.provider] || COST_PER_1K.openai;
+      estimatedCostUSD += (pt / 1000) * rates.input + (ct / 1000) * rates.output;
     }
   }
 
@@ -201,9 +276,17 @@ export function getLLMActivityStats() {
     lastMinute: lastMinute.length,
     requestsPerMinute: lastMinute.length,
     avgDurationMs: avgDuration,
+    // Window-aware breakdowns (5-min when active, buffer otherwise)
     byProvider,
     byCapability,
     byStatus,
+    windowLabel,
+    // Full buffer breakdowns — always available regardless of recent activity
+    allTime: {
+      byProvider: allTimeByProvider,
+      byStatus: allTimeByStatus,
+      byCapability: allTimeByCapability,
+    },
     tokenUsage: {
       last5Minutes: {
         promptTokens: totalPromptTokens,
@@ -213,7 +296,10 @@ export function getLLMActivityStats() {
       },
       allTime: {
         totalTokens: allTimeTokens,
+        promptTokens: allTimePromptTokens,
+        completionTokens: allTimeCompletionTokens,
         entriesInBuffer: activityLog.length,
+        estimatedCostUSD: Math.round(estimatedCostUSD * 10000) / 10000, // 4 decimal places
       },
     },
   };

--- a/backend/migrations/151_llm_activity_logs.sql
+++ b/backend/migrations/151_llm_activity_logs.sql
@@ -1,8 +1,8 @@
 -- Migration 151: LLM Activity Logs (persistent storage)
--- Replaces the in-memory rolling buffer with a proper audit table.
--- Non-blocking insert path: backend inserts fire-and-forget, never block response.
---
--- Retention: 90 days (managed via pg_cron or scheduled cleanup job)
+-- Adds a persistent audit table alongside the existing in-memory rolling buffer.
+-- The buffer remains for real-time display (fast, no DB round-trip); this table
+-- provides durable history that survives restarts, with 90-day retention.
+-- Non-blocking insert path: backend inserts are fire-and-forget, never blocking response.
 
 CREATE TABLE IF NOT EXISTS llm_activity_logs (
   id              TEXT PRIMARY KEY,                        -- e.g. "llm-<ts>-<rand>"
@@ -39,10 +39,10 @@ ALTER TABLE llm_activity_logs ENABLE ROW LEVEL SECURITY;
 CREATE POLICY llm_activity_logs_service_all ON llm_activity_logs
   FOR ALL TO service_role USING (true) WITH CHECK (true);
 
--- Authenticated users can see their own tenant's logs
+-- Authenticated users can see their own tenant's logs (matches repo UUID-based pattern)
 CREATE POLICY llm_activity_logs_tenant_select ON llm_activity_logs
   FOR SELECT TO authenticated
-  USING (tenant_id = (SELECT id FROM tenants WHERE slug = current_setting('app.tenant_slug', true)));
+  USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
 
 -- Cleanup function: delete entries older than 90 days
 CREATE OR REPLACE FUNCTION cleanup_llm_activity_logs()

--- a/backend/migrations/151_llm_activity_logs.sql
+++ b/backend/migrations/151_llm_activity_logs.sql
@@ -1,0 +1,53 @@
+-- Migration 151: LLM Activity Logs (persistent storage)
+-- Replaces the in-memory rolling buffer with a proper audit table.
+-- Non-blocking insert path: backend inserts fire-and-forget, never block response.
+--
+-- Retention: 90 days (managed via pg_cron or scheduled cleanup job)
+
+CREATE TABLE IF NOT EXISTS llm_activity_logs (
+  id              TEXT PRIMARY KEY,                        -- e.g. "llm-<ts>-<rand>"
+  tenant_id       UUID,                                    -- nullable for system calls
+  capability      TEXT NOT NULL,                           -- chat_tools, json_strict, etc.
+  provider        TEXT NOT NULL,                           -- openai, anthropic, groq, local
+  model           TEXT NOT NULL,
+  node_id         TEXT,                                    -- e.g. "ai:chat:iter0"
+  container_id    TEXT,                                    -- MCP_NODE_ID / HOSTNAME
+  status          TEXT NOT NULL DEFAULT 'success',         -- success | error | failover
+  duration_ms     INTEGER,
+  error           TEXT,
+  usage           JSONB,                                   -- { prompt_tokens, completion_tokens, total_tokens }
+  tools_called    TEXT[],                                  -- array of tool names
+  intent          TEXT,                                    -- e.g. LEAD_CREATE
+  task_id         TEXT,
+  request_id      TEXT,
+  attempt         SMALLINT,
+  total_attempts  SMALLINT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes for dashboard queries
+CREATE INDEX IF NOT EXISTS llm_activity_logs_created_at_idx   ON llm_activity_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_tenant_idx        ON llm_activity_logs (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_provider_idx      ON llm_activity_logs (provider, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_status_idx        ON llm_activity_logs (status, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_capability_idx    ON llm_activity_logs (capability, created_at DESC);
+
+-- RLS: admin/superadmin read; backend service role insert
+ALTER TABLE llm_activity_logs ENABLE ROW LEVEL SECURITY;
+
+-- Service role (backend) can do everything
+CREATE POLICY llm_activity_logs_service_all ON llm_activity_logs
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Authenticated users can see their own tenant's logs
+CREATE POLICY llm_activity_logs_tenant_select ON llm_activity_logs
+  FOR SELECT TO authenticated
+  USING (tenant_id = (SELECT id FROM tenants WHERE slug = current_setting('app.tenant_slug', true)));
+
+-- Cleanup function: delete entries older than 90 days
+CREATE OR REPLACE FUNCTION cleanup_llm_activity_logs()
+RETURNS void LANGUAGE sql AS $$
+  DELETE FROM llm_activity_logs WHERE created_at < NOW() - INTERVAL '90 days';
+$$;
+
+COMMENT ON TABLE llm_activity_logs IS 'Persistent audit log for all LLM API calls. 90-day retention.';

--- a/backend/migrations/151_llm_activity_logs.sql
+++ b/backend/migrations/151_llm_activity_logs.sql
@@ -3,10 +3,22 @@
 -- The buffer remains for real-time display (fast, no DB round-trip); this table
 -- provides durable history that survives restarts, with 90-day retention.
 -- Non-blocking insert path: backend inserts are fire-and-forget, never blocking response.
+--
+-- Conventions honored:
+--   * RLS uses public.current_tenant_id() (JWT-based helper) to match the
+--     standardized tenant-isolation pattern (migration
+--     rls_fix_high3_standardize_tenant_isolation_pattern).
+--   * UUID primary keys (gen_random_uuid) to eliminate ID-collision risk across
+--     concurrent MCP containers.
+--   * 90-day retention scheduled via pg_cron (extension already installed).
+
+-- Ensure pgcrypto is available for gen_random_uuid (noop if already enabled).
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE TABLE IF NOT EXISTS llm_activity_logs (
-  id              TEXT PRIMARY KEY,                        -- e.g. "llm-<ts>-<rand>"
-  tenant_id       UUID,                                    -- nullable for system calls
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  external_id     TEXT,                                    -- in-memory buffer id ("llm-<ts>-<rand>") for cross-ref
+  tenant_id       UUID,                                    -- nullable for system/unscoped calls
   capability      TEXT NOT NULL,                           -- chat_tools, json_strict, etc.
   provider        TEXT NOT NULL,                           -- openai, anthropic, groq, local
   model           TEXT NOT NULL,
@@ -16,7 +28,7 @@ CREATE TABLE IF NOT EXISTS llm_activity_logs (
   duration_ms     INTEGER,
   error           TEXT,
   usage           JSONB,                                   -- { prompt_tokens, completion_tokens, total_tokens }
-  tools_called    TEXT[],                                  -- array of tool names
+  tools_called    TEXT[] NOT NULL DEFAULT '{}',            -- array of tool names (never null for consistency)
   intent          TEXT,                                    -- e.g. LEAD_CREATE
   task_id         TEXT,
   request_id      TEXT,
@@ -25,29 +37,74 @@ CREATE TABLE IF NOT EXISTS llm_activity_logs (
   created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Indexes for dashboard queries
-CREATE INDEX IF NOT EXISTS llm_activity_logs_created_at_idx   ON llm_activity_logs (created_at DESC);
-CREATE INDEX IF NOT EXISTS llm_activity_logs_tenant_idx        ON llm_activity_logs (tenant_id, created_at DESC);
-CREATE INDEX IF NOT EXISTS llm_activity_logs_provider_idx      ON llm_activity_logs (provider, created_at DESC);
-CREATE INDEX IF NOT EXISTS llm_activity_logs_status_idx        ON llm_activity_logs (status, created_at DESC);
-CREATE INDEX IF NOT EXISTS llm_activity_logs_capability_idx    ON llm_activity_logs (capability, created_at DESC);
+-- Composite indexes aligned to dashboard query patterns.
+-- Primary access is "this tenant, recent, maybe filtered by status or provider".
+CREATE INDEX IF NOT EXISTS llm_activity_logs_created_at_idx
+  ON llm_activity_logs (created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_tenant_created_idx
+  ON llm_activity_logs (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_tenant_status_created_idx
+  ON llm_activity_logs (tenant_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS llm_activity_logs_provider_created_idx
+  ON llm_activity_logs (provider, created_at DESC);
 
--- RLS: admin/superadmin read; backend service role insert
+-- Row-level security matches the repo convention (current_tenant_id() JWT helper).
 ALTER TABLE llm_activity_logs ENABLE ROW LEVEL SECURITY;
 
--- Service role (backend) can do everything
+-- Service role (backend) has full access for inserts, retention cleanup, etc.
+DROP POLICY IF EXISTS llm_activity_logs_service_all ON llm_activity_logs;
 CREATE POLICY llm_activity_logs_service_all ON llm_activity_logs
   FOR ALL TO service_role USING (true) WITH CHECK (true);
 
--- Authenticated users can see their own tenant's logs (matches repo UUID-based pattern)
+-- Authenticated users may read only their own tenant's logs.
+-- Uses the standardized current_tenant_id() helper (JWT-derived, STABLE, SECURITY DEFINER).
+DROP POLICY IF EXISTS llm_activity_logs_tenant_select ON llm_activity_logs;
 CREATE POLICY llm_activity_logs_tenant_select ON llm_activity_logs
   FOR SELECT TO authenticated
-  USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid);
+  USING (tenant_id = public.current_tenant_id());
 
--- Cleanup function: delete entries older than 90 days
-CREATE OR REPLACE FUNCTION cleanup_llm_activity_logs()
-RETURNS void LANGUAGE sql AS $$
-  DELETE FROM llm_activity_logs WHERE created_at < NOW() - INTERVAL '90 days';
+-- Retention cleanup: delete entries older than 90 days.
+CREATE OR REPLACE FUNCTION public.cleanup_llm_activity_logs()
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  removed bigint;
+BEGIN
+  DELETE FROM public.llm_activity_logs
+    WHERE created_at < NOW() - INTERVAL '90 days';
+  GET DIAGNOSTICS removed = ROW_COUNT;
+  RETURN removed;
+END;
 $$;
 
-COMMENT ON TABLE llm_activity_logs IS 'Persistent audit log for all LLM API calls. 90-day retention.';
+REVOKE ALL ON FUNCTION public.cleanup_llm_activity_logs() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.cleanup_llm_activity_logs() TO service_role;
+
+-- Schedule retention daily at 03:15 UTC via pg_cron.
+-- Safe to re-run: unschedule first if already scheduled.
+DO $$
+DECLARE
+  existing_job_id BIGINT;
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    SELECT jobid INTO existing_job_id
+      FROM cron.job
+      WHERE jobname = 'llm_activity_logs_cleanup';
+    IF existing_job_id IS NOT NULL THEN
+      PERFORM cron.unschedule(existing_job_id);
+    END IF;
+    PERFORM cron.schedule(
+      'llm_activity_logs_cleanup',
+      '15 3 * * *',
+      $cron$SELECT public.cleanup_llm_activity_logs();$cron$
+    );
+  END IF;
+END
+$$;
+
+COMMENT ON TABLE  llm_activity_logs                      IS 'Persistent audit log for all LLM API calls. 90-day retention (pg_cron daily).';
+COMMENT ON COLUMN llm_activity_logs.external_id          IS 'In-memory buffer id for cross-referencing real-time monitor entries.';
+COMMENT ON FUNCTION public.cleanup_llm_activity_logs()   IS 'Deletes llm_activity_logs older than 90 days. Scheduled via pg_cron.';

--- a/backend/routes/braidMetrics.js
+++ b/backend/routes/braidMetrics.js
@@ -1,20 +1,48 @@
 /**
  * Braid Metrics REST API
- * 
+ *
  * Dashboard-ready endpoints for tool performance, usage, and health metrics.
  * Combines real-time Redis counters with historical data from braid_audit_log.
- * 
+ *
  * AUTHENTICATION: Superadmin-only (ADMIN_EMAILS) - monitors ALL tenants
- * 
+ *
  * @module routes/braidMetrics
  */
 
 import express from 'express';
 import { requireAuthCookie } from '../middleware/authCookie.js';
 import { getRealtimeMetrics } from '../lib/braidIntegration-v2.js';
-import { getToolMetrics, getMetricsTimeSeries, getErrorAnalysis, getAuditStats } from '../../braid-llm-kit/sdk/index.js';
+import { TOOL_GRAPH } from '../lib/braid/analysis.js';
+import {
+  getToolMetrics,
+  getMetricsTimeSeries,
+  getErrorAnalysis,
+  getAuditStats,
+} from '../../braid-llm-kit/sdk/index.js';
 import { getSupabaseClient } from '../lib/supabase-db.js';
 import logger from '../lib/logger.js';
+
+/**
+ * Build a zero-call registry entry for each tool in TOOL_GRAPH.
+ * Used to pre-populate the Tool Health tab before any audit log entries exist.
+ */
+function buildRegistryFallback() {
+  return Object.entries(TOOL_GRAPH).map(([name, config]) => ({
+    name,
+    policy: config.category || 'GENERAL',
+    calls: 0,
+    successRate: 100,
+    errorRate: 0,
+    cacheHitRate: 0,
+    avgLatencyMs: 0,
+    p95LatencyMs: 0,
+    errorTypes: {},
+    lastUsed: null,
+    healthScore: 100,
+    healthStatus: 'healthy',
+    _fromRegistry: true, // flag: no real data yet
+  }));
+}
 
 const router = express.Router();
 
@@ -22,25 +50,25 @@ const router = express.Router();
 function requireAdmin(req, res, next) {
   if (!req.user || !req.user.email) {
     return res.status(401).json({
-      error: "Unauthorized - authentication required"
+      error: 'Unauthorized - authentication required',
     });
   }
 
-  const adminEmails = (process.env.ADMIN_EMAILS || "")
-    .split(",")
+  const adminEmails = (process.env.ADMIN_EMAILS || '')
+    .split(',')
     .map((s) => s.trim().toLowerCase())
     .filter(Boolean);
 
   if (adminEmails.length === 0) {
     return res.status(403).json({
-      error: "Admin access not configured (ADMIN_EMAILS missing)"
+      error: 'Admin access not configured (ADMIN_EMAILS missing)',
     });
   }
 
   const userEmail = String(req.user.email).toLowerCase();
   if (!adminEmails.includes(userEmail)) {
     return res.status(403).json({
-      error: "Forbidden - superadmin access required"
+      error: 'Forbidden - superadmin access required',
     });
   }
 
@@ -53,13 +81,13 @@ router.use(requireAdmin);
 
 /**
  * GET /api/braid/metrics/realtime
- * 
+ *
  * Returns real-time metrics from Redis counters (last minute and hour).
  * Fastest endpoint - no database queries.
- * 
+ *
  * Query params:
  * - tenant_id: Optional - filter by specific tenant UUID (superadmin can monitor any tenant)
- * 
+ *
  * Response:
  * {
  *   minute: { total: 45, success: 42, failed: 3, cacheHits: 20, totalLatencyMs: 12500 },
@@ -75,48 +103,42 @@ router.get('/realtime', async (req, res) => {
     // Get both minute and hour windows
     const [minuteMetrics, hourMetrics] = await Promise.all([
       getRealtimeMetrics(tenantId, 'minute'),
-      getRealtimeMetrics(tenantId, 'hour')
+      getRealtimeMetrics(tenantId, 'hour'),
     ]);
-    
+
     const metrics = {
       minute: {
         total: minuteMetrics.calls,
         success: minuteMetrics.calls - minuteMetrics.errors,
         failed: minuteMetrics.errors,
         cacheHits: minuteMetrics.cacheHits,
-        totalLatencyMs: 0 // Not tracked in current implementation
+        totalLatencyMs: 0, // Not tracked in current implementation
       },
       hour: {
         total: hourMetrics.calls,
         success: hourMetrics.calls - hourMetrics.errors,
         failed: hourMetrics.errors,
         cacheHits: hourMetrics.cacheHits,
-        totalLatencyMs: 0 // Not tracked in current implementation
-      }
+        totalLatencyMs: 0, // Not tracked in current implementation
+      },
     };
-    
+
     // Add derived metrics for easy dashboard consumption
     const derived = {
-      minuteSuccessRate: metrics.minute.total > 0 
-        ? metrics.minute.success / metrics.minute.total 
-        : 1,
-      hourSuccessRate: metrics.hour.total > 0 
-        ? metrics.hour.success / metrics.hour.total 
-        : 1,
-      minuteCacheRate: metrics.minute.total > 0 
-        ? metrics.minute.cacheHits / metrics.minute.total 
-        : 0,
-      hourCacheRate: metrics.hour.total > 0 
-        ? metrics.hour.cacheHits / metrics.hour.total 
-        : 0,
+      minuteSuccessRate:
+        metrics.minute.total > 0 ? metrics.minute.success / metrics.minute.total : 1,
+      hourSuccessRate: metrics.hour.total > 0 ? metrics.hour.success / metrics.hour.total : 1,
+      minuteCacheRate:
+        metrics.minute.total > 0 ? metrics.minute.cacheHits / metrics.minute.total : 0,
+      hourCacheRate: metrics.hour.total > 0 ? metrics.hour.cacheHits / metrics.hour.total : 0,
       minuteAvgLatencyMs: 0, // Not tracked yet
-      hourAvgLatencyMs: 0 // Not tracked yet
+      hourAvgLatencyMs: 0, // Not tracked yet
     };
 
     res.json({
       ...metrics,
       derived,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     logger.error('[Braid Metrics] Realtime error:', error);
@@ -126,13 +148,13 @@ router.get('/realtime', async (req, res) => {
 
 /**
  * GET /api/braid/metrics/tools
- * 
+ *
  * Returns per-tool metrics with health scores.
- * 
+ *
  * Query params:
  * - period: '1h' | '24h' | '7d' | '30d' (default: '24h')
  * - tenant_id: Optional - filter by specific tenant UUID (superadmin can monitor any tenant)
- * 
+ *
  * Response:
  * {
  *   tools: [
@@ -166,25 +188,41 @@ router.get('/tools', async (req, res) => {
     }
 
     // Extract tools array from result
-    const tools = result.tools || [];
+    let tools = result.tools || [];
+
+    // When the audit log is empty (no Braid tool calls yet), fall back to the static
+    // TOOL_GRAPH registry so the Tool Health tab always shows the full tool inventory.
+    const fromRegistry = tools.length === 0;
+    if (fromRegistry) {
+      tools = buildRegistryFallback();
+    } else {
+      // Merge registry tools that have no audit log entries yet (show them as 0-call healthy)
+      const auditedNames = new Set(tools.map((t) => t.name));
+      const missingTools = buildRegistryFallback().filter((t) => !auditedNames.has(t.name));
+      tools = [...tools, ...missingTools];
+    }
 
     // Generate summary
     const summary = {
       totalTools: tools.length,
-      healthyCount: tools.filter(t => t.healthStatus === 'healthy').length,
-      degradedCount: tools.filter(t => t.healthStatus === 'degraded').length,
-      warningCount: tools.filter(t => t.healthStatus === 'warning').length,
-      criticalCount: tools.filter(t => t.healthStatus === 'critical').length,
-      overallHealth: tools.length > 0 
-        ? Math.round(tools.reduce((sum, t) => sum + t.healthScore, 0) / tools.length) 
-        : 100
+      healthyCount: tools.filter((t) => t.healthStatus === 'healthy').length,
+      degradedCount: tools.filter((t) => t.healthStatus === 'degraded').length,
+      warningCount: tools.filter((t) => t.healthStatus === 'warning').length,
+      criticalCount: tools.filter((t) => t.healthStatus === 'critical').length,
+      overallHealth:
+        tools.length > 0
+          ? Math.round(tools.reduce((sum, t) => sum + t.healthScore, 0) / tools.length)
+          : 100,
+      registeredTools: Object.keys(TOOL_GRAPH).length,
+      auditedTools: fromRegistry ? 0 : tools.length - tools.filter((t) => t._fromRegistry).length,
+      dataSource: fromRegistry ? 'registry' : 'audit_log+registry',
     };
 
     res.json({
       period,
       tools,
       summary,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     logger.error('[Braid Metrics] Tools error:', error);
@@ -194,14 +232,14 @@ router.get('/tools', async (req, res) => {
 
 /**
  * GET /api/braid/metrics/timeseries
- * 
+ *
  * Returns time-series data for charting.
- * 
+ *
  * Query params:
  * - granularity: 'minute' | 'hour' | 'day' (default: 'hour')
  * - points: number of data points (default: 24, max: 168)
  * - tenant_id: Optional - filter by specific tenant UUID
- * 
+ *
  * Response:
  * {
  *   granularity: 'hour',
@@ -218,7 +256,9 @@ router.get('/timeseries', async (req, res) => {
     const granularity = req.query.granularity || 'hour';
     const validGranularities = ['minute', 'hour', 'day'];
     if (!validGranularities.includes(granularity)) {
-      return res.status(400).json({ error: `Invalid granularity. Use: ${validGranularities.join(', ')}` });
+      return res
+        .status(400)
+        .json({ error: `Invalid granularity. Use: ${validGranularities.join(', ')}` });
     }
 
     const points = Math.min(parseInt(req.query.points) || 24, 168);
@@ -230,7 +270,7 @@ router.get('/timeseries', async (req, res) => {
       granularity,
       points,
       data,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     logger.error('[Braid Metrics] Timeseries error:', error);
@@ -240,13 +280,13 @@ router.get('/timeseries', async (req, res) => {
 
 /**
  * GET /api/braid/metrics/errors
- * 
+ *
  * Returns error analysis for debugging.
- * 
+ *
  * Query params:
  * - period: '1h' | '24h' | '7d' | '30d' (default: '24h')
  * - tenant_id: Optional - filter by specific tenant UUID
- * 
+ *
  * Response:
  * {
  *   totalErrors: 25,
@@ -271,7 +311,7 @@ router.get('/errors', async (req, res) => {
     res.json({
       period,
       ...analysis,
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     logger.error('[Braid Metrics] Errors analysis error:', error);
@@ -281,10 +321,10 @@ router.get('/errors', async (req, res) => {
 
 /**
  * GET /api/braid/metrics/summary
- * 
+ *
  * Returns a combined summary for dashboard widgets.
  * Includes realtime stats, top tools, and health overview.
- * 
+ *
  * Query params:
  * - tenant_id: Optional - filter by specific tenant UUID
  */
@@ -298,7 +338,7 @@ router.get('/summary', async (req, res) => {
     const [realtime, toolMetricsResult, auditStats] = await Promise.all([
       getRealtimeMetrics(tenantId),
       getToolMetrics(supabase, tenantId, 'day'),
-      getAuditStats(supabase, tenantId, 'day')
+      getAuditStats(supabase, tenantId, 'day'),
     ]);
 
     // Extract tools array from result
@@ -308,30 +348,41 @@ router.get('/summary', async (req, res) => {
     const topTools = toolMetrics
       .sort((a, b) => b.calls - a.calls)
       .slice(0, 5)
-      .map(t => ({ name: t.name, total: t.calls, successRate: t.successRate, health: t.healthScore }));
+      .map((t) => ({
+        name: t.name,
+        total: t.calls,
+        successRate: t.successRate,
+        health: t.healthScore,
+      }));
 
     // Tools needing attention (health < 80)
     const problemTools = toolMetrics
-      .filter(t => t.healthScore < 80)
+      .filter((t) => t.healthScore < 80)
       .sort((a, b) => a.healthScore - b.healthScore)
       .slice(0, 5)
-      .map(t => ({ name: t.name, health: t.healthScore, status: t.healthStatus, successRate: t.successRate }));
+      .map((t) => ({
+        name: t.name,
+        health: t.healthScore,
+        status: t.healthStatus,
+        successRate: t.successRate,
+      }));
 
     // Calculate overall health
-    const overallHealth = toolMetrics.length > 0
-      ? Math.round(toolMetrics.reduce((sum, t) => sum + t.healthScore, 0) / toolMetrics.length)
-      : 100;
+    const overallHealth =
+      toolMetrics.length > 0
+        ? Math.round(toolMetrics.reduce((sum, t) => sum + t.healthScore, 0) / toolMetrics.length)
+        : 100;
 
     // Determine overall status
     let overallStatus = 'healthy';
-    if (problemTools.some(t => t.status === 'critical')) overallStatus = 'critical';
-    else if (problemTools.some(t => t.status === 'warning')) overallStatus = 'warning';
+    if (problemTools.some((t) => t.status === 'critical')) overallStatus = 'critical';
+    else if (problemTools.some((t) => t.status === 'warning')) overallStatus = 'warning';
     else if (problemTools.length > 0) overallStatus = 'degraded';
 
     res.json({
       realtime: {
         lastMinute: realtime.minute,
-        lastHour: realtime.hour
+        lastHour: realtime.hour,
       },
       today: auditStats,
       topTools,
@@ -340,9 +391,9 @@ router.get('/summary', async (req, res) => {
         score: overallHealth,
         status: overallStatus,
         toolCount: toolMetrics.length,
-        healthyCount: toolMetrics.filter(t => t.healthScore >= 80).length
+        healthyCount: toolMetrics.filter((t) => t.healthScore >= 80).length,
       },
-      timestamp: new Date().toISOString()
+      timestamp: new Date().toISOString(),
     });
   } catch (error) {
     logger.error('[Braid Metrics] Summary error:', error);

--- a/backend/routes/braidMetrics.js
+++ b/backend/routes/braidMetrics.js
@@ -29,6 +29,7 @@ import logger from '../lib/logger.js';
 function buildRegistryFallback() {
   return Object.entries(TOOL_GRAPH).map(([name, config]) => ({
     name,
+    category: config.category || 'GENERAL',
     policy: config.category || 'GENERAL',
     calls: 0,
     successRate: 100,

--- a/backend/routes/braidMetrics.js
+++ b/backend/routes/braidMetrics.js
@@ -2,9 +2,18 @@
  * Braid Metrics REST API
  *
  * Dashboard-ready endpoints for tool performance, usage, and health metrics.
- * Combines real-time Redis counters with historical data from braid_audit_log.
+ * Combines real-time Redis counters with historical data from braid_audit_log,
+ * and pre-populates from the static TOOL_GRAPH registry for tools that have
+ * no call history yet (surfaced with healthStatus: 'unused').
  *
- * AUTHENTICATION: Superadmin-only (ADMIN_EMAILS) - monitors ALL tenants
+ * Registry-vs-audit semantics:
+ *   - Tools with real audit data carry a numeric healthScore (0-100) and one
+ *     of: 'healthy' | 'degraded' | 'warning' | 'critical'.
+ *   - Tools present only in TOOL_GRAPH carry healthScore: null and
+ *     healthStatus: 'unused' — excluded from overallHealth averages and from
+ *     problemTools so a fresh deployment does not look degraded.
+ *
+ * AUTHENTICATION: Superadmin-only (ADMIN_EMAILS) - monitors ALL tenants.
  *
  * @module routes/braidMetrics
  */
@@ -26,23 +35,52 @@ import logger from '../lib/logger.js';
  * Build a zero-call registry entry for each tool in TOOL_GRAPH.
  * Used to pre-populate the Tool Health tab before any audit log entries exist.
  */
-function buildRegistryFallback() {
-  return Object.entries(TOOL_GRAPH).map(([name, config]) => ({
+export function buildRegistryFallback(toolGraph = TOOL_GRAPH) {
+  return Object.entries(toolGraph).map(([name, config]) => ({
     name,
     category: config.category || 'GENERAL',
-    policy: config.category || 'GENERAL',
+    // policy is the tool's declared policy (read/write/side-effect class),
+    // NOT its category. Leave null when the registry does not carry one —
+    // the UI treats missing policy as "unspecified".
+    policy: config.policy || null,
     calls: 0,
-    successRate: 100,
-    errorRate: 0,
-    cacheHitRate: 0,
-    avgLatencyMs: 0,
-    p95LatencyMs: 0,
+    successRate: null, // null = no samples; distinct from 100% success with 0 calls
+    errorRate: null,
+    cacheHitRate: null,
+    avgLatencyMs: null,
+    p95LatencyMs: null,
     errorTypes: {},
     lastUsed: null,
-    healthScore: 100,
-    healthStatus: 'healthy',
+    healthScore: null, // null signals "unknown / never called"
+    healthStatus: 'unused',
     _fromRegistry: true, // flag: no real data yet
   }));
+}
+
+/**
+ * Merge audited tools with TOOL_GRAPH registry fallback and return source metadata.
+ *
+ * @param {Array} auditedTools
+ * @param {Object} toolGraph
+ * @returns {{tools:Array, fromRegistry:boolean, auditedTools:number}}
+ */
+export function mergeRegistryToolMetrics(auditedTools = [], toolGraph = TOOL_GRAPH) {
+  const fromRegistry = auditedTools.length === 0;
+  if (fromRegistry) {
+    return {
+      tools: buildRegistryFallback(toolGraph),
+      fromRegistry: true,
+      auditedTools: 0,
+    };
+  }
+
+  const auditedNames = new Set(auditedTools.map((t) => t.name));
+  const missingTools = buildRegistryFallback(toolGraph).filter((t) => !auditedNames.has(t.name));
+  return {
+    tools: [...auditedTools, ...missingTools],
+    fromRegistry: false,
+    auditedTools: auditedTools.length,
+  };
 }
 
 const router = express.Router();
@@ -189,33 +227,27 @@ router.get('/tools', async (req, res) => {
     }
 
     // Extract tools array from result
-    let tools = result.tools || [];
+    const merged = mergeRegistryToolMetrics(result.tools || []);
+    const tools = merged.tools;
+    const fromRegistry = merged.fromRegistry;
 
-    // When the audit log is empty (no Braid tool calls yet), fall back to the static
-    // TOOL_GRAPH registry so the Tool Health tab always shows the full tool inventory.
-    const fromRegistry = tools.length === 0;
-    if (fromRegistry) {
-      tools = buildRegistryFallback();
-    } else {
-      // Merge registry tools that have no audit log entries yet (show them as 0-call healthy)
-      const auditedNames = new Set(tools.map((t) => t.name));
-      const missingTools = buildRegistryFallback().filter((t) => !auditedNames.has(t.name));
-      tools = [...tools, ...missingTools];
-    }
-
-    // Generate summary
+    // Generate summary — `unused` tools (registry-only, never called) are
+    // excluded from the overallHealth average so a fresh deployment does not
+    // skew the dashboard toward a neutral score.
+    const scored = tools.filter((t) => typeof t.healthScore === 'number');
     const summary = {
       totalTools: tools.length,
       healthyCount: tools.filter((t) => t.healthStatus === 'healthy').length,
       degradedCount: tools.filter((t) => t.healthStatus === 'degraded').length,
       warningCount: tools.filter((t) => t.healthStatus === 'warning').length,
       criticalCount: tools.filter((t) => t.healthStatus === 'critical').length,
+      unusedCount: tools.filter((t) => t.healthStatus === 'unused').length,
       overallHealth:
-        tools.length > 0
-          ? Math.round(tools.reduce((sum, t) => sum + t.healthScore, 0) / tools.length)
-          : 100,
+        scored.length > 0
+          ? Math.round(scored.reduce((sum, t) => sum + t.healthScore, 0) / scored.length)
+          : null,
       registeredTools: Object.keys(TOOL_GRAPH).length,
-      auditedTools: fromRegistry ? 0 : tools.length - tools.filter((t) => t._fromRegistry).length,
+      auditedTools: merged.auditedTools,
       dataSource: fromRegistry ? 'registry' : 'audit_log+registry',
     };
 
@@ -356,9 +388,9 @@ router.get('/summary', async (req, res) => {
         health: t.healthScore,
       }));
 
-    // Tools needing attention (health < 80)
+    // Tools needing attention (health < 80) — ignore null (never-called) tools
     const problemTools = toolMetrics
-      .filter((t) => t.healthScore < 80)
+      .filter((t) => typeof t.healthScore === 'number' && t.healthScore < 80)
       .sort((a, b) => a.healthScore - b.healthScore)
       .slice(0, 5)
       .map((t) => ({
@@ -368,11 +400,13 @@ router.get('/summary', async (req, res) => {
         successRate: t.successRate,
       }));
 
-    // Calculate overall health
+    // Calculate overall health — only count tools that have a numeric score
+    // (exclude registry-only "unused" rows with null healthScore).
+    const scoredTools = toolMetrics.filter((t) => typeof t.healthScore === 'number');
     const overallHealth =
-      toolMetrics.length > 0
-        ? Math.round(toolMetrics.reduce((sum, t) => sum + t.healthScore, 0) / toolMetrics.length)
-        : 100;
+      scoredTools.length > 0
+        ? Math.round(scoredTools.reduce((sum, t) => sum + t.healthScore, 0) / scoredTools.length)
+        : null;
 
     // Determine overall status
     let overallStatus = 'healthy';
@@ -392,7 +426,9 @@ router.get('/summary', async (req, res) => {
         score: overallHealth,
         status: overallStatus,
         toolCount: toolMetrics.length,
-        healthyCount: toolMetrics.filter((t) => t.healthScore >= 80).length,
+        scoredCount: scoredTools.length,
+        healthyCount: scoredTools.filter((t) => t.healthScore >= 80).length,
+        unusedCount: toolMetrics.filter((t) => t.healthStatus === 'unused').length,
       },
       timestamp: new Date().toISOString(),
     });

--- a/src/components/settings/BraidSDKMonitor.jsx
+++ b/src/components/settings/BraidSDKMonitor.jsx
@@ -466,7 +466,10 @@ export default function BraidSDKMonitor() {
                       </div>
                     </div>
                     <div className="text-xs text-muted-foreground text-center pt-2">
-                      {tm.summary.totalTools} tools monitored
+                      {tm.summary.totalTools} tools registered
+                      {tm.summary.auditedTools > 0 && (
+                        <span className="ml-1">· {tm.summary.auditedTools} with call data</span>
+                      )}
                     </div>
                   </>
                 )}
@@ -507,6 +510,18 @@ export default function BraidSDKMonitor() {
                 {(!tm?.tools || tm.tools.length === 0) && (
                   <div className="text-center py-8 text-muted-foreground">
                     No tool data available yet. Start using AI tools to see metrics.
+                  </div>
+                )}
+                {tm?.summary?.dataSource === 'registry' && tm.tools?.length > 0 && (
+                  <div className="mt-3 px-4 py-2 bg-blue-950/30 border border-blue-800/40 rounded text-xs text-blue-400">
+                    Showing {tm.tools.length} registered tools — no calls logged yet. Metrics will
+                    appear after first Braid tool use.
+                  </div>
+                )}
+                {tm?.summary?.dataSource?.startsWith('audit') && (
+                  <div className="mt-3 px-4 py-2 bg-muted/20 rounded text-xs text-muted-foreground">
+                    {tm.summary.auditedTools} tools with call history ·{' '}
+                    {tm.summary.registeredTools - tm.summary.auditedTools} awaiting first call
                   </div>
                 )}
               </div>

--- a/src/components/settings/LLMActivityMonitor.jsx
+++ b/src/components/settings/LLMActivityMonitor.jsx
@@ -524,7 +524,7 @@ export default function LLMActivityMonitor() {
                       </td>
                       <td className="px-3 py-2 text-right">
                         <span
-                          className={`font-mono text-xs ${entry.durationMs > 3000 ? 'text-yellow-500' : entry.durationMs > 5000 ? 'text-red-500' : ''}`}
+                          className={`font-mono text-xs ${entry.durationMs > 5000 ? 'text-red-500' : entry.durationMs > 3000 ? 'text-yellow-500' : ''}`}
                         >
                           {formatDuration(entry.durationMs)}
                         </span>

--- a/src/components/settings/LLMActivityMonitor.jsx
+++ b/src/components/settings/LLMActivityMonitor.jsx
@@ -1,20 +1,26 @@
 /**
  * LLM Activity Monitor
- * 
+ *
  * Real-time view of all LLM calls showing:
  * - Tenant ID, Capability, Provider, Model, Node ID
  * - Status, Duration, Token Usage
  * - Auto-refresh with polling
  */
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
-import { Label } from "@/components/ui/label";
-import { BACKEND_URL } from "@/api/entities";
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { BACKEND_URL } from '@/api/entities';
 import {
   RefreshCw,
   Trash2,
@@ -23,20 +29,20 @@ import {
   AlertCircle,
   CheckCircle,
   ArrowRightLeft,
-} from "lucide-react";
+} from 'lucide-react';
 
 const PROVIDER_COLORS = {
-  openai: "bg-green-600",
-  anthropic: "bg-orange-600",
-  groq: "bg-purple-600",
-  local: "bg-blue-600",
-  unknown: "bg-gray-600",
+  openai: 'bg-green-600',
+  anthropic: 'bg-orange-600',
+  groq: 'bg-purple-600',
+  local: 'bg-blue-600',
+  unknown: 'bg-gray-600',
 };
 
 const STATUS_COLORS = {
-  success: "bg-green-600",
-  error: "bg-red-600",
-  failover: "bg-yellow-600",
+  success: 'bg-green-600',
+  error: 'bg-red-600',
+  failover: 'bg-yellow-600',
 };
 
 const STATUS_ICONS = {
@@ -46,33 +52,36 @@ const STATUS_ICONS = {
 };
 
 function formatDuration(ms) {
-  if (!ms) return "-";
+  if (!ms) return '-';
   if (ms < 1000) return `${ms}ms`;
   return `${(ms / 1000).toFixed(2)}s`;
 }
 
 function formatTimestamp(iso) {
-  if (!iso) return "-";
+  if (!iso) return '-';
   const d = new Date(iso);
   const today = new Date();
   const isToday = d.toDateString() === today.toDateString();
-  
+
   // Show date if not today, otherwise just time
   if (isToday) {
-    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
   }
-  return d.toLocaleDateString([], { month: "short", day: "numeric" }) + " " + 
-    d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return (
+    d.toLocaleDateString([], { month: 'short', day: 'numeric' }) +
+    ' ' +
+    d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  );
 }
 
 function formatTokens(usage) {
-  if (!usage) return "-";
+  if (!usage) return '-';
   const { prompt_tokens, completion_tokens, total_tokens } = usage;
   if (total_tokens) return `${total_tokens} tokens`;
   if (prompt_tokens || completion_tokens) {
     return `${prompt_tokens || 0}/${completion_tokens || 0}`;
   }
-  return "-";
+  return '-';
 }
 
 export default function LLMActivityMonitor() {
@@ -82,67 +91,72 @@ export default function LLMActivityMonitor() {
   const [autoRefresh, setAutoRefresh] = useState(true);
   const [refreshInterval, _setRefreshInterval] = useState(3000);
   const [filters, setFilters] = useState({
-    provider: "",
-    capability: "",
-    status: "",
+    provider: '',
+    capability: '',
+    status: '',
   });
   const [showFilters, setShowFilters] = useState(false);
   const lastTimestamp = useRef(null);
 
-  const fetchActivity = useCallback(async (incremental = false) => {
-    try {
-      const params = new URLSearchParams();
-      params.set("limit", "100");
-      
-      if (filters.provider) params.set("provider", filters.provider);
-      if (filters.capability) params.set("capability", filters.capability);
-      if (filters.status) params.set("status", filters.status);
-      
-      // Incremental fetch: only get entries since last fetch
-      if (incremental && lastTimestamp.current) {
-        params.set("since", lastTimestamp.current);
+  const fetchActivity = useCallback(
+    async (incremental = false) => {
+      try {
+        const params = new URLSearchParams();
+        params.set('limit', '100');
+
+        if (filters.provider) params.set('provider', filters.provider);
+        if (filters.capability) params.set('capability', filters.capability);
+        if (filters.status) params.set('status', filters.status);
+
+        // Incremental fetch: only get entries since last fetch
+        if (incremental && lastTimestamp.current) {
+          params.set('since', lastTimestamp.current);
+        }
+
+        const response = await fetch(`${BACKEND_URL}/api/system/llm-activity?${params}`);
+        if (!response.ok) throw new Error('Failed to fetch LLM activity');
+
+        const data = await response.json();
+        const newEntries = data.data || [];
+
+        if (incremental && newEntries.length > 0) {
+          // Merge new entries at the top
+          setEntries((prev) => {
+            const combined = [...newEntries, ...prev];
+            // Dedupe by id and limit to 200 entries
+            const seen = new Set();
+            return combined
+              .filter((e) => {
+                if (seen.has(e.id)) return false;
+                seen.add(e.id);
+                return true;
+              })
+              .slice(0, 200);
+          });
+        } else if (!incremental) {
+          setEntries(newEntries);
+        }
+
+        // Update last timestamp for incremental fetches
+        if (newEntries.length > 0) {
+          lastTimestamp.current = newEntries[0].timestamp;
+        }
+      } catch (err) {
+        console.error('[LLMActivityMonitor] Fetch error:', err);
       }
-      
-      const response = await fetch(`${BACKEND_URL}/api/system/llm-activity?${params}`);
-      if (!response.ok) throw new Error("Failed to fetch LLM activity");
-      
-      const data = await response.json();
-      const newEntries = data.data || [];
-      
-      if (incremental && newEntries.length > 0) {
-        // Merge new entries at the top
-        setEntries((prev) => {
-          const combined = [...newEntries, ...prev];
-          // Dedupe by id and limit to 200 entries
-          const seen = new Set();
-          return combined.filter((e) => {
-            if (seen.has(e.id)) return false;
-            seen.add(e.id);
-            return true;
-          }).slice(0, 200);
-        });
-      } else if (!incremental) {
-        setEntries(newEntries);
-      }
-      
-      // Update last timestamp for incremental fetches
-      if (newEntries.length > 0) {
-        lastTimestamp.current = newEntries[0].timestamp;
-      }
-    } catch (err) {
-      console.error("[LLMActivityMonitor] Fetch error:", err);
-    }
-  }, [filters]);
+    },
+    [filters],
+  );
 
   const fetchStats = useCallback(async () => {
     try {
       const response = await fetch(`${BACKEND_URL}/api/system/llm-activity/stats`);
-      if (!response.ok) throw new Error("Failed to fetch LLM stats");
-      
+      if (!response.ok) throw new Error('Failed to fetch LLM stats');
+
       const data = await response.json();
       setStats(data.data || null);
     } catch (err) {
-      console.error("[LLMActivityMonitor] Stats error:", err);
+      console.error('[LLMActivityMonitor] Stats error:', err);
     }
   }, []);
 
@@ -150,15 +164,15 @@ export default function LLMActivityMonitor() {
     try {
       setLoading(true);
       const response = await fetch(`${BACKEND_URL}/api/system/llm-activity`, {
-        method: "DELETE",
+        method: 'DELETE',
       });
-      if (!response.ok) throw new Error("Failed to clear logs");
-      
+      if (!response.ok) throw new Error('Failed to clear logs');
+
       setEntries([]);
       lastTimestamp.current = null;
       await fetchStats();
     } catch (err) {
-      console.error("[LLMActivityMonitor] Clear error:", err);
+      console.error('[LLMActivityMonitor] Clear error:', err);
     } finally {
       setLoading(false);
     }
@@ -179,12 +193,12 @@ export default function LLMActivityMonitor() {
   // Auto-refresh polling
   useEffect(() => {
     if (!autoRefresh) return;
-    
+
     const interval = setInterval(() => {
       fetchActivity(true);
       fetchStats();
     }, refreshInterval);
-    
+
     return () => clearInterval(interval);
   }, [autoRefresh, refreshInterval, fetchActivity, fetchStats]);
 
@@ -219,25 +233,53 @@ export default function LLMActivityMonitor() {
           </Card>
           <Card className="bg-card/50">
             <CardContent className="p-3">
-              <div className="text-xs text-muted-foreground">By Provider</div>
+              <div className="text-xs text-muted-foreground flex items-center gap-1">
+                By Provider
+                {stats.windowLabel === 'buffer' && (
+                  <span className="text-[10px] text-muted-foreground/60">(buffer)</span>
+                )}
+              </div>
               <div className="flex flex-wrap gap-1 mt-1">
-                {Object.entries(stats.byProvider || {}).map(([p, count]) => (
-                  <Badge key={p} variant="outline" className="text-xs">
-                    {p}: {count}
-                  </Badge>
-                ))}
+                {Object.entries(stats.allTime?.byProvider || stats.byProvider || {}).map(
+                  ([p, count]) => (
+                    <Badge
+                      key={p}
+                      variant="outline"
+                      className={`text-xs ${PROVIDER_COLORS[p] ? 'border-current' : ''}`}
+                    >
+                      {p}: {count}
+                    </Badge>
+                  ),
+                )}
+                {Object.keys(stats.allTime?.byProvider || stats.byProvider || {}).length === 0 && (
+                  <span className="text-xs text-muted-foreground/60">No data</span>
+                )}
               </div>
             </CardContent>
           </Card>
           <Card className="bg-card/50">
             <CardContent className="p-3">
-              <div className="text-xs text-muted-foreground">By Status</div>
+              <div className="text-xs text-muted-foreground flex items-center gap-1">
+                By Status
+                {stats.windowLabel === 'buffer' && (
+                  <span className="text-[10px] text-muted-foreground/60">(buffer)</span>
+                )}
+              </div>
               <div className="flex flex-wrap gap-1 mt-1">
-                {Object.entries(stats.byStatus || {}).map(([s, count]) => (
-                  <Badge key={s} variant="outline" className={`text-xs ${s === "error" ? "border-red-500" : s === "failover" ? "border-yellow-500" : ""}`}>
-                    {s}: {count}
-                  </Badge>
-                ))}
+                {Object.entries(stats.allTime?.byStatus || stats.byStatus || {}).map(
+                  ([s, count]) => (
+                    <Badge
+                      key={s}
+                      variant="outline"
+                      className={`text-xs ${s === 'error' ? 'border-red-500 text-red-400' : s === 'failover' ? 'border-yellow-500 text-yellow-400' : 'border-green-600 text-green-400'}`}
+                    >
+                      {s}: {count}
+                    </Badge>
+                  ),
+                )}
+                {Object.keys(stats.allTime?.byStatus || stats.byStatus || {}).length === 0 && (
+                  <span className="text-xs text-muted-foreground/60">No data</span>
+                )}
               </div>
             </CardContent>
           </Card>
@@ -248,7 +290,8 @@ export default function LLMActivityMonitor() {
                 {stats.tokenUsage?.last5Minutes?.totalTokens?.toLocaleString() || 0}
               </div>
               <div className="text-xs text-muted-foreground mt-1">
-                {stats.tokenUsage?.last5Minutes?.promptTokens?.toLocaleString() || 0} in / {stats.tokenUsage?.last5Minutes?.completionTokens?.toLocaleString() || 0} out
+                {stats.tokenUsage?.last5Minutes?.promptTokens?.toLocaleString() || 0} in /{' '}
+                {stats.tokenUsage?.last5Minutes?.completionTokens?.toLocaleString() || 0} out
               </div>
             </CardContent>
           </Card>
@@ -257,6 +300,18 @@ export default function LLMActivityMonitor() {
               <div className="text-xs text-muted-foreground">Tokens (buffer)</div>
               <div className="text-xl font-bold">
                 {stats.tokenUsage?.allTime?.totalTokens?.toLocaleString() || 0}
+              </div>
+              <div className="text-xs text-muted-foreground mt-1">
+                {stats.tokenUsage?.allTime?.promptTokens?.toLocaleString() || 0} in /{' '}
+                {stats.tokenUsage?.allTime?.completionTokens?.toLocaleString() || 0} out
+              </div>
+            </CardContent>
+          </Card>
+          <Card className="bg-card/50">
+            <CardContent className="p-3">
+              <div className="text-xs text-muted-foreground">Est. Cost (buffer)</div>
+              <div className="text-xl font-bold text-yellow-500">
+                ${stats.tokenUsage?.allTime?.estimatedCostUSD?.toFixed(4) || '0.0000'}
               </div>
               <div className="text-xs text-muted-foreground mt-1">
                 {stats.tokenUsage?.allTime?.entriesInBuffer || 0} entries
@@ -269,41 +324,33 @@ export default function LLMActivityMonitor() {
       {/* Controls */}
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-2">
-          <Switch
-            id="auto-refresh"
-            checked={autoRefresh}
-            onCheckedChange={setAutoRefresh}
-          />
+          <Switch id="auto-refresh" checked={autoRefresh} onCheckedChange={setAutoRefresh} />
           <Label htmlFor="auto-refresh" className="text-sm">
             Auto-refresh
           </Label>
           {autoRefresh && (
-            <span className="text-xs text-muted-foreground">
-              ({refreshInterval / 1000}s)
-            </span>
+            <span className="text-xs text-muted-foreground">({refreshInterval / 1000}s)</span>
           )}
         </div>
-        
+
         <Button variant="outline" size="sm" onClick={refresh} disabled={loading}>
-          <RefreshCw className={`w-4 h-4 mr-1 ${loading ? "animate-spin" : ""}`} />
+          <RefreshCw className={`w-4 h-4 mr-1 ${loading ? 'animate-spin' : ''}`} />
           Refresh
         </Button>
-        
+
         <Button variant="outline" size="sm" onClick={() => setShowFilters(!showFilters)}>
           <Filter className="w-4 h-4 mr-1" />
           Filters
         </Button>
-        
+
         <Button variant="outline" size="sm" onClick={clearLogs} disabled={loading}>
           <Trash2 className="w-4 h-4 mr-1" />
           Clear Logs
         </Button>
-        
+
         <div className="flex-1" />
-        
-        <div className="text-sm text-muted-foreground">
-          {entries.length} entries
-        </div>
+
+        <div className="text-sm text-muted-foreground">{entries.length} entries</div>
       </div>
 
       {/* Filters */}
@@ -313,7 +360,7 @@ export default function LLMActivityMonitor() {
             <Label className="text-xs">Provider:</Label>
             <Select
               value={filters.provider}
-              onValueChange={(v) => setFilters((f) => ({ ...f, provider: v === "all" ? "" : v }))}
+              onValueChange={(v) => setFilters((f) => ({ ...f, provider: v === 'all' ? '' : v }))}
             >
               <SelectTrigger className="w-32 h-8">
                 <SelectValue placeholder="All" />
@@ -327,12 +374,12 @@ export default function LLMActivityMonitor() {
               </SelectContent>
             </Select>
           </div>
-          
+
           <div className="flex items-center gap-2">
             <Label className="text-xs">Capability:</Label>
             <Select
               value={filters.capability}
-              onValueChange={(v) => setFilters((f) => ({ ...f, capability: v === "all" ? "" : v }))}
+              onValueChange={(v) => setFilters((f) => ({ ...f, capability: v === 'all' ? '' : v }))}
             >
               <SelectTrigger className="w-36 h-8">
                 <SelectValue placeholder="All" />
@@ -347,12 +394,12 @@ export default function LLMActivityMonitor() {
               </SelectContent>
             </Select>
           </div>
-          
+
           <div className="flex items-center gap-2">
             <Label className="text-xs">Status:</Label>
             <Select
               value={filters.status}
-              onValueChange={(v) => setFilters((f) => ({ ...f, status: v === "all" ? "" : v }))}
+              onValueChange={(v) => setFilters((f) => ({ ...f, status: v === 'all' ? '' : v }))}
             >
               <SelectTrigger className="w-28 h-8">
                 <SelectValue placeholder="All" />
@@ -365,12 +412,12 @@ export default function LLMActivityMonitor() {
               </SelectContent>
             </Select>
           </div>
-          
+
           <Button
             variant="ghost"
             size="sm"
             onClick={() => {
-              setFilters({ provider: "", capability: "", status: "" });
+              setFilters({ provider: '', capability: '', status: '' });
               refresh();
             }}
           >
@@ -404,7 +451,9 @@ export default function LLMActivityMonitor() {
                   <td colSpan={11} className="px-3 py-8 text-center text-muted-foreground">
                     <Activity className="w-8 h-8 mx-auto mb-2 opacity-50" />
                     <div>No LLM activity recorded yet.</div>
-                    <div className="text-xs mt-1">Activity will appear here as AI features are used.</div>
+                    <div className="text-xs mt-1">
+                      Activity will appear here as AI features are used.
+                    </div>
                   </td>
                 </tr>
               ) : (
@@ -418,13 +467,17 @@ export default function LLMActivityMonitor() {
                         </span>
                       </td>
                       <td className="px-3 py-2">
-                        <Badge className={`${STATUS_COLORS[entry.status] || "bg-gray-600"} text-white text-xs`}>
+                        <Badge
+                          className={`${STATUS_COLORS[entry.status] || 'bg-gray-600'} text-white text-xs`}
+                        >
                           <StatusIcon className="w-3 h-3 mr-1" />
                           {entry.status}
                         </Badge>
                       </td>
                       <td className="px-3 py-2">
-                        <Badge className={`${PROVIDER_COLORS[entry.provider] || PROVIDER_COLORS.unknown} text-white text-xs`}>
+                        <Badge
+                          className={`${PROVIDER_COLORS[entry.provider] || PROVIDER_COLORS.unknown} text-white text-xs`}
+                        >
                           {entry.provider}
                         </Badge>
                       </td>
@@ -436,7 +489,10 @@ export default function LLMActivityMonitor() {
                       </td>
                       <td className="px-3 py-2">
                         {entry.intent ? (
-                          <Badge variant="outline" className="text-xs font-mono bg-blue-950/30 border-blue-600/50">
+                          <Badge
+                            variant="outline"
+                            className="text-xs font-mono bg-blue-950/30 border-blue-600/50"
+                          >
                             {entry.intent}
                           </Badge>
                         ) : (
@@ -458,16 +514,18 @@ export default function LLMActivityMonitor() {
                       </td>
                       <td className="px-3 py-2">
                         <span className="font-mono text-xs text-muted-foreground">
-                          {entry.nodeId || "-"}
+                          {entry.nodeId || '-'}
                         </span>
                       </td>
                       <td className="px-3 py-2">
                         <span className="font-mono text-xs text-muted-foreground">
-                          {entry.tenantId?.slice(0, 8) || "-"}...
+                          {entry.tenantId?.slice(0, 8) || '-'}...
                         </span>
                       </td>
                       <td className="px-3 py-2 text-right">
-                        <span className={`font-mono text-xs ${entry.durationMs > 3000 ? "text-yellow-500" : entry.durationMs > 5000 ? "text-red-500" : ""}`}>
+                        <span
+                          className={`font-mono text-xs ${entry.durationMs > 3000 ? 'text-yellow-500' : entry.durationMs > 5000 ? 'text-red-500' : ''}`}
+                        >
                           {formatDuration(entry.durationMs)}
                         </span>
                       </td>
@@ -484,9 +542,9 @@ export default function LLMActivityMonitor() {
           </table>
         </div>
       </div>
-      
+
       {/* Error Details (if any errors visible) */}
-      {entries.some((e) => e.status === "error" && e.error) && (
+      {entries.some((e) => e.status === 'error' && e.error) && (
         <Card className="border-red-500/50">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm flex items-center gap-2">
@@ -496,10 +554,13 @@ export default function LLMActivityMonitor() {
           </CardHeader>
           <CardContent className="space-y-2">
             {entries
-              .filter((e) => e.status === "error" && e.error)
+              .filter((e) => e.status === 'error' && e.error)
               .slice(0, 5)
               .map((e) => (
-                <div key={e.id} className="text-xs p-2 bg-red-950/30 rounded border border-red-900/50">
+                <div
+                  key={e.id}
+                  className="text-xs p-2 bg-red-950/30 rounded border border-red-900/50"
+                >
                   <div className="font-mono text-muted-foreground mb-1">
                     {formatTimestamp(e.timestamp)} | {e.provider}:{e.model} | {e.nodeId}
                   </div>


### PR DESCRIPTION
## Summary

- **LLM Monitor By Provider/By Status empty** — fixed: stats now use full buffer instead of 5-min window only
- **Avg Duration showing '-'** — same fix, falls back to buffer durations
- **AI Tools Monitor 0 tools monitored** — fixed: pre-populates from TOOL_GRAPH registry (42 tools) when audit log is empty
- **Est. Cost card** — new: estimatedCostUSD computed from per-provider token rates
- **DB persistence (migration 151)** — llm_activity_logs table, 90-day retention, fire-and-forget insert so restarts don't wipe history

## Test plan
- [ ] LLM Monitor By Provider/By Status cards show data after 5+ min idle
- [ ] AI Tools Monitor Tool Health shows 42 tools with registry banner on fresh instance
- [ ] Est. Cost increments after each LLM call
- [ ] Run migration 151 — verify llm_activity_logs rows persist across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)