### PR TITLE
 feat: Zapier-style field mapping for workflow nodes

### DIFF
--- a/backend/__tests__/routes/workflows.resolveMapping.test.js
+++ b/backend/__tests__/routes/workflows.resolveMapping.test.js
@@ -1,0 +1,285 @@
+/**
+ * workflows.resolveMapping.test.js
+ *
+ * Unit tests for the resolveMapping helper and the create_activity
+ * field_mappings execution logic inside the workflow executor.
+ *
+ * These tests extract and exercise the pure logic without a DB or HTTP layer.
+ *
+ * Run:
+ *   docker compose exec backend node --test \
+ *     backend/__tests__/routes/workflows.resolveMapping.test.js
+ *
+ * Coverage:
+ *  resolveMapping — new unified shape  { target_field, source_value }
+ *  resolveMapping — legacy lead shape  { lead_field, webhook_field }
+ *  resolveMapping — legacy contact shape { contact_field, webhook_field }
+ *  resolveMapping — dotted source_value resolves via context.variables
+ *  resolveMapping — returns null for unrecognised / empty mapping
+ *  resolveMapping — unresolved template is returned as-is (not stripped)
+ *  create_activity field resolution — subject, body, status, due_date, assigned_to
+ *  create_activity association — auto-detect from context
+ *  create_activity association — explicit entity override
+ *  create_activity association — field_mappings override related_to / related_id
+ *  backward compat — legacy cfg.title / cfg.details still work when no field_mappings
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ─── Inline the logic under test ────────────────────────────────────────────
+// We inline rather than import from workflows.js because the file is an
+// Express route factory (requires pgPool, Redis, etc.) and we want pure unit
+// tests with no side-effects.
+
+function buildExecutor(payload = {}, variables = {}) {
+  const context = { payload, variables };
+
+  function replaceVariables(template) {
+    if (typeof template !== 'string') return template;
+    return template.replace(/\{\{([^}]+)\}\}/g, (match, variable) => {
+      const trimmed = String(variable).trim();
+      if (context.payload && context.payload[trimmed] !== undefined)
+        return context.payload[trimmed];
+      const parts = trimmed.split('.');
+      if (parts.length > 1) {
+        let value = context.variables[parts[0]];
+        for (let i = 1; i < parts.length; i++) {
+          if (value && value[parts[i]] !== undefined) value = value[parts[i]];
+          else { value = undefined; break; }
+        }
+        if (value !== undefined) return value;
+      } else if (context.variables && context.variables[trimmed] !== undefined) {
+        return context.variables[trimmed];
+      }
+      return match;
+    });
+  }
+
+  function resolveMapping(m) {
+    if (m.target_field) {
+      const targetField = m.target_field;
+      const raw = m.source_value || '';
+      const template = raw.startsWith('{{') ? raw : raw ? `{{${raw}}}` : '';
+      const resolved = template ? replaceVariables(template) : '';
+      return { targetField, resolved };
+    }
+    if (m.lead_field && m.webhook_field) {
+      const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+      return { targetField: m.lead_field, resolved };
+    }
+    if (m.contact_field && m.webhook_field) {
+      const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+      return { targetField: m.contact_field, resolved };
+    }
+    return null;
+  }
+
+  /**
+   * Mirrors the create_activity field resolution logic from the executor.
+   * Returns the resolved fields object (does NOT hit DB).
+   */
+  function resolveActivityFields(cfg) {
+    const fieldMappings = cfg.field_mappings || [];
+    const resolvedFields = {};
+    for (const m of fieldMappings) {
+      const rm = resolveMapping(m);
+      if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+        resolvedFields[rm.targetField] = rm.resolved;
+      }
+    }
+    const subject = resolvedFields.subject || replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
+    const body = resolvedFields.body || replaceVariables(cfg.details || cfg.description || '');
+    const status = resolvedFields.status || 'scheduled';
+    const due_date = resolvedFields.due_date || null;
+    const assigned_to = resolvedFields.assigned_to || null;
+
+    const lead = context.variables.found_lead;
+    const contact = context.variables.found_contact;
+    const account = context.variables.found_account;
+    const opportunity = context.variables.found_opportunity;
+
+    const associate = cfg.associate || 'auto';
+    let related_to = null;
+    let related_id = null;
+    if (associate === 'auto') {
+      related_to = lead ? 'lead' : contact ? 'contact' : account ? 'account' : opportunity ? 'opportunity' : null;
+      related_id = lead ? lead.id : contact ? contact.id : account ? account.id : opportunity ? opportunity.id : null;
+    } else {
+      const entityMap = { lead, contact, account, opportunity };
+      const entity = entityMap[associate];
+      if (entity) { related_to = associate; related_id = entity.id; }
+    }
+    if (resolvedFields.related_to) related_to = resolvedFields.related_to;
+    if (resolvedFields.related_id) related_id = resolvedFields.related_id;
+
+    return { subject, body, status, due_date, assigned_to, related_to, related_id };
+  }
+
+  return { resolveMapping, resolveActivityFields };
+}
+
+// ─── resolveMapping tests ───────────────────────────────────────────────────
+
+describe('resolveMapping', () => {
+  it('new shape: resolves source_value token from payload', () => {
+    const { resolveMapping } = buildExecutor({ email: 'jane@example.com' });
+    const result = resolveMapping({ target_field: 'email', source_type: 'token', source_value: 'email' });
+    assert.deepEqual(result, { targetField: 'email', resolved: 'jane@example.com' });
+  });
+
+  it('new shape: resolves dotted source_value from context.variables', () => {
+    const { resolveMapping } = buildExecutor({}, { found_lead: { email: 'lead@example.com' } });
+    const result = resolveMapping({ target_field: 'email', source_type: 'token', source_value: 'found_lead.email' });
+    assert.deepEqual(result, { targetField: 'email', resolved: 'lead@example.com' });
+  });
+
+  it('new shape: source_value already wrapped in {{ }} is resolved correctly', () => {
+    const { resolveMapping } = buildExecutor({ company: 'Acme' });
+    const result = resolveMapping({ target_field: 'company', source_value: '{{company}}' });
+    assert.deepEqual(result, { targetField: 'company', resolved: 'Acme' });
+  });
+
+  it('new shape: unresolved token is returned as template string (not empty)', () => {
+    const { resolveMapping } = buildExecutor({});
+    const result = resolveMapping({ target_field: 'email', source_value: 'missing_field' });
+    // replaceVariables returns the original {{missing_field}} when not found
+    assert.equal(result.targetField, 'email');
+    assert.equal(result.resolved, '{{missing_field}}');
+  });
+
+  it('new shape: empty source_value returns empty resolved string', () => {
+    const { resolveMapping } = buildExecutor({ email: 'x@y.com' });
+    const result = resolveMapping({ target_field: 'email', source_value: '' });
+    assert.deepEqual(result, { targetField: 'email', resolved: '' });
+  });
+
+  it('legacy lead shape: resolves via lead_field + webhook_field', () => {
+    const { resolveMapping } = buildExecutor({ first_name: 'Jane' });
+    const result = resolveMapping({ lead_field: 'first_name', webhook_field: 'first_name' });
+    assert.deepEqual(result, { targetField: 'first_name', resolved: 'Jane' });
+  });
+
+  it('legacy contact shape: resolves via contact_field + webhook_field', () => {
+    const { resolveMapping } = buildExecutor({ phone: '555-1234' });
+    const result = resolveMapping({ contact_field: 'phone', webhook_field: 'phone' });
+    assert.deepEqual(result, { targetField: 'phone', resolved: '555-1234' });
+  });
+
+  it('returns null for empty object', () => {
+    const { resolveMapping } = buildExecutor();
+    assert.equal(resolveMapping({}), null);
+  });
+
+  it('returns null for mapping with only source_value and no target_field', () => {
+    const { resolveMapping } = buildExecutor({ email: 'x@y.com' });
+    assert.equal(resolveMapping({ source_value: 'email' }), null);
+  });
+});
+
+// ─── create_activity field resolution ──────────────────────────────────────
+
+describe('create_activity field resolution', () => {
+  it('resolves subject and body from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ subject_val: 'Follow up', body_val: 'Hello' });
+    const result = resolveActivityFields({
+      type: 'task',
+      field_mappings: [
+        { target_field: 'subject', source_value: 'subject_val' },
+        { target_field: 'body', source_value: 'body_val' },
+      ],
+    });
+    assert.equal(result.subject, 'Follow up');
+    assert.equal(result.body, 'Hello');
+  });
+
+  it('resolves status from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ s: 'completed' });
+    const result = resolveActivityFields({
+      field_mappings: [{ target_field: 'status', source_value: 's' }],
+    });
+    assert.equal(result.status, 'completed');
+  });
+
+  it('resolves due_date and assigned_to from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ d: '2026-06-01', u: 'user-uuid-123' });
+    const result = resolveActivityFields({
+      field_mappings: [
+        { target_field: 'due_date', source_value: 'd' },
+        { target_field: 'assigned_to', source_value: 'u' },
+      ],
+    });
+    assert.equal(result.due_date, '2026-06-01');
+    assert.equal(result.assigned_to, 'user-uuid-123');
+  });
+
+  it('falls back to legacy cfg.title and cfg.details when no field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ title: 'Legacy title', details: 'Legacy body' });
+    assert.equal(result.subject, 'Legacy title');
+    assert.equal(result.body, 'Legacy body');
+  });
+
+  it('falls back to default subject when neither field_mappings nor cfg.title set', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({});
+    assert.equal(result.subject, 'Workflow activity');
+  });
+
+  it('defaults status to "scheduled" when not mapped', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ field_mappings: [] });
+    assert.equal(result.status, 'scheduled');
+  });
+
+  it('auto-detect association: picks found_lead when present', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_lead: { id: 'lead-1' },
+    });
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, 'lead');
+    assert.equal(result.related_id, 'lead-1');
+  });
+
+  it('auto-detect association: falls back to found_contact when no lead', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_contact: { id: 'contact-1' },
+    });
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, 'contact');
+    assert.equal(result.related_id, 'contact-1');
+  });
+
+  it('explicit association: uses specified entity type', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_lead: { id: 'lead-1' },
+      found_contact: { id: 'contact-1' },
+    });
+    const result = resolveActivityFields({ associate: 'contact', field_mappings: [] });
+    assert.equal(result.related_to, 'contact');
+    assert.equal(result.related_id, 'contact-1');
+  });
+
+  it('field_mappings related_to / related_id override auto-detect', () => {
+    const { resolveActivityFields } = buildExecutor(
+      { custom_entity: 'opportunity', custom_id: 'opp-99' },
+      { found_lead: { id: 'lead-1' } },
+    );
+    const result = resolveActivityFields({
+      associate: 'auto',
+      field_mappings: [
+        { target_field: 'related_to', source_value: 'custom_entity' },
+        { target_field: 'related_id', source_value: 'custom_id' },
+      ],
+    });
+    assert.equal(result.related_to, 'opportunity');
+    assert.equal(result.related_id, 'opp-99');
+  });
+
+  it('returns null related_to / related_id when no entity in context and associate=auto', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, null);
+    assert.equal(result.related_id, null);
+  });
+});

--- a/backend/routes/workflows.js
+++ b/backend/routes/workflows.js
@@ -324,6 +324,16 @@ export default function createWorkflowRoutes(pgPool) {
           const resolved = replaceVariables(`{{${m.webhook_field}}}`);
           return { targetField: m.contact_field, resolved };
         }
+        // Legacy account shape
+        if (m.account_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.account_field, resolved };
+        }
+        // Legacy opportunity shape
+        if (m.opportunity_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.opportunity_field, resolved };
+        }
         return null;
       }
 

--- a/backend/routes/workflows.js
+++ b/backend/routes/workflows.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Workflow Routes
  * CRUD operations for workflows and workflow executions
  */
@@ -298,6 +298,35 @@ export default function createWorkflowRoutes(pgPool) {
         return (workflow.nodes || []).find((n) => n.id === outgoing[0].to) || null;
       }
 
+      // Helper: normalise a field_mappings entry to { targetField, resolvedValue }.
+      // Handles both legacy shapes and the new unified shape from FieldMappingPanel.
+      //   Legacy create_lead/update_lead: { lead_field, webhook_field }
+      //   Legacy update_contact:          { contact_field, webhook_field }
+      //   New unified shape:              { target_field, source_value }
+      function resolveMapping(m) {
+        // New shape
+        if (m.target_field) {
+          const targetField = m.target_field;
+          const raw = m.source_value || '';
+          // source_value is already a token key (e.g. "email" or "found_lead.first_name").
+          // Wrap it in {{ }} for replaceVariables, or use it directly if it already contains {{ }}.
+          const template = raw.startsWith('{{') ? raw : raw ? `{{${raw}}}` : '';
+          const resolved = template ? replaceVariables(template) : '';
+          return { targetField, resolved };
+        }
+        // Legacy lead shape
+        if (m.lead_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.lead_field, resolved };
+        }
+        // Legacy contact shape
+        if (m.contact_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.contact_field, resolved };
+        }
+        return null;
+      }
+
       // Helper: variable replacement
       function replaceVariables(template) {
         if (typeof template !== 'string') return template;
@@ -511,13 +540,11 @@ export default function createWorkflowRoutes(pgPool) {
               vals.push(new Date().toISOString());
               ph.push(`$${idx++}`);
               for (const m of mappings) {
-                if (m.lead_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== null && v !== undefined && v !== '') {
-                    cols.push(m.lead_field);
-                    vals.push(v);
-                    ph.push(`$${idx++}`);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+                  cols.push(rm.targetField);
+                  vals.push(rm.resolved);
+                  ph.push('$' + idx++);
                 }
               }
               const q = `INSERT INTO leads (${cols.join(',')}) VALUES (${ph.join(',')}) RETURNING *`;
@@ -538,12 +565,10 @@ export default function createWorkflowRoutes(pgPool) {
               const vals = [];
               let idx = 1;
               for (const m of mappings) {
-                if (m.lead_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                    sets.push(`${m.lead_field} = $${idx++}`);
-                    vals.push(v);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== ('{{' + rm.targetField + '}}')) {
+                  sets.push(rm.targetField + ' = $' + idx++);
+                  vals.push(rm.resolved);
                 }
               }
               if (!sets.length) {
@@ -589,12 +614,10 @@ export default function createWorkflowRoutes(pgPool) {
               const vals = [];
               let idx = 1;
               for (const m of mappings) {
-                if (m.contact_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                    sets.push(`${m.contact_field} = $${idx++}`);
-                    vals.push(v);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== ('{{' + rm.targetField + '}}')) {
+                  sets.push(rm.targetField + ' = $' + idx++);
+                  vals.push(rm.resolved);
                 }
               }
               if (!sets.length) {
@@ -742,30 +765,39 @@ export default function createWorkflowRoutes(pgPool) {
             }
             case 'create_activity': {
               const activityType = cfg.type || 'task';
-              const subject = replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
-              const description = replaceVariables(cfg.details || cfg.description || '');
+              // Resolve field_mappings (new unified shape) with fallback to legacy cfg.title/cfg.details
+              const fieldMappings = cfg.field_mappings || [];
+              const resolvedFields = {};
+              for (const m of fieldMappings) {
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+                  resolvedFields[rm.targetField] = rm.resolved;
+                }
+              }
+              const subject = resolvedFields.subject || replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
+              const body = resolvedFields.body || replaceVariables(cfg.details || cfg.description || '');
+              const status = resolvedFields.status || 'scheduled';
+              const due_date = resolvedFields.due_date || null;
+              const assigned_to = resolvedFields.assigned_to || null;
               const lead = context.variables.found_lead;
               const contact = context.variables.found_contact;
               const account = context.variables.found_account;
               const opportunity = context.variables.found_opportunity;
-              const related_to = lead
-                ? 'lead'
-                : contact
-                  ? 'contact'
-                  : account
-                    ? 'account'
-                    : opportunity
-                      ? 'opportunity'
-                      : null;
-              const related_id = lead
-                ? lead.id
-                : contact
-                  ? contact.id
-                  : account
-                    ? account.id
-                    : opportunity
-                      ? opportunity.id
-                      : null;
+              // Associate: 'auto' (default) = first found entity in context
+              const associate = cfg.associate || 'auto';
+              let related_to = null;
+              let related_id = null;
+              if (associate === 'auto') {
+                related_to = lead ? 'lead' : contact ? 'contact' : account ? 'account' : opportunity ? 'opportunity' : null;
+                related_id = lead ? lead.id : contact ? contact.id : account ? account.id : opportunity ? opportunity.id : null;
+              } else {
+                const entityMap = { lead, contact, account, opportunity };
+                const entity = entityMap[associate];
+                if (entity) { related_to = associate; related_id = entity.id; }
+              }
+              // field_mappings can explicitly override related_to / related_id
+              if (resolvedFields.related_to) related_to = resolvedFields.related_to;
+              if (resolvedFields.related_id) related_id = resolvedFields.related_id;
               const metadata = { created_by_workflow: workflow.id };
               const q = `
                 INSERT INTO activities (
@@ -774,22 +806,25 @@ export default function createWorkflowRoutes(pgPool) {
                   assigned_to, related_to, metadata, created_date, updated_date
                 ) VALUES (
                   $1, $2, $3, $4, $5, $6,
-                  NULL, NULL, NULL, NULL, NULL,
-                  NULL, $7, $8, NOW(), NOW()
+                  NULL, NULL, NULL, $7, NULL,
+                  $8, $9, $10, NOW(), NOW()
                 ) RETURNING *
               `;
               const vals = [
                 workflow.tenant_id,
                 activityType,
                 subject || null,
-                description || null,
-                'scheduled',
+                body || null,
+                status,
                 related_id,
+                due_date,
+                assigned_to,
                 related_to,
                 JSON.stringify(metadata),
               ];
               const r = await pgPool.query(q, vals);
               log.output = { activity: r.rows[0] };
+              context.variables.created_activity = r.rows[0];
               break;
             }
             case 'condition': {

--- a/src/components/workflows/FieldMappingPanel.jsx
+++ b/src/components/workflows/FieldMappingPanel.jsx
@@ -1,0 +1,222 @@
+/**
+ * FieldMappingPanel
+ *
+ * Reusable Zapier-style field mapper. Each row has:
+ *  - left:  target field (Select from a schema definition)
+ *  - right: source value (token pill picker from upstream node outputs OR free text)
+ *
+ * Props:
+ *  mappings        {Array<{target_field, source_type, source_value}>}
+ *  onChange        (newMappings) => void
+ *  targetSchema    Array<{value, label}> – the entity fields on the left
+ *  upstreamTokens  Array<{key, label, stepIndex, stepLabel, nodeType}> – tokens from upstream nodes
+ *  addLabel        string (default "Add Field")
+ */
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Plus, X, ChevronDown, Tag } from 'lucide-react';
+
+// Groups upstream tokens by step for display
+function groupTokensByStep(tokens) {
+  const groups = {};
+  for (const t of tokens) {
+    const key = `${t.stepIndex}`;
+    if (!groups[key]) groups[key] = { stepIndex: t.stepIndex, stepLabel: t.stepLabel, tokens: [] };
+    groups[key].tokens.push(t);
+  }
+  return Object.values(groups).sort((a, b) => a.stepIndex - b.stepIndex);
+}
+
+function TokenPicker({ value, tokens, onSelect, placeholder }) {
+  const [open, setOpen] = useState(false);
+
+  // Resolve display label for current value
+  const selected = tokens.find((t) => t.key === value);
+  const displayLabel = selected ? `${selected.stepIndex}. ${selected.label}` : value ? value : null;
+
+  const groups = groupTokensByStep(tokens);
+
+  return (
+    <div className="relative flex-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-md border text-sm
+          bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 transition-colors min-h-[36px]`}
+      >
+        {selected ? (
+          <span className="flex items-center gap-1.5 truncate">
+            <span className="inline-flex items-center gap-1 bg-purple-600/30 border border-purple-500/40 text-purple-300 rounded px-1.5 py-0.5 text-xs font-mono truncate max-w-[180px]">
+              <Tag className="w-3 h-3 shrink-0" />
+              {selected.stepIndex}. {selected.label}
+            </span>
+          </span>
+        ) : displayLabel ? (
+          <span className="text-slate-400 text-xs truncate font-mono">{displayLabel}</span>
+        ) : (
+          <span className="text-slate-500 text-xs">{placeholder || 'Select or type value…'}</span>
+        )}
+        <ChevronDown className="w-3.5 h-3.5 shrink-0 text-slate-400" />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-72 bg-slate-900 border border-slate-700 rounded-lg shadow-xl overflow-hidden">
+          {/* Free text input at top */}
+          <div className="p-2 border-b border-slate-700">
+            <Input
+              placeholder="Type static value or {{variable}}"
+              className="bg-slate-800 border-slate-600 text-slate-200 text-xs h-7"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && e.target.value) {
+                  onSelect(e.target.value);
+                  setOpen(false);
+                }
+              }}
+            />
+            <p className="text-[10px] text-slate-500 mt-1">Press Enter to set free-text value</p>
+          </div>
+
+          {/* Token groups */}
+          <div className="max-h-64 overflow-y-auto">
+            {groups.length === 0 ? (
+              <div className="p-3 text-xs text-slate-500">
+                No upstream data available. Run the webhook trigger first to capture a payload.
+              </div>
+            ) : (
+              groups.map((group) => (
+                <div key={group.stepIndex}>
+                  <div className="px-3 py-1.5 bg-slate-800/60 text-[10px] font-semibold text-slate-400 uppercase tracking-wider sticky top-0">
+                    {group.stepIndex}. {group.stepLabel}
+                  </div>
+                  {group.tokens.map((token) => (
+                    <button
+                      key={token.key}
+                      type="button"
+                      onClick={() => {
+                        onSelect(token.key);
+                        setOpen(false);
+                      }}
+                      className="w-full px-3 py-2 text-left hover:bg-slate-700/60 flex items-center gap-2 transition-colors"
+                    >
+                      <Tag className="w-3 h-3 text-purple-400 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-xs text-slate-200 font-mono truncate">
+                          {token.label}
+                        </div>
+                        {token.example !== undefined && (
+                          <div className="text-[10px] text-slate-500 truncate">
+                            {String(token.example).slice(0, 40)}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Click-away backdrop */}
+      {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />}
+    </div>
+  );
+}
+
+export default function FieldMappingPanel({
+  mappings = [],
+  onChange,
+  targetSchema = [],
+  upstreamTokens = [],
+  addLabel = 'Add Field',
+}) {
+  const updateRow = (index, patch) => {
+    const next = mappings.map((m, i) => (i === index ? { ...m, ...patch } : m));
+    onChange(next);
+  };
+
+  const removeRow = (index) => {
+    onChange(mappings.filter((_, i) => i !== index));
+  };
+
+  const addRow = () => {
+    onChange([...mappings, { target_field: '', source_type: 'token', source_value: '' }]);
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Header row */}
+      {mappings.length > 0 && (
+        <div className="flex gap-2 items-center mb-1">
+          <span className="flex-1 text-[10px] text-slate-500 uppercase tracking-wider">
+            Target Field
+          </span>
+          <span className="flex-1 text-[10px] text-slate-500 uppercase tracking-wider">
+            Source Value
+          </span>
+          <span className="w-7" />
+        </div>
+      )}
+
+      {mappings.map((mapping, index) => (
+        <div key={index} className="flex gap-2 items-center">
+          {/* Target field selector */}
+          <div className="flex-1">
+            <Select
+              value={mapping.target_field || ''}
+              onValueChange={(v) => updateRow(index, { target_field: v })}
+            >
+              <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200 text-sm h-9">
+                <SelectValue placeholder="Field…" />
+              </SelectTrigger>
+              <SelectContent className="bg-slate-900 border-slate-700 max-h-64">
+                {targetSchema.map((f) => (
+                  <SelectItem key={f.value} value={f.value}>
+                    {f.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Source value: token picker */}
+          <TokenPicker
+            value={mapping.source_value || ''}
+            tokens={upstreamTokens}
+            onSelect={(v) => updateRow(index, { source_value: v, source_type: 'token' })}
+            placeholder="Pick value…"
+          />
+
+          {/* Remove */}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removeRow(index)}
+            className="w-7 h-7 shrink-0 text-red-400 hover:text-red-300 hover:bg-red-900/20"
+          >
+            <X className="w-3.5 h-3.5" />
+          </Button>
+        </div>
+      ))}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={addRow}
+        className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 w-full mt-1"
+      >
+        <Plus className="w-4 h-4 mr-2" />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1094,106 +1094,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to lead fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.lead_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, lead_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Lead Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="score">Score</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="source">Source</SelectItem>
-                        <SelectItem value="next_action">Next Action</SelectItem>
-                        <SelectItem value="score_reason">Score Reason</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { lead_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to lead fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.lead}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Lead Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2351,105 +2259,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to contact fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.contact_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, contact_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Contact Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="first_name">First Name</SelectItem>
-                        <SelectItem value="last_name">Last Name</SelectItem>
-                        <SelectItem value="email">Email</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { contact_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to contact fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.contact}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Contact Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2868,36 +2685,23 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
             </div>
 
             <div>
-              <Label className="text-slate-200">Subject/Title</Label>
-              <Input
-                value={node.config?.title || ''}
-                onChange={(e) => {
-                  updateNodeConfig(node.id, { ...node.config, title: e.target.value });
-                }}
-                placeholder="e.g., Follow-up email"
-                className="bg-slate-800 border-slate-700 text-slate-200"
-              />
-            </div>
-
-            <div>
-              <Label className="text-slate-200">Details</Label>
-              <textarea
-                value={node.config?.details || ''}
-                onChange={(e) => {
-                  updateNodeConfig(node.id, { ...node.config, details: e.target.value });
-                }}
-                placeholder="Activity details (supports {{field}} replacements)"
-                className="w-full min-h-[120px] rounded-md bg-slate-800 border border-slate-700 text-slate-200 p-2"
-              />
-              <p className="text-xs text-slate-500 mt-1">
-                Use {'{{field_name}}'} to reference webhook data
+              <Label className="text-slate-200">Field Mappings</Label>
+              <p className="text-sm text-slate-400 mb-3">
+                Map inbound data to activity fields. Subject, Body, Status, Due Date, Assigned To.
               </p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.activity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Activity Field"
+              />
             </div>
 
             <div>
               <Label className="text-slate-200">Associate With</Label>
               <Select
-                value={node.config?.associate || 'lead'}
+                value={node.config?.associate || 'auto'}
                 onValueChange={(value) => {
                   updateNodeConfig(node.id, { ...node.config, associate: value });
                 }}
@@ -2906,12 +2710,17 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-700">
+                  <SelectItem value="auto">Auto-detect from upstream (recommended)</SelectItem>
                   <SelectItem value="lead">Lead</SelectItem>
                   <SelectItem value="contact">Contact</SelectItem>
                   <SelectItem value="account">Account</SelectItem>
                   <SelectItem value="opportunity">Opportunity</SelectItem>
                 </SelectContent>
               </Select>
+              <p className="text-xs text-slate-500 mt-1">
+                Auto-detect uses the first found_lead / found_contact / found_account /
+                found_opportunity from upstream nodes.
+              </p>
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -28,6 +28,8 @@ import {
 import WorkflowCanvas from './WorkflowCanvas';
 import NodeLibrary from './NodeLibrary';
 import WorkflowTemplatesBrowser from './WorkflowTemplatesBrowser';
+import FieldMappingPanel from './FieldMappingPanel';
+import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from './upstreamTokens';
 import { useToast } from '@/components/ui/use-toast';
 import { WorkflowExecution } from '@/api/entities';
 import { Switch } from '@/components/ui/switch';
@@ -1074,108 +1076,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to new lead fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.lead_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, lead_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Lead Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="first_name">First Name</SelectItem>
-                        <SelectItem value="last_name">Last Name</SelectItem>
-                        <SelectItem value="email">Email</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="score">Score</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="source">Source</SelectItem>
-                        <SelectItem value="next_action">Next Action</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { lead_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to new lead fields</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.lead}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Lead Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+﻿import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -2340,102 +2340,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to account fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.account_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, account_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Account Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="website">Website</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { account_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to account fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.account}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Account Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2447,105 +2359,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">
-                Map webhook fields to opportunity fields
-              </p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.opportunity_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, opportunity_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Opportunity Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="name">Name</SelectItem>
-                        <SelectItem value="stage">Stage</SelectItem>
-                        <SelectItem value="amount">Amount</SelectItem>
-                        <SelectItem value="probability">Probability</SelectItem>
-                        <SelectItem value="close_date">Close Date</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { opportunity_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to new opportunity fields</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.opportunity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Opportunity Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2557,104 +2378,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">
-                Map webhook fields to opportunity fields
-              </p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.opportunity_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, opportunity_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Opportunity Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="stage">Stage</SelectItem>
-                        <SelectItem value="amount">Amount</SelectItem>
-                        <SelectItem value="probability">Probability</SelectItem>
-                        <SelectItem value="close_date">Close Date</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { opportunity_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to opportunity fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.opportunity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Opportunity Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -29,7 +29,7 @@ import WorkflowCanvas from './WorkflowCanvas';
 import NodeLibrary from './NodeLibrary';
 import WorkflowTemplatesBrowser from './WorkflowTemplatesBrowser';
 import FieldMappingPanel from './FieldMappingPanel';
-import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from './upstreamTokens';
+import { getUpstreamTokens, ENTITY_SCHEMAS } from './upstreamTokens';
 import { useToast } from '@/components/ui/use-toast';
 import { WorkflowExecution } from '@/api/entities';
 import { Switch } from '@/components/ui/switch';

--- a/src/components/workflows/__tests__/FieldMappingPanel.test.jsx
+++ b/src/components/workflows/__tests__/FieldMappingPanel.test.jsx
@@ -1,0 +1,217 @@
+/**
+ * FieldMappingPanel.test.jsx
+ *
+ * Tests for the reusable Zapier-style field mapping component.
+ *
+ * Coverage:
+ *  1. Renders empty state with only the "Add Field" button
+ *  2. Renders existing mappings
+ *  3. Add row — calls onChange with new empty entry appended
+ *  4. Remove row — calls onChange with that entry removed
+ *  5. Target field change — calls onChange with updated target_field
+ *  6. addLabel prop overrides button text
+ *  7. Header row is shown only when mappings exist
+ *  8. TokenPicker shows placeholder text when no value selected
+ *  9. TokenPicker shows no upstream tokens message when tokens array is empty
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FieldMappingPanel from '../FieldMappingPanel.jsx';
+
+// ─── UI component mocks ───────────────────────────────────────────────────
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({ ...props }) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, onValueChange, value }) => (
+    <div data-testid="select" data-value={value}>
+      {/* Expose a hidden button to trigger value change in tests */}
+      <button
+        data-testid="select-trigger-change"
+        onClick={() => onValueChange && onValueChange('email')}
+      >
+        {value || 'Select'}
+      </button>
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }) => <div>{children}</div>,
+  SelectItem: ({ children, value }) => <div data-value={value}>{children}</div>,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+const targetSchema = [
+  { value: 'email', label: 'Email' },
+  { value: 'first_name', label: 'First Name' },
+  { value: 'last_name', label: 'Last Name' },
+];
+
+const upstreamTokens = [
+  { key: 'email', label: 'email', stepIndex: 1, stepLabel: 'Webhook Trigger', nodeType: 'webhook_trigger', example: 'test@example.com' },
+  { key: 'first_name', label: 'first_name', stepIndex: 1, stepLabel: 'Webhook Trigger', nodeType: 'webhook_trigger', example: 'Jane' },
+];
+
+const baseMappings = [
+  { target_field: 'email', source_type: 'token', source_value: 'email' },
+  { target_field: 'first_name', source_type: 'token', source_value: 'first_name' },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('[WORKFLOWS] FieldMappingPanel', () => {
+  let onChange;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it('renders Add Field button when mappings are empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Add Field')).toBeTruthy();
+  });
+
+  it('does not render header row when mappings are empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.queryByText('Target Field')).toBeNull();
+  });
+
+  it('renders header row when mappings exist', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Target Field')).toBeTruthy();
+    expect(screen.getByText('Source Value')).toBeTruthy();
+  });
+
+  it('renders one row per mapping', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    // 2 mappings = 2 Select components for target fields
+    const selects = screen.getAllByTestId('select');
+    expect(selects.length).toBe(2);
+  });
+
+  it('calls onChange with appended empty entry when Add button clicked', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    fireEvent.click(screen.getByText('Add Field'));
+    expect(onChange).toHaveBeenCalledOnce();
+    const result = onChange.mock.calls[0][0];
+    expect(result).toHaveLength(3);
+    expect(result[2]).toEqual({ target_field: '', source_type: 'token', source_value: '' });
+  });
+
+  it('calls onChange with row removed when X button clicked', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    // The Select mock renders one button per row (select-trigger-change).
+    // The remove (X) buttons are the last button in each row — find by
+    // filtering out the 'Add Field' button and the select-trigger-change buttons.
+    const allButtons = screen.getAllByRole('button');
+    // Layout per row: [select-trigger-change, TokenPicker-chevron, remove-X]
+    // Plus final 'Add Field' button. With 2 rows: 6 buttons + 1 = 7 total.
+    // Remove buttons are at indices 2 and 5 (every 3rd, 0-indexed).
+    // Clicking the first remove (index 2) should remove row 0 (email).
+    const removeButtons = allButtons.filter(
+      (btn) => !btn.textContent.includes('Add') && !btn.textContent.includes('email') &&
+               !btn.textContent.includes('first_name') && !btn.textContent.includes('Select'),
+    );
+    fireEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledOnce();
+    const result = onChange.mock.calls[0][0];
+    expect(result).toHaveLength(1);
+    expect(result[0].target_field).toBe('first_name');
+  });
+
+  it('overrides add button label via addLabel prop', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+        addLabel="Add Activity Field"
+      />,
+    );
+    expect(screen.getByText('Add Activity Field')).toBeTruthy();
+  });
+
+  it('renders TokenPicker with placeholder when source_value is empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[{ target_field: 'email', source_type: 'token', source_value: '' }]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Pick value…')).toBeTruthy();
+  });
+
+  it('shows no-tokens message in popover when upstreamTokens is empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[{ target_field: 'email', source_type: 'token', source_value: '' }]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={[]}
+      />,
+    );
+    // Open the picker popover
+    fireEvent.click(screen.getByText('Pick value…'));
+    expect(
+      screen.getByText(/No upstream data available/),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/workflows/__tests__/upstreamTokens.test.js
+++ b/src/components/workflows/__tests__/upstreamTokens.test.js
@@ -1,0 +1,184 @@
+/**
+ * upstreamTokens.test.js
+ *
+ * Tests for the upstream token resolver and ENTITY_SCHEMAS.
+ *
+ * Coverage:
+ *  1. getUpstreamTokens — webhook_trigger uses testPayload keys
+ *  2. getUpstreamTokens — find_lead emits prefixed tokens
+ *  3. getUpstreamTokens — multi-node graph, correct stepIndex labels
+ *  4. getUpstreamTokens — target node itself is excluded
+ *  5. getUpstreamTokens — http_request emits last_http_status / last_http_response
+ *  6. getUpstreamTokens — returns empty array when no upstream nodes
+ *  7. getUpstreamTokens — unknown node type is silently skipped
+ *  8. tokenToTemplate — wraps bare key in {{ }}
+ *  9. tokenToTemplate — leaves existing {{ }} untouched
+ * 10. tokenToTemplate — returns empty string for falsy input
+ * 11. ENTITY_SCHEMAS — all five entities have required fields
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from '../upstreamTokens.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const triggerNode = { id: 'n1', type: 'webhook_trigger' };
+const findLeadNode = { id: 'n2', type: 'find_lead' };
+const createActivityNode = { id: 'n3', type: 'create_activity' };
+const httpNode = { id: 'n4', type: 'http_request' };
+const unknownNode = { id: 'n5', type: 'some_future_node_type' };
+
+const linearConnections = [
+  { from: 'n1', to: 'n2' },
+  { from: 'n2', to: 'n3' },
+];
+
+const testPayload = { email: 'test@example.com', first_name: 'Jane', company: 'Acme' };
+
+// ─── getUpstreamTokens ─────────────────────────────────────────────────────
+
+describe('[upstreamTokens] getUpstreamTokens', () => {
+  it('returns payload keys as tokens for webhook_trigger', () => {
+    // Target = n2, upstream = n1 (webhook_trigger)
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, testPayload);
+    const keys = tokens.map((t) => t.key);
+    expect(keys).toContain('email');
+    expect(keys).toContain('first_name');
+    expect(keys).toContain('company');
+  });
+
+  it('returns empty token list for webhook_trigger when no testPayload', () => {
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, null);
+    expect(tokens.filter((t) => t.nodeType === 'webhook_trigger')).toHaveLength(0);
+  });
+
+  it('attaches example value from testPayload to webhook tokens', () => {
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, testPayload);
+    const emailToken = tokens.find((t) => t.key === 'email');
+    expect(emailToken.example).toBe('test@example.com');
+  });
+
+  it('emits prefixed tokens for find_lead (found_lead.field)', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const leadTokens = tokens.filter((t) => t.nodeType === 'find_lead');
+    expect(leadTokens.length).toBeGreaterThan(0);
+    const keys = leadTokens.map((t) => t.key);
+    expect(keys).toContain('found_lead.email');
+    expect(keys).toContain('found_lead.first_name');
+    expect(keys).toContain('found_lead.id');
+  });
+
+  it('sets correct stepIndex — trigger is step 1, find_lead is step 2', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const triggerTokens = tokens.filter((t) => t.nodeType === 'webhook_trigger');
+    const leadTokens = tokens.filter((t) => t.nodeType === 'find_lead');
+    expect(triggerTokens[0].stepIndex).toBe(1);
+    expect(leadTokens[0].stepIndex).toBe(2);
+  });
+
+  it('does not include the target node itself in tokens', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const activityTokens = tokens.filter((t) => t.nodeType === 'create_activity');
+    expect(activityTokens).toHaveLength(0);
+  });
+
+  it('returns empty array when target is the first node (no upstream)', () => {
+    const tokens = getUpstreamTokens('n1', [triggerNode], [], testPayload);
+    expect(tokens).toHaveLength(0);
+  });
+
+  it('emits last_http_status and last_http_response for http_request node', () => {
+    const nodes = [triggerNode, httpNode, createActivityNode];
+    const conns = [{ from: 'n1', to: 'n4' }, { from: 'n4', to: 'n3' }];
+    const tokens = getUpstreamTokens('n3', nodes, conns, testPayload);
+    const httpTokens = tokens.filter((t) => t.nodeType === 'http_request');
+    const keys = httpTokens.map((t) => t.key);
+    expect(keys).toContain('last_http_status');
+    expect(keys).toContain('last_http_response');
+  });
+
+  it('silently skips unknown node types', () => {
+    const nodes = [triggerNode, unknownNode, createActivityNode];
+    const conns = [{ from: 'n1', to: 'n5' }, { from: 'n5', to: 'n3' }];
+    // Should not throw
+    expect(() =>
+      getUpstreamTokens('n3', nodes, conns, testPayload),
+    ).not.toThrow();
+    const tokens = getUpstreamTokens('n3', nodes, conns, testPayload);
+    const unknownTokens = tokens.filter((t) => t.nodeType === 'some_future_node_type');
+    expect(unknownTokens).toHaveLength(0);
+  });
+});
+
+// ─── tokenToTemplate ───────────────────────────────────────────────────────
+
+describe('[upstreamTokens] tokenToTemplate', () => {
+  it('wraps a bare key in {{ }}', () => {
+    expect(tokenToTemplate('email')).toBe('{{email}}');
+  });
+
+  it('wraps a dotted key in {{ }}', () => {
+    expect(tokenToTemplate('found_lead.email')).toBe('{{found_lead.email}}');
+  });
+
+  it('leaves an already-wrapped key untouched', () => {
+    expect(tokenToTemplate('{{email}}')).toBe('{{email}}');
+  });
+
+  it('returns empty string for null', () => {
+    expect(tokenToTemplate(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(tokenToTemplate(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(tokenToTemplate('')).toBe('');
+  });
+});
+
+// ─── ENTITY_SCHEMAS ────────────────────────────────────────────────────────
+
+describe('[upstreamTokens] ENTITY_SCHEMAS', () => {
+  const requiredByEntity = {
+    lead: ['first_name', 'last_name', 'email', 'phone', 'company'],
+    contact: ['first_name', 'last_name', 'email', 'phone'],
+    account: ['name', 'industry', 'website'],
+    opportunity: ['name', 'amount', 'stage'],
+    activity: ['subject', 'body', 'status', 'due_date', 'assigned_to'],
+  };
+
+  for (const [entity, required] of Object.entries(requiredByEntity)) {
+    it(`ENTITY_SCHEMAS.${entity} contains required fields`, () => {
+      const values = ENTITY_SCHEMAS[entity].map((f) => f.value);
+      for (const field of required) {
+        expect(values).toContain(field);
+      }
+    });
+
+    it(`ENTITY_SCHEMAS.${entity} entries each have value and label`, () => {
+      for (const entry of ENTITY_SCHEMAS[entity]) {
+        expect(typeof entry.value).toBe('string');
+        expect(entry.value.length).toBeGreaterThan(0);
+        expect(typeof entry.label).toBe('string');
+        expect(entry.label.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});

--- a/src/components/workflows/upstreamTokens.js
+++ b/src/components/workflows/upstreamTokens.js
@@ -1,0 +1,350 @@
+/**
+ * upstreamTokens.js
+ *
+ * Given a target node ID and the full nodes/connections array, walks the
+ * execution graph backwards and returns a flat list of all variable tokens
+ * that are available to that node.
+ *
+ * Token shape:
+ *  {
+ *    key:       string  – the variable key to embed, e.g. "email" or "found_lead.first_name"
+ *    label:     string  – human label, e.g. "email" or "found_lead · first_name"
+ *    stepIndex: number  – 1-based position of the source node in execution order
+ *    stepLabel: string  – human name of the source node
+ *    nodeType:  string  – e.g. "webhook_trigger"
+ *    example:   any     – optional example value from testPayload
+ *  }
+ *
+ * Variable resolution rules (mirrors backend replaceVariables):
+ *  - webhook_trigger fields  → "{{fieldName}}"
+ *  - find_lead / create_lead → "{{found_lead.fieldName}}"
+ *  - find_contact            → "{{found_contact.fieldName}}"
+ *  - find_account            → "{{found_account.fieldName}}"
+ *  - find_opportunity        → "{{found_opportunity.fieldName}}"
+ *  - create_activity         → "{{created_activity.fieldName}}"
+ *  - http_request            → "{{last_http_response}}", "{{last_http_status}}"
+ *  - ai_* nodes              → "{{ai_stage.stage}}", etc.
+ */
+
+// Static field definitions per node type (mirrors generateNodeOutputPreview)
+const NODE_OUTPUT_FIELDS = {
+  webhook_trigger: {
+    label: 'Webhook Trigger',
+    prefix: null, // fields come directly from testPayload keys
+    fields: [], // populated dynamically from testPayload
+  },
+  find_lead: {
+    label: 'Find Lead',
+    prefix: 'found_lead',
+    fields: [
+      'id',
+      'first_name',
+      'last_name',
+      'email',
+      'phone',
+      'company',
+      'status',
+      'score',
+      'job_title',
+      'source',
+      'notes',
+    ],
+  },
+  create_lead: {
+    label: 'Create Lead',
+    prefix: 'found_lead',
+    fields: [
+      'id',
+      'first_name',
+      'last_name',
+      'email',
+      'phone',
+      'company',
+      'status',
+      'job_title',
+      'source',
+    ],
+  },
+  update_lead: {
+    label: 'Update Lead',
+    prefix: 'found_lead',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'status'],
+  },
+  find_contact: {
+    label: 'Find Contact',
+    prefix: 'found_contact',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'account_id'],
+  },
+  update_contact: {
+    label: 'Update Contact',
+    prefix: 'found_contact',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone'],
+  },
+  find_account: {
+    label: 'Find Account',
+    prefix: 'found_account',
+    fields: ['id', 'name', 'industry', 'website', 'email', 'phone'],
+  },
+  update_account: {
+    label: 'Update Account',
+    prefix: 'found_account',
+    fields: ['id', 'name', 'industry', 'website'],
+  },
+  find_opportunity: {
+    label: 'Find Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
+  },
+  create_opportunity: {
+    label: 'Create Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
+  },
+  update_opportunity: {
+    label: 'Update Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage'],
+  },
+  create_activity: {
+    label: 'Create Activity',
+    prefix: 'created_activity',
+    fields: [
+      'id',
+      'type',
+      'subject',
+      'body',
+      'status',
+      'due_date',
+      'assigned_to',
+      'related_id',
+      'related_to',
+    ],
+  },
+  http_request: {
+    label: 'HTTP Request',
+    prefix: null,
+    fields: ['last_http_status', 'last_http_response'],
+  },
+  ai_classify_opportunity_stage: {
+    label: 'AI: Classify Stage',
+    prefix: 'ai_stage',
+    fields: ['stage', 'confidence', 'reasoning'],
+  },
+  ai_generate_email: {
+    label: 'AI: Generate Email',
+    prefix: 'ai_email',
+    fields: ['subject', 'body', 'tone'],
+  },
+  ai_enrich_account: {
+    label: 'AI: Enrich Account',
+    prefix: 'ai_enrichment',
+    fields: ['industry', 'size', 'description', 'technologies'],
+  },
+  ai_route_activity: {
+    label: 'AI: Route Activity',
+    prefix: 'ai_route',
+    fields: ['assigned_to', 'priority', 'reasoning'],
+  },
+  ai_summarize: {
+    label: 'AI Summarize',
+    prefix: 'ai_summary',
+    fields: ['summary', 'key_points'],
+  },
+  pep_query: {
+    label: 'PEP Query',
+    prefix: 'pep_results',
+    fields: ['results', 'count'],
+  },
+};
+
+/**
+ * Topological walk: returns nodes in execution order up to (but not including)
+ * the targetNodeId. Handles linear and branching graphs.
+ */
+function getExecutionOrderBefore(targetNodeId, nodes, connections) {
+  // Build adjacency: from → [to]
+  const adj = {};
+  for (const c of connections) {
+    if (!adj[c.from]) adj[c.from] = [];
+    adj[c.from].push(c.to);
+  }
+
+  // Find start node (trigger – no incoming connections)
+  const hasIncoming = new Set(connections.map((c) => c.to));
+  const startNodes = nodes.filter((n) => !hasIncoming.has(n.id));
+  if (!startNodes.length) return [];
+
+  // BFS to collect all ancestors of targetNodeId
+  const ancestors = [];
+  const visited = new Set();
+  const queue = [...startNodes.map((n) => n.id)];
+
+  while (queue.length) {
+    const id = queue.shift();
+    if (id === targetNodeId) continue; // don't include target itself
+    if (visited.has(id)) continue;
+    visited.add(id);
+    const node = nodes.find((n) => n.id === id);
+    if (node) ancestors.push(node);
+    const nexts = adj[id] || [];
+    for (const next of nexts) {
+      if (!visited.has(next)) queue.push(next);
+    }
+  }
+
+  return ancestors;
+}
+
+/**
+ * Build a list of upstream tokens available to a given node.
+ *
+ * @param {string}  targetNodeId
+ * @param {Array}   nodes          – full workflow nodes array
+ * @param {Array}   connections    – full workflow connections array
+ * @param {object}  testPayload    – the captured webhook payload (or null)
+ * @returns {Array<Token>}
+ */
+export function getUpstreamTokens(targetNodeId, nodes, connections, testPayload) {
+  const ancestors = getExecutionOrderBefore(targetNodeId, nodes, connections);
+  const tokens = [];
+
+  ancestors.forEach((node, idx) => {
+    const stepIndex = idx + 1;
+    const def = NODE_OUTPUT_FIELDS[node.type];
+    if (!def) return;
+
+    const stepLabel = def.label;
+
+    if (node.type === 'webhook_trigger') {
+      // Dynamic: use testPayload keys if available, else show nothing
+      const payloadKeys = testPayload ? Object.keys(testPayload) : [];
+      for (const field of payloadKeys) {
+        tokens.push({
+          key: field,
+          label: field,
+          stepIndex,
+          stepLabel,
+          nodeType: node.type,
+          example: testPayload[field],
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'http_request') {
+      tokens.push({
+        key: 'last_http_status',
+        label: 'HTTP Status Code',
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: 200,
+      });
+      tokens.push({
+        key: 'last_http_response',
+        label: 'HTTP Response Body',
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: '{"success":true}',
+      });
+      return;
+    }
+
+    const prefix = def.prefix;
+    for (const field of def.fields) {
+      const key = prefix ? `${prefix}.${field}` : field;
+      tokens.push({
+        key,
+        label: prefix ? `${prefix} · ${field}` : field,
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: undefined,
+      });
+    }
+  });
+
+  return tokens;
+}
+
+/**
+ * Convert a token key to a {{variable}} template string.
+ * e.g. "found_lead.email" → "{{found_lead.email}}"
+ *      "email"            → "{{email}}"
+ */
+export function tokenToTemplate(key) {
+  if (!key) return '';
+  // If already a template string, return as-is
+  if (key.startsWith('{{') && key.endsWith('}}')) return key;
+  return `{{${key}}}`;
+}
+
+/**
+ * Schema definitions for each entity's writable fields.
+ * Used by FieldMappingPanel targetSchema prop.
+ */
+export const ENTITY_SCHEMAS = {
+  lead: [
+    { value: 'first_name', label: 'First Name' },
+    { value: 'last_name', label: 'Last Name' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'company', label: 'Company' },
+    { value: 'job_title', label: 'Job Title' },
+    { value: 'status', label: 'Status' },
+    { value: 'score', label: 'Score' },
+    { value: 'source', label: 'Source' },
+    { value: 'next_action', label: 'Next Action' },
+    { value: 'notes', label: 'Notes' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+  ],
+  contact: [
+    { value: 'first_name', label: 'First Name' },
+    { value: 'last_name', label: 'Last Name' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'mobile', label: 'Mobile' },
+    { value: 'job_title', label: 'Job Title' },
+    { value: 'company', label: 'Company' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'notes', label: 'Notes' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+  ],
+  account: [
+    { value: 'name', label: 'Name' },
+    { value: 'industry', label: 'Industry' },
+    { value: 'website', label: 'Website' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'annual_revenue', label: 'Annual Revenue' },
+    { value: 'employee_count', label: 'Employee Count' },
+    { value: 'notes', label: 'Notes' },
+  ],
+  opportunity: [
+    { value: 'name', label: 'Name' },
+    { value: 'amount', label: 'Amount' },
+    { value: 'stage', label: 'Stage' },
+    { value: 'probability', label: 'Probability' },
+    { value: 'close_date', label: 'Close Date' },
+    { value: 'notes', label: 'Notes' },
+  ],
+  activity: [
+    { value: 'type', label: 'Type' },
+    { value: 'subject', label: 'Subject / Title' },
+    { value: 'body', label: 'Body / Details' },
+    { value: 'status', label: 'Status' },
+    { value: 'due_date', label: 'Due Date' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+    { value: 'related_to', label: 'Related To (entity type)' },
+    { value: 'related_id', label: 'Related ID' },
+  ],
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -167,6 +167,7 @@ export default defineConfig({
         plugins: [react()],
         test: {
           ...sharedConfig,
+          env: { NODE_ENV: 'test' },
           include: [
             'src/components/workflows/**/*.test.{js,jsx,ts,tsx}',
             'src/components/workflows/**/__tests__/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## Summary

Upgrades the workflow node config panels from bare `{{field}}` text inputs and static dropdown pairs to a unified Zapier-style **FieldMappingPanel** — a token pill picker that walks the execution graph upstream and surfaces available variables from each prior node's output.

## What changed

### Frontend

**New components:**
- `src/components/workflows/FieldMappingPanel.jsx` — reusable field mapper with token pill popover. Each row: target field (entity schema dropdown) + source value (upstream token picker or free text).
- `src/components/workflows/upstreamTokens.js` — BFS graph walker that returns typed tokens (`{key, label, stepIndex, stepLabel, example}`) from all upstream nodes. Includes `ENTITY_SCHEMAS` for all five entity types.

**Upgraded node config panels** (all now use `FieldMappingPanel`):
- `create_lead`, `update_lead`
- `update_contact`
- `update_account`
- `create_opportunity`, `update_opportunity`
- `create_activity` — also upgraded from bare `title`/`details` text inputs to field mappings; added `due_date`, `assigned_to`, `auto` association mode

### Backend (`backend/routes/workflows.js`)

- Added `resolveMapping(m)` helper — normalises all legacy field mapping shapes (`lead_field/webhook_field`, `contact_field/webhook_field`, `account_field/webhook_field`, `opportunity_field/webhook_field`) and the new unified shape (`target_field/source_value`) into `{ targetField, resolved }`. Full backward compat — existing saved workflows continue to execute without migration.
- Upgraded `create_lead`, `update_lead`, `update_contact` executors to use `resolveMapping`.
- Upgraded `create_activity` executor to process `field_mappings` with fallback to legacy `cfg.title`/`cfg.details`; now correctly populates `due_date`, `assigned_to`, and supports `associate: 'auto'` (first found entity in context) or explicit entity type. Stores result in `context.variables.created_activity` for downstream nodes.

### Tests

- `backend/__tests__/routes/workflows.resolveMapping.test.js` — 20 node:test cases covering all mapping shapes, dotted variable resolution, legacy fallbacks, `create_activity` field resolution, association logic.
- `src/components/workflows/__tests__/upstreamTokens.test.js` — 25 Vitest cases covering BFS graph walking, step indexing, token emission per node type, `tokenToTemplate`, `ENTITY_SCHEMAS`.
- `src/components/workflows/__tests__/FieldMappingPanel.test.jsx` — 9 Vitest cases covering render, add/remove rows, label override, token picker empty state.

### Config

- `vitest.config.ts` — added `env: { NODE_ENV: 'test' }` to the `workflows` project to prevent React production build from loading in `vmForks` pool on Windows.

## Test results

- Backend: 20/20 ✅
- Frontend: 34/34 ✅ (25 upstreamTokens + 9 FieldMappingPanel)
- Build: ✅
- Full pre-push suite: ✅

## Notes

- `pabbly_webhook` node retains its existing `{key, source_value}` body mapping UI — it maps outbound HTTP body keys rather than entity fields, so `FieldMappingPanel` with `ENTITY_SCHEMAS` would be incorrect there.
- The 6 `no-case-declarations` lint warnings in `WorkflowBuilder.jsx` (lines ~561–584) are pre-existing in `generateNodeOutputPreview` and not introduced by this PR.
