### PR TITLE
 feat: workflow field mapping + AI campaign integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ Instructions.txt
 Aider-Codex Orchestration.md
 
 .aider*
+
+# Session fix scripts and temp files
+fix_*.py
+tmp/

--- a/backend/__tests__/routes/workflows.resolveMapping.test.js
+++ b/backend/__tests__/routes/workflows.resolveMapping.test.js
@@ -1,0 +1,285 @@
+/**
+ * workflows.resolveMapping.test.js
+ *
+ * Unit tests for the resolveMapping helper and the create_activity
+ * field_mappings execution logic inside the workflow executor.
+ *
+ * These tests extract and exercise the pure logic without a DB or HTTP layer.
+ *
+ * Run:
+ *   docker compose exec backend node --test \
+ *     backend/__tests__/routes/workflows.resolveMapping.test.js
+ *
+ * Coverage:
+ *  resolveMapping — new unified shape  { target_field, source_value }
+ *  resolveMapping — legacy lead shape  { lead_field, webhook_field }
+ *  resolveMapping — legacy contact shape { contact_field, webhook_field }
+ *  resolveMapping — dotted source_value resolves via context.variables
+ *  resolveMapping — returns null for unrecognised / empty mapping
+ *  resolveMapping — unresolved template is returned as-is (not stripped)
+ *  create_activity field resolution — subject, body, status, due_date, assigned_to
+ *  create_activity association — auto-detect from context
+ *  create_activity association — explicit entity override
+ *  create_activity association — field_mappings override related_to / related_id
+ *  backward compat — legacy cfg.title / cfg.details still work when no field_mappings
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+// ─── Inline the logic under test ────────────────────────────────────────────
+// We inline rather than import from workflows.js because the file is an
+// Express route factory (requires pgPool, Redis, etc.) and we want pure unit
+// tests with no side-effects.
+
+function buildExecutor(payload = {}, variables = {}) {
+  const context = { payload, variables };
+
+  function replaceVariables(template) {
+    if (typeof template !== 'string') return template;
+    return template.replace(/\{\{([^}]+)\}\}/g, (match, variable) => {
+      const trimmed = String(variable).trim();
+      if (context.payload && context.payload[trimmed] !== undefined)
+        return context.payload[trimmed];
+      const parts = trimmed.split('.');
+      if (parts.length > 1) {
+        let value = context.variables[parts[0]];
+        for (let i = 1; i < parts.length; i++) {
+          if (value && value[parts[i]] !== undefined) value = value[parts[i]];
+          else { value = undefined; break; }
+        }
+        if (value !== undefined) return value;
+      } else if (context.variables && context.variables[trimmed] !== undefined) {
+        return context.variables[trimmed];
+      }
+      return match;
+    });
+  }
+
+  function resolveMapping(m) {
+    if (m.target_field) {
+      const targetField = m.target_field;
+      const raw = m.source_value || '';
+      const template = raw.startsWith('{{') ? raw : raw ? `{{${raw}}}` : '';
+      const resolved = template ? replaceVariables(template) : '';
+      return { targetField, resolved };
+    }
+    if (m.lead_field && m.webhook_field) {
+      const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+      return { targetField: m.lead_field, resolved };
+    }
+    if (m.contact_field && m.webhook_field) {
+      const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+      return { targetField: m.contact_field, resolved };
+    }
+    return null;
+  }
+
+  /**
+   * Mirrors the create_activity field resolution logic from the executor.
+   * Returns the resolved fields object (does NOT hit DB).
+   */
+  function resolveActivityFields(cfg) {
+    const fieldMappings = cfg.field_mappings || [];
+    const resolvedFields = {};
+    for (const m of fieldMappings) {
+      const rm = resolveMapping(m);
+      if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+        resolvedFields[rm.targetField] = rm.resolved;
+      }
+    }
+    const subject = resolvedFields.subject || replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
+    const body = resolvedFields.body || replaceVariables(cfg.details || cfg.description || '');
+    const status = resolvedFields.status || 'scheduled';
+    const due_date = resolvedFields.due_date || null;
+    const assigned_to = resolvedFields.assigned_to || null;
+
+    const lead = context.variables.found_lead;
+    const contact = context.variables.found_contact;
+    const account = context.variables.found_account;
+    const opportunity = context.variables.found_opportunity;
+
+    const associate = cfg.associate || 'auto';
+    let related_to = null;
+    let related_id = null;
+    if (associate === 'auto') {
+      related_to = lead ? 'lead' : contact ? 'contact' : account ? 'account' : opportunity ? 'opportunity' : null;
+      related_id = lead ? lead.id : contact ? contact.id : account ? account.id : opportunity ? opportunity.id : null;
+    } else {
+      const entityMap = { lead, contact, account, opportunity };
+      const entity = entityMap[associate];
+      if (entity) { related_to = associate; related_id = entity.id; }
+    }
+    if (resolvedFields.related_to) related_to = resolvedFields.related_to;
+    if (resolvedFields.related_id) related_id = resolvedFields.related_id;
+
+    return { subject, body, status, due_date, assigned_to, related_to, related_id };
+  }
+
+  return { resolveMapping, resolveActivityFields };
+}
+
+// ─── resolveMapping tests ───────────────────────────────────────────────────
+
+describe('resolveMapping', () => {
+  it('new shape: resolves source_value token from payload', () => {
+    const { resolveMapping } = buildExecutor({ email: 'jane@example.com' });
+    const result = resolveMapping({ target_field: 'email', source_type: 'token', source_value: 'email' });
+    assert.deepEqual(result, { targetField: 'email', resolved: 'jane@example.com' });
+  });
+
+  it('new shape: resolves dotted source_value from context.variables', () => {
+    const { resolveMapping } = buildExecutor({}, { found_lead: { email: 'lead@example.com' } });
+    const result = resolveMapping({ target_field: 'email', source_type: 'token', source_value: 'found_lead.email' });
+    assert.deepEqual(result, { targetField: 'email', resolved: 'lead@example.com' });
+  });
+
+  it('new shape: source_value already wrapped in {{ }} is resolved correctly', () => {
+    const { resolveMapping } = buildExecutor({ company: 'Acme' });
+    const result = resolveMapping({ target_field: 'company', source_value: '{{company}}' });
+    assert.deepEqual(result, { targetField: 'company', resolved: 'Acme' });
+  });
+
+  it('new shape: unresolved token is returned as template string (not empty)', () => {
+    const { resolveMapping } = buildExecutor({});
+    const result = resolveMapping({ target_field: 'email', source_value: 'missing_field' });
+    // replaceVariables returns the original {{missing_field}} when not found
+    assert.equal(result.targetField, 'email');
+    assert.equal(result.resolved, '{{missing_field}}');
+  });
+
+  it('new shape: empty source_value returns empty resolved string', () => {
+    const { resolveMapping } = buildExecutor({ email: 'x@y.com' });
+    const result = resolveMapping({ target_field: 'email', source_value: '' });
+    assert.deepEqual(result, { targetField: 'email', resolved: '' });
+  });
+
+  it('legacy lead shape: resolves via lead_field + webhook_field', () => {
+    const { resolveMapping } = buildExecutor({ first_name: 'Jane' });
+    const result = resolveMapping({ lead_field: 'first_name', webhook_field: 'first_name' });
+    assert.deepEqual(result, { targetField: 'first_name', resolved: 'Jane' });
+  });
+
+  it('legacy contact shape: resolves via contact_field + webhook_field', () => {
+    const { resolveMapping } = buildExecutor({ phone: '555-1234' });
+    const result = resolveMapping({ contact_field: 'phone', webhook_field: 'phone' });
+    assert.deepEqual(result, { targetField: 'phone', resolved: '555-1234' });
+  });
+
+  it('returns null for empty object', () => {
+    const { resolveMapping } = buildExecutor();
+    assert.equal(resolveMapping({}), null);
+  });
+
+  it('returns null for mapping with only source_value and no target_field', () => {
+    const { resolveMapping } = buildExecutor({ email: 'x@y.com' });
+    assert.equal(resolveMapping({ source_value: 'email' }), null);
+  });
+});
+
+// ─── create_activity field resolution ──────────────────────────────────────
+
+describe('create_activity field resolution', () => {
+  it('resolves subject and body from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ subject_val: 'Follow up', body_val: 'Hello' });
+    const result = resolveActivityFields({
+      type: 'task',
+      field_mappings: [
+        { target_field: 'subject', source_value: 'subject_val' },
+        { target_field: 'body', source_value: 'body_val' },
+      ],
+    });
+    assert.equal(result.subject, 'Follow up');
+    assert.equal(result.body, 'Hello');
+  });
+
+  it('resolves status from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ s: 'completed' });
+    const result = resolveActivityFields({
+      field_mappings: [{ target_field: 'status', source_value: 's' }],
+    });
+    assert.equal(result.status, 'completed');
+  });
+
+  it('resolves due_date and assigned_to from field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor({ d: '2026-06-01', u: 'user-uuid-123' });
+    const result = resolveActivityFields({
+      field_mappings: [
+        { target_field: 'due_date', source_value: 'd' },
+        { target_field: 'assigned_to', source_value: 'u' },
+      ],
+    });
+    assert.equal(result.due_date, '2026-06-01');
+    assert.equal(result.assigned_to, 'user-uuid-123');
+  });
+
+  it('falls back to legacy cfg.title and cfg.details when no field_mappings', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ title: 'Legacy title', details: 'Legacy body' });
+    assert.equal(result.subject, 'Legacy title');
+    assert.equal(result.body, 'Legacy body');
+  });
+
+  it('falls back to default subject when neither field_mappings nor cfg.title set', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({});
+    assert.equal(result.subject, 'Workflow activity');
+  });
+
+  it('defaults status to "scheduled" when not mapped', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ field_mappings: [] });
+    assert.equal(result.status, 'scheduled');
+  });
+
+  it('auto-detect association: picks found_lead when present', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_lead: { id: 'lead-1' },
+    });
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, 'lead');
+    assert.equal(result.related_id, 'lead-1');
+  });
+
+  it('auto-detect association: falls back to found_contact when no lead', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_contact: { id: 'contact-1' },
+    });
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, 'contact');
+    assert.equal(result.related_id, 'contact-1');
+  });
+
+  it('explicit association: uses specified entity type', () => {
+    const { resolveActivityFields } = buildExecutor({}, {
+      found_lead: { id: 'lead-1' },
+      found_contact: { id: 'contact-1' },
+    });
+    const result = resolveActivityFields({ associate: 'contact', field_mappings: [] });
+    assert.equal(result.related_to, 'contact');
+    assert.equal(result.related_id, 'contact-1');
+  });
+
+  it('field_mappings related_to / related_id override auto-detect', () => {
+    const { resolveActivityFields } = buildExecutor(
+      { custom_entity: 'opportunity', custom_id: 'opp-99' },
+      { found_lead: { id: 'lead-1' } },
+    );
+    const result = resolveActivityFields({
+      associate: 'auto',
+      field_mappings: [
+        { target_field: 'related_to', source_value: 'custom_entity' },
+        { target_field: 'related_id', source_value: 'custom_id' },
+      ],
+    });
+    assert.equal(result.related_to, 'opportunity');
+    assert.equal(result.related_id, 'opp-99');
+  });
+
+  it('returns null related_to / related_id when no entity in context and associate=auto', () => {
+    const { resolveActivityFields } = buildExecutor();
+    const result = resolveActivityFields({ associate: 'auto', field_mappings: [] });
+    assert.equal(result.related_to, null);
+    assert.equal(result.related_id, null);
+  });
+});

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -11,25 +11,25 @@
 
 import { emitTenantWebhooks } from './webhookEmitter.js';
 import logger from './logger.js';
+import { getSupabaseClient, query as supabaseSqlQuery } from './supabase-db.js';
 
 let workerInterval = null;
-let pgPool = null;
+let supabase = null;
+const webhookDb = { query: supabaseSqlQuery };
 const TARGET_BATCH_SIZE = Number(process.env.CAMPAIGN_WORKER_TARGET_BATCH_SIZE || 25);
 
 /**
  * Initialize and start the campaign worker
  */
 export function startCampaignWorker(pool, intervalMs = 30000) {
-  if (!pool) {
-    logger.warn('[CampaignWorker] No database pool provided - worker disabled');
-    return;
+  if (pool) {
+    logger.debug('[CampaignWorker] Ignoring pgPool input; using Supabase client');
   }
-
-  pgPool = pool;
-  const enabled = process.env.CAMPAIGN_WORKER_ENABLED === 'true';
+  supabase = getSupabaseClient();
+  const enabled = process.env.CAMPAIGN_WORKER_ENABLED !== 'false';
 
   if (!enabled) {
-    logger.info('[CampaignWorker] Disabled (CAMPAIGN_WORKER_ENABLED not true)');
+    logger.info('[CampaignWorker] Disabled (CAMPAIGN_WORKER_ENABLED=false)');
     return;
   }
 
@@ -63,39 +63,40 @@ export function stopCampaignWorker() {
  * Main processing loop - finds and executes scheduled campaigns
  */
 async function processPendingCampaigns() {
-  if (!pgPool) return;
+  if (!supabase) return;
 
   try {
     // Phase A: pickup due scheduled campaigns
-    const scheduledQuery = `
-      SELECT id, tenant_id, name, metadata, campaign_type, status
-      FROM ai_campaign
-      WHERE status = 'scheduled'
-        AND (
-          (metadata->'schedule'->>'scheduled_at') IS NULL
-          OR (metadata->'schedule'->>'scheduled_at') = ''
-          OR (metadata->'schedule'->>'scheduled_at')::timestamptz <= NOW()
-        )
-      ORDER BY created_at ASC
-      LIMIT 10
-    `;
+    const { data: scheduledCampaigns, error: scheduledErr } = await supabase
+      .from('ai_campaign')
+      .select('id, tenant_id, name, metadata, campaign_type, status, workflow_id, created_at')
+      .eq('status', 'scheduled')
+      .order('created_at', { ascending: true })
+      .limit(10);
+    if (scheduledErr) throw scheduledErr;
 
-    const scheduledResult = await pgPool.query(scheduledQuery);
-    for (const campaign of scheduledResult.rows) {
+    const dueScheduled = (scheduledCampaigns || []).filter(isScheduledDue);
+    for (const campaign of dueScheduled) {
       await processCampaign(campaign);
     }
 
     // Phase B: process running campaigns
-    const runningQuery = `
-      SELECT id, tenant_id, name, metadata, campaign_type, status
-      FROM ai_campaign
-      WHERE status = 'running'
-      ORDER BY updated_at ASC
-      LIMIT 10
-    `;
+    const { data: runningCampaigns, error: runningErr } = await supabase
+      .from('ai_campaign')
+      .select('id, tenant_id, name, metadata, campaign_type, status, workflow_id, updated_at')
+      .eq('status', 'running')
+      .order('updated_at', { ascending: true })
+      .limit(10);
+    if (runningErr) throw runningErr;
 
-    const runningResult = await pgPool.query(runningQuery);
-    for (const campaign of runningResult.rows) {
+    logger.info(
+      {
+        scheduledDue: dueScheduled.length,
+        runningActive: (runningCampaigns || []).length,
+      },
+      '[CampaignWorker] Tick',
+    );
+    for (const campaign of runningCampaigns || []) {
       await processCampaign(campaign);
     }
   } catch (err) {
@@ -104,27 +105,12 @@ async function processPendingCampaigns() {
 }
 
 /**
- * Process a single campaign with advisory locking
+ * Process a single campaign
  */
 async function processCampaign(campaign) {
   const { id, tenant_id, name } = campaign;
 
-  // Advisory lock ID (hash campaign ID to int)
-  const lockId = hashStringToInt(id);
-
-  let client = null;
   try {
-    // Get a dedicated client for this transaction
-    client = await pgPool.connect();
-
-    // Try to acquire advisory lock (non-blocking)
-    const lockResult = await client.query('SELECT pg_try_advisory_lock($1) as locked', [lockId]);
-
-    if (!lockResult.rows[0].locked) {
-      // Another worker is processing this campaign
-      return;
-    }
-
     logger.info(
       { campaignId: id, name, status: campaign.status },
       '[CampaignWorker] Processing campaign',
@@ -132,45 +118,36 @@ async function processCampaign(campaign) {
 
     let campaignRow = campaign;
     if (campaign.status === 'scheduled') {
-      const startedRow = await transitionScheduledCampaignToRunning(client, campaign);
+      const startedRow = await transitionScheduledCampaignToRunning(campaign);
       if (!startedRow) return;
       campaignRow = startedRow;
     }
 
     if (campaignRow.status !== 'running') return;
 
-    await processRunningCampaignBatch(client, campaignRow);
+    await processRunningCampaignBatch(campaignRow);
   } catch (err) {
     logger.error({ err, campaignId: id }, '[CampaignWorker] Error processing campaign');
 
     // Mark as failed
-    if (client) {
-      try {
-        await client.query(
-          `
-          UPDATE ai_campaign
-          SET status = 'failed',
-              metadata = jsonb_set(
-                jsonb_set(metadata, '{lifecycle,failed_at}', to_jsonb(NOW()::text)),
-                '{error}', to_jsonb($1::text)
-              )
-          WHERE id = $2 AND tenant_id = $3
-        `,
-          [err.message, id, tenant_id],
-        );
-      } catch (updateErr) {
-        logger.error({ err: updateErr }, '[CampaignWorker] Failed to update error status');
-      }
-    }
-  } finally {
-    // Release advisory lock
-    if (client) {
-      try {
-        await client.query('SELECT pg_advisory_unlock($1)', [lockId]);
-      } catch (unlockErr) {
-        logger.error({ err: unlockErr }, '[CampaignWorker] Failed to release lock');
-      }
-      client.release();
+    try {
+      const metadataObj = toObject(campaign.metadata);
+      metadataObj.lifecycle = toObject(metadataObj.lifecycle);
+      metadataObj.lifecycle.failed_at = new Date().toISOString();
+      metadataObj.error = err.message;
+
+      const { error: updateErr } = await supabase
+        .from('ai_campaign')
+        .update({
+          status: 'failed',
+          metadata: metadataObj,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', id)
+        .eq('tenant_id', tenant_id);
+      if (updateErr) throw updateErr;
+    } catch (updateErr) {
+      logger.error({ err: updateErr }, '[CampaignWorker] Failed to update error status');
     }
   }
 }
@@ -178,35 +155,29 @@ async function processCampaign(campaign) {
 /**
  * Transition due scheduled campaign to running and emit start event.
  */
-async function transitionScheduledCampaignToRunning(client, campaign) {
+async function transitionScheduledCampaignToRunning(campaign) {
   const { id, tenant_id } = campaign;
-  const updateResult = await client.query(
-    `
-    UPDATE ai_campaign
-    SET status = 'running',
-        metadata = jsonb_set(
-          COALESCE(metadata, '{}'::jsonb),
-          '{lifecycle,started_at}',
-          to_jsonb(NOW()::text),
-          true
-        ),
-        updated_at = NOW()
-    WHERE id = $1
-      AND tenant_id = $2
-      AND status = 'scheduled'
-      AND (
-        (metadata->'schedule'->>'scheduled_at') IS NULL
-        OR (metadata->'schedule'->>'scheduled_at') = ''
-        OR (metadata->'schedule'->>'scheduled_at')::timestamptz <= NOW()
-      )
-    RETURNING *
-  `,
-    [id, tenant_id],
-  );
+  if (!isScheduledDue(campaign)) return null;
 
-  if (updateResult.rows.length === 0) return null;
+  const metadataObj = toObject(campaign.metadata);
+  metadataObj.lifecycle = toObject(metadataObj.lifecycle);
+  metadataObj.lifecycle.started_at = new Date().toISOString();
 
-  await insertCampaignEvent(client, {
+  const { data: updatedRows, error: updateErr } = await supabase
+    .from('ai_campaign')
+    .update({
+      status: 'running',
+      metadata: metadataObj,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', id)
+    .eq('tenant_id', tenant_id)
+    .eq('status', 'scheduled')
+    .select('*');
+  if (updateErr) throw updateErr;
+  if (!updatedRows || updatedRows.length === 0) return null;
+
+  await insertCampaignEvent({
     tenant_id,
     campaign_id: id,
     contact_id: null,
@@ -214,46 +185,62 @@ async function transitionScheduledCampaignToRunning(client, campaign) {
     event_type: 'campaign_started',
     attempt_no: 0,
     payload: {
-      campaign_type: updateResult.rows[0].campaign_type || 'call',
+      campaign_type: updatedRows[0].campaign_type || 'call',
     },
   });
 
-  return updateResult.rows[0];
+  return updatedRows[0];
 }
 
 /**
  * Process a single batch of running campaign targets.
  */
-async function processRunningCampaignBatch(client, campaign) {
-  const targets = await claimPendingTargets(client, campaign, TARGET_BATCH_SIZE);
+async function processRunningCampaignBatch(campaign) {
+  const targets = await claimPendingTargets(campaign, TARGET_BATCH_SIZE);
+  logger.info(
+    {
+      campaignId: campaign.id,
+      claimedTargets: targets.length,
+      batchSize: TARGET_BATCH_SIZE,
+    },
+    '[CampaignWorker] Batch claim',
+  );
 
   if (targets.length > 0) {
-    let deliveryContext = null;
-    try {
-      deliveryContext = await getDeliveryContext(client, campaign);
-    } catch (err) {
-      deliveryContext = { type: 'error', error: err.message };
-    }
-
     for (const target of targets) {
-      if (deliveryContext?.type === 'error') {
-        await markTargetFailed(client, campaign, target, deliveryContext.error);
-        continue;
-      }
-
       try {
-        await deliverTarget(client, campaign, target, deliveryContext);
-        await markTargetCompleted(client, campaign, target);
+        await Promise.race([
+          dispatchViaWorkflow(campaign, target),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('Execution timeout')), 15000),
+          ),
+        ]);
+
+        await markTargetCompleted(campaign, target);
       } catch (err) {
-        await markTargetFailed(client, campaign, target, err.message || 'Unknown target error');
+        console.error('Target execution error:', err);
+        try {
+          await markTargetFailed(campaign, target, err.message || 'Execution failed');
+        } catch (markErr) {
+          console.error('Target failure update error:', markErr);
+          await supabase
+            .from('ai_campaign_targets')
+            .update({
+              status: 'failed',
+              error_message: err.message || 'Execution failed',
+              completed_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            })
+            .eq('id', target.id);
+        }
       }
     }
   }
 
-  const progress = await computeCampaignProgress(client, campaign.id, campaign.tenant_id);
-  await updateCampaignProgress(client, campaign, progress);
+  const progress = await computeCampaignProgress(campaign.id, campaign.tenant_id);
+  await updateCampaignProgress(campaign, progress);
 
-  await emitTenantWebhooks(pgPool, campaign.tenant_id, 'aicampaign.progress', {
+  await emitTenantWebhooks(webhookDb, campaign.tenant_id, 'aicampaign.progress', {
     id: campaign.id,
     status: progress.pending === 0 && progress.processing === 0 ? 'completed' : 'running',
     progress,
@@ -263,39 +250,119 @@ async function processRunningCampaignBatch(client, campaign) {
 /**
  * Claim pending targets for processing using row locks.
  */
-async function claimPendingTargets(client, campaign, batchSize) {
-  const result = await client.query(
-    `
-    WITH to_claim AS (
-      SELECT id
-      FROM ai_campaign_targets
-      WHERE tenant_id = $1
-        AND campaign_id = $2
-        AND status = 'pending'
-      ORDER BY created_at ASC
-      FOR UPDATE SKIP LOCKED
-      LIMIT $3
-    )
-    UPDATE ai_campaign_targets t
-    SET status = 'processing',
-        started_at = NOW(),
-        attempt_count = COALESCE(t.attempt_count, 0) + 1,
-        last_attempt_at = NOW(),
-        updated_at = NOW()
-    FROM to_claim
-    WHERE t.id = to_claim.id
-    RETURNING t.*
-  `,
-    [campaign.tenant_id, campaign.id, batchSize],
-  );
-  return result.rows;
+async function claimPendingTargets(campaign, batchSize) {
+  const { data: pendingTargets, error: pendingErr } = await supabase
+    .from('ai_campaign_targets')
+    .select('*')
+    .eq('tenant_id', campaign.tenant_id)
+    .eq('campaign_id', campaign.id)
+    .eq('status', 'pending')
+    .order('created_at', { ascending: true })
+    .limit(batchSize);
+  if (pendingErr) throw pendingErr;
+
+  const claimed = [];
+  const now = new Date().toISOString();
+  for (const target of pendingTargets || []) {
+    const { data: updatedRows, error: updateErr } = await supabase
+      .from('ai_campaign_targets')
+      .update({
+        status: 'processing',
+        started_at: now,
+        attempt_count: Number(target.attempt_count || 0) + 1,
+        last_attempt_at: now,
+        updated_at: now,
+      })
+      .eq('id', target.id)
+      .eq('tenant_id', campaign.tenant_id)
+      .eq('campaign_id', campaign.id)
+      .eq('status', 'pending')
+      .select('*');
+    if (updateErr) throw updateErr;
+    if (updatedRows && updatedRows.length > 0) {
+      claimed.push(updatedRows[0]);
+    }
+  }
+
+  return claimed;
+}
+
+/**
+ * Dispatch a single campaign target via the campaign's linked workflow webhook.
+ */
+async function dispatchViaWorkflow(campaign, target) {
+  if (!campaign.workflow_id) {
+    throw new Error('No workflow configured');
+  }
+
+  const { data: workflow, error: workflowErr } = await supabase
+    .from('workflow')
+    .select('id, metadata')
+    .eq('id', campaign.workflow_id)
+    .maybeSingle();
+  if (workflowErr) throw workflowErr;
+
+  console.log('Workflow object:', workflow);
+  let webhookUrl = workflow?.metadata?.webhook_url;
+  if (!webhookUrl) {
+    throw new Error('No webhook URL configured');
+  }
+  // Resolve relative URLs — workflow saves path-only URLs like /api/workflows/:id/webhook
+  if (webhookUrl.startsWith('/')) {
+    const port = process.env.BACKEND_PORT || process.env.PORT || 3001;
+    webhookUrl = `http://localhost:${port}${webhookUrl}`;
+  }
+
+  const targetPayload =
+    typeof target.target_payload === 'string'
+      ? safeParseJson(target.target_payload, {})
+      : toObject(target.target_payload);
+
+  const campaignMeta = typeof campaign.metadata === 'object' ? campaign.metadata : {};
+  const assignedTo = campaign.assigned_to || campaignMeta.lifecycle?.scheduled_by || null;
+
+  const payload = {
+    event: 'campaign.dispatch',
+    tenant_id: campaign.tenant_id,
+    campaign_id: campaign.id,
+    target_id: target.id,
+    channel: campaign.campaign_type,
+    destination: target.destination,
+    assigned_to: assignedTo,
+    contact: targetPayload,
+    campaign: {
+      name: campaign.name,
+      type: campaign.campaign_type,
+      assigned_to: assignedTo,
+      metadata: campaign.metadata,
+    },
+    idempotency_key: `${campaign.id}-${target.id}`,
+  };
+
+  console.log('Dispatching campaign target', target.id);
+
+  const response = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(14000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    console.log('Webhook failed', target.id, text);
+    throw new Error(`Webhook returned ${response.status}: ${text}`);
+  }
+
+  console.log('Webhook success', target.id);
 }
 
 /**
  * Load tenant-scoped delivery integration configuration.
+ * @deprecated Superseded by dispatchViaWorkflow. Kept for reference.
  */
-async function getDeliveryContext(client, campaign) {
-  const meta = campaign.metadata || {};
+async function getDeliveryContext(campaign) {
+  const meta = toObject(campaign.metadata);
   const type = campaign.campaign_type || meta.campaign_type || 'call';
 
   if (type === 'email') {
@@ -304,18 +371,22 @@ async function getDeliveryContext(client, campaign) {
       throw new Error('No sending profile configured for email campaign');
     }
 
-    const integrationResult = await client.query(
-      'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
-      [campaign.tenant_id, sendingProfileId],
-    );
-    if (integrationResult.rows.length === 0) {
+    const { data: integration, error: integrationErr } = await supabase
+      .from('tenant_integrations')
+      .select('*')
+      .eq('tenant_id', campaign.tenant_id)
+      .eq('id', sendingProfileId)
+      .eq('is_active', true)
+      .maybeSingle();
+    if (integrationErr) throw integrationErr;
+    if (!integration) {
       throw new Error('Sending profile not found or inactive');
     }
 
     return {
       type: 'email',
-      integrationType: integrationResult.rows[0].integration_type,
-      credentials: integrationResult.rows[0].credentials || {},
+      integrationType: integration.integration_type,
+      credentials: integration.credentials || {},
       subject: meta?.ai_email_config?.subject || 'No Subject',
       bodyTemplate: meta?.ai_email_config?.body_template || '',
     };
@@ -327,18 +398,22 @@ async function getDeliveryContext(client, campaign) {
       throw new Error('No call integration configured');
     }
 
-    const integrationResult = await client.query(
-      'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
-      [campaign.tenant_id, callIntegrationId],
-    );
-    if (integrationResult.rows.length === 0) {
+    const { data: integration, error: integrationErr } = await supabase
+      .from('tenant_integrations')
+      .select('*')
+      .eq('tenant_id', campaign.tenant_id)
+      .eq('id', callIntegrationId)
+      .eq('is_active', true)
+      .maybeSingle();
+    if (integrationErr) throw integrationErr;
+    if (!integration) {
       throw new Error('Call integration not found or inactive');
     }
 
     return {
       type: 'call',
-      integrationType: integrationResult.rows[0].integration_type,
-      credentials: integrationResult.rows[0].credentials || {},
+      integrationType: integration.integration_type,
+      credentials: integration.credentials || {},
     };
   }
 
@@ -351,14 +426,17 @@ async function getDeliveryContext(client, campaign) {
 /**
  * Deliver a single target based on campaign type.
  */
-async function deliverTarget(_client, campaign, target, deliveryContext) {
+async function deliverTarget(campaign, target, deliveryContext) {
   const destination = target.destination || null;
   if (!destination) {
     throw new Error('Target destination is missing');
   }
 
-  const payload = target.target_payload || {};
-  const campaignMeta = campaign.metadata || {};
+  const payload =
+    typeof target.target_payload === 'string'
+      ? safeParseJson(target.target_payload, {})
+      : toObject(target.target_payload);
+  const campaignMeta = toObject(campaign.metadata);
 
   if (deliveryContext.type === 'email') {
     const templateInput = {
@@ -395,22 +473,21 @@ async function deliverTarget(_client, campaign, target, deliveryContext) {
 /**
  * Update target as completed and emit event.
  */
-async function markTargetCompleted(client, campaign, target) {
-  await client.query(
-    `
-    UPDATE ai_campaign_targets
-    SET status = 'completed',
-        error_message = NULL,
-        completed_at = NOW(),
-        updated_at = NOW()
-    WHERE id = $1
-      AND tenant_id = $2
-      AND campaign_id = $3
-  `,
-    [target.id, campaign.tenant_id, campaign.id],
-  );
+async function markTargetCompleted(campaign, target) {
+  const { error: updateErr } = await supabase
+    .from('ai_campaign_targets')
+    .update({
+      status: 'completed',
+      error_message: null,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', target.id)
+    .eq('tenant_id', campaign.tenant_id)
+    .eq('campaign_id', campaign.id);
+  if (updateErr) throw updateErr;
 
-  await insertCampaignEvent(client, {
+  await insertCampaignEvent({
     tenant_id: campaign.tenant_id,
     campaign_id: campaign.id,
     contact_id: target.contact_id,
@@ -427,23 +504,22 @@ async function markTargetCompleted(client, campaign, target) {
 /**
  * Update target as failed and emit event.
  */
-async function markTargetFailed(client, campaign, target, errorMessage) {
+async function markTargetFailed(campaign, target, errorMessage) {
   const safeMessage = String(errorMessage || 'Unknown target failure').slice(0, 2000);
-  await client.query(
-    `
-    UPDATE ai_campaign_targets
-    SET status = 'failed',
-        error_message = $4,
-        completed_at = NOW(),
-        updated_at = NOW()
-    WHERE id = $1
-      AND tenant_id = $2
-      AND campaign_id = $3
-  `,
-    [target.id, campaign.tenant_id, campaign.id, safeMessage],
-  );
+  const { error: updateErr } = await supabase
+    .from('ai_campaign_targets')
+    .update({
+      status: 'failed',
+      error_message: safeMessage,
+      completed_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', target.id)
+    .eq('tenant_id', campaign.tenant_id)
+    .eq('campaign_id', campaign.id);
+  if (updateErr) throw updateErr;
 
-  await insertCampaignEvent(client, {
+  await insertCampaignEvent({
     tenant_id: campaign.tenant_id,
     campaign_id: campaign.id,
     contact_id: target.contact_id,
@@ -461,127 +537,97 @@ async function markTargetFailed(client, campaign, target, errorMessage) {
 /**
  * Aggregate target status counts for campaign metadata rollup.
  */
-async function computeCampaignProgress(client, campaignId, tenantId) {
-  const countsResult = await client.query(
-    `
-    SELECT
-      COUNT(*)::int AS total,
-      COUNT(*) FILTER (WHERE status = 'pending')::int AS pending,
-      COUNT(*) FILTER (WHERE status = 'processing')::int AS processing,
-      COUNT(*) FILTER (WHERE status = 'completed')::int AS completed,
-      COUNT(*) FILTER (WHERE status = 'failed')::int AS failed
-    FROM ai_campaign_targets
-    WHERE campaign_id = $1
-      AND tenant_id = $2
-  `,
-    [campaignId, tenantId],
-  );
-  return (
-    countsResult.rows[0] || {
-      total: 0,
-      pending: 0,
-      processing: 0,
-      completed: 0,
-      failed: 0,
-    }
-  );
+async function computeCampaignProgress(campaignId, tenantId) {
+  const { data: rows, error } = await supabase
+    .from('ai_campaign_targets')
+    .select('status')
+    .eq('campaign_id', campaignId)
+    .eq('tenant_id', tenantId);
+  if (error) throw error;
+
+  const progress = { total: 0, pending: 0, processing: 0, completed: 0, failed: 0 };
+  for (const row of rows || []) {
+    progress.total += 1;
+    if (row.status === 'pending') progress.pending += 1;
+    if (row.status === 'processing') progress.processing += 1;
+    if (row.status === 'completed') progress.completed += 1;
+    if (row.status === 'failed') progress.failed += 1;
+  }
+  return progress;
 }
 
 /**
  * Persist progress and mark campaign complete when work is drained.
  */
-async function updateCampaignProgress(client, campaign, progress) {
+async function updateCampaignProgress(campaign, progress) {
   const shouldComplete = Number(progress.pending) === 0 && Number(progress.processing) === 0;
+  const metadataObj = toObject(campaign.metadata);
+  metadataObj.progress = progress;
 
   if (shouldComplete) {
-    const completeResult = await client.query(
-      `
-      UPDATE ai_campaign
-      SET status = 'completed',
-          metadata = jsonb_set(
-            jsonb_set(
-              COALESCE(metadata, '{}'::jsonb),
-              '{progress}',
-              $3::jsonb,
-              true
-            ),
-            '{lifecycle,completed_at}',
-            to_jsonb(NOW()::text),
-            true
-          ),
-          updated_at = NOW()
-      WHERE id = $1
-        AND tenant_id = $2
-        AND status = 'running'
-      RETURNING id
-    `,
-      [campaign.id, campaign.tenant_id, JSON.stringify(progress)],
-    );
+    metadataObj.lifecycle = toObject(metadataObj.lifecycle);
+    // Mark as 'failed' if every target failed and nothing completed
+    const allFailed = Number(progress.failed || 0) > 0 && Number(progress.completed || 0) === 0;
+    const finalStatus = allFailed ? 'failed' : 'completed';
+    metadataObj.lifecycle[`${finalStatus}_at`] = new Date().toISOString();
+    const { data: completedRows, error: completedErr } = await supabase
+      .from('ai_campaign')
+      .update({
+        status: finalStatus,
+        metadata: metadataObj,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', campaign.id)
+      .eq('tenant_id', campaign.tenant_id)
+      .eq('status', 'running')
+      .select('id');
+    if (completedErr) throw completedErr;
 
-    if (completeResult.rows.length > 0) {
-      await insertCampaignEvent(client, {
+    if (completedRows && completedRows.length > 0) {
+      await insertCampaignEvent({
         tenant_id: campaign.tenant_id,
         campaign_id: campaign.id,
         contact_id: null,
-        status: 'completed',
-        event_type: 'campaign_completed',
+        status: finalStatus,
+        event_type: allFailed ? 'campaign_failed' : 'campaign_completed',
         attempt_no: 0,
         payload: { progress },
       });
-      await emitTenantWebhooks(pgPool, campaign.tenant_id, 'aicampaign.completed', {
+      await emitTenantWebhooks(webhookDb, campaign.tenant_id, `aicampaign.${finalStatus}`, {
         id: campaign.id,
-        status: 'completed',
+        status: finalStatus,
         progress,
       }).catch((err) => logger.error({ err }, '[CampaignWorker] Final webhook emission failed'));
     }
     return;
   }
 
-  await client.query(
-    `
-    UPDATE ai_campaign
-    SET metadata = jsonb_set(
-          COALESCE(metadata, '{}'::jsonb),
-          '{progress}',
-          $3::jsonb,
-          true
-        ),
-        updated_at = NOW()
-    WHERE id = $1
-      AND tenant_id = $2
-  `,
-    [campaign.id, campaign.tenant_id, JSON.stringify(progress)],
-  );
+  const { error: updateErr } = await supabase
+    .from('ai_campaign')
+    .update({
+      metadata: metadataObj,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', campaign.id)
+    .eq('tenant_id', campaign.tenant_id);
+  if (updateErr) throw updateErr;
 }
 
 /**
  * Insert campaign execution event row.
  */
-async function insertCampaignEvent(client, event) {
-  await client.query(
-    `
-    INSERT INTO ai_campaign_events (
-      tenant_id,
-      campaign_id,
-      contact_id,
-      status,
-      event_type,
-      attempt_no,
-      payload,
-      created_at
-    )
-    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW())
-  `,
-    [
-      event.tenant_id,
-      event.campaign_id,
-      event.contact_id || null,
-      event.status || 'pending',
-      event.event_type,
-      Number(event.attempt_no || 0),
-      JSON.stringify(event.payload || {}),
-    ],
-  );
+async function insertCampaignEvent(event) {
+  const { error } = await supabase.from('ai_campaign_events').insert({
+    tenant_id: event.tenant_id,
+    campaign_id: event.campaign_id,
+    contact_id: event.contact_id || null,
+    status: event.status || 'pending',
+    event_type: event.event_type,
+    attempt_no: Number(event.attempt_no || 0),
+    payload: event.payload || {},
+    created_at: new Date().toISOString(),
+  });
+  if (error) throw error;
 }
 
 /**
@@ -625,9 +671,8 @@ async function triggerAICall(integrationType, credentials, phone, metadata) {
   let callContext;
   try {
     const { prepareOutboundCall } = await import('./callFlowHandler.js');
-    const { pgPool } = await import('../config/db.js');
 
-    callContext = await prepareOutboundCall(pgPool, {
+    callContext = await prepareOutboundCall(webhookDb, {
       tenant_id,
       contact_id,
       campaign_id,
@@ -755,15 +800,26 @@ function personalizeTemplate(template, contact) {
   return result;
 }
 
-/**
- * Hash string to integer for advisory lock
- */
-function hashStringToInt(str) {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash; // Convert to 32bit integer
+function safeParseJson(raw, fallback = {}) {
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : fallback;
+  } catch {
+    return fallback;
   }
-  return Math.abs(hash);
+}
+
+function toObject(value) {
+  if (value && typeof value === 'object') return value;
+  if (typeof value === 'string') return safeParseJson(value, {});
+  return {};
+}
+
+function isScheduledDue(campaign) {
+  const metadata = toObject(campaign.metadata);
+  const scheduledAt = metadata?.schedule?.scheduled_at;
+  if (!scheduledAt) return true;
+  const scheduledTime = new Date(scheduledAt);
+  if (Number.isNaN(scheduledTime.getTime())) return true;
+  return scheduledTime.getTime() <= Date.now();
 }

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -14,6 +14,7 @@ import logger from './logger.js';
 
 let workerInterval = null;
 let pgPool = null;
+const TARGET_BATCH_SIZE = Number(process.env.CAMPAIGN_WORKER_TARGET_BATCH_SIZE || 25);
 
 /**
  * Initialize and start the campaign worker
@@ -65,27 +66,36 @@ async function processPendingCampaigns() {
   if (!pgPool) return;
 
   try {
-    // Find scheduled campaigns (not yet picked up by any worker)
-    const query = `
-      SELECT id, tenant_id, name, metadata, target_contacts, campaign_type
+    // Phase A: pickup due scheduled campaigns
+    const scheduledQuery = `
+      SELECT id, tenant_id, name, metadata, campaign_type, status
       FROM ai_campaign
       WHERE status = 'scheduled'
-        AND (metadata->'lifecycle'->>'started_at' IS NULL OR metadata->'lifecycle'->>'started_at' = '')
+        AND (
+          (metadata->'schedule'->>'scheduled_at') IS NULL
+          OR (metadata->'schedule'->>'scheduled_at') = ''
+          OR (metadata->'schedule'->>'scheduled_at')::timestamptz <= NOW()
+        )
       ORDER BY created_at ASC
       LIMIT 10
     `;
 
-    const result = await pgPool.query(query);
-
-    if (result.rows.length === 0) {
-      // No work to do
-      return;
+    const scheduledResult = await pgPool.query(scheduledQuery);
+    for (const campaign of scheduledResult.rows) {
+      await processCampaign(campaign);
     }
 
-    logger.debug({ count: result.rows.length }, '[CampaignWorker] Found pending campaigns');
+    // Phase B: process running campaigns
+    const runningQuery = `
+      SELECT id, tenant_id, name, metadata, campaign_type, status
+      FROM ai_campaign
+      WHERE status = 'running'
+      ORDER BY updated_at ASC
+      LIMIT 10
+    `;
 
-    // Process each campaign
-    for (const campaign of result.rows) {
+    const runningResult = await pgPool.query(runningQuery);
+    for (const campaign of runningResult.rows) {
       await processCampaign(campaign);
     }
   } catch (err) {
@@ -115,60 +125,21 @@ async function processCampaign(campaign) {
       return;
     }
 
-    logger.info({ campaignId: id, name }, '[CampaignWorker] Processing campaign');
-
-    // Mark as running and stamp start time
-    await client.query(
-      `
-      UPDATE ai_campaign
-      SET status = 'running',
-          metadata = jsonb_set(
-            jsonb_set(metadata, '{lifecycle,started_at}', to_jsonb(NOW()::text)),
-            '{progress}', '{"total": 0, "processed": 0, "success": 0, "failed": 0}'::jsonb
-          )
-      WHERE id = $1 AND tenant_id = $2
-    `,
-      [id, tenant_id],
+    logger.info(
+      { campaignId: id, name, status: campaign.status },
+      '[CampaignWorker] Processing campaign',
     );
 
-    // Emit progress webhook (started)
-    await emitTenantWebhooks(pgPool, tenant_id, 'aicampaign.progress', {
-      id,
-      status: 'running',
-      progress: { total: 0, processed: 0, success: 0, failed: 0 },
-    }).catch((err) => logger.error({ err }, '[CampaignWorker] Webhook emission failed'));
+    let campaignRow = campaign;
+    if (campaign.status === 'scheduled') {
+      const startedRow = await transitionScheduledCampaignToRunning(client, campaign);
+      if (!startedRow) return;
+      campaignRow = startedRow;
+    }
 
-    // Execute the campaign based on type
-    const result = await executeCampaign(campaign, client);
+    if (campaignRow.status !== 'running') return;
 
-    // Update final status and metrics
-    const finalStatus = result.success ? 'completed' : 'failed';
-    await client.query(
-      `
-      UPDATE ai_campaign
-      SET status = $1,
-          metadata = jsonb_set(
-            jsonb_set(
-              jsonb_set(metadata, '{lifecycle,${finalStatus}_at}', to_jsonb(NOW()::text)),
-              '{progress}', to_jsonb($2::jsonb)
-            ),
-            '{execution_result}', to_jsonb($3::jsonb)
-          )
-      WHERE id = $4 AND tenant_id = $5
-    `,
-      [finalStatus, JSON.stringify(result.progress), JSON.stringify(result.details), id, tenant_id],
-    );
-
-    // Emit final webhook
-    const event = result.success ? 'aicampaign.completed' : 'aicampaign.failed';
-    await emitTenantWebhooks(pgPool, tenant_id, event, {
-      id,
-      status: finalStatus,
-      progress: result.progress,
-      details: result.details,
-    }).catch((err) => logger.error({ err }, '[CampaignWorker] Final webhook emission failed'));
-
-    logger.info({ campaignId: id, finalStatus }, '[CampaignWorker] Campaign finished');
+    await processRunningCampaignBatch(client, campaignRow);
   } catch (err) {
     logger.error({ err, campaignId: id }, '[CampaignWorker] Error processing campaign');
 
@@ -205,164 +176,412 @@ async function processCampaign(campaign) {
 }
 
 /**
- * Execute a campaign based on its type
+ * Transition due scheduled campaign to running and emit start event.
  */
-async function executeCampaign(campaign, client) {
-  const { id: _id, tenant_id: _tenant_id, metadata, target_contacts, campaign_type } = campaign;
+async function transitionScheduledCampaignToRunning(client, campaign) {
+  const { id, tenant_id } = campaign;
+  const updateResult = await client.query(
+    `
+    UPDATE ai_campaign
+    SET status = 'running',
+        metadata = jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{lifecycle,started_at}',
+          to_jsonb(NOW()::text),
+          true
+        ),
+        updated_at = NOW()
+    WHERE id = $1
+      AND tenant_id = $2
+      AND status = 'scheduled'
+      AND (
+        (metadata->'schedule'->>'scheduled_at') IS NULL
+        OR (metadata->'schedule'->>'scheduled_at') = ''
+        OR (metadata->'schedule'->>'scheduled_at')::timestamptz <= NOW()
+      )
+    RETURNING *
+  `,
+    [id, tenant_id],
+  );
 
-  const type = metadata?.campaign_type || campaign_type || 'call';
-  const contacts = Array.isArray(target_contacts) ? target_contacts : [];
+  if (updateResult.rows.length === 0) return null;
 
-  const progress = {
-    total: contacts.length,
-    processed: 0,
-    success: 0,
-    failed: 0,
+  await insertCampaignEvent(client, {
+    tenant_id,
+    campaign_id: id,
+    contact_id: null,
+    status: 'running',
+    event_type: 'campaign_started',
+    attempt_no: 0,
+    payload: {
+      campaign_type: updateResult.rows[0].campaign_type || 'call',
+    },
+  });
+
+  return updateResult.rows[0];
+}
+
+/**
+ * Process a single batch of running campaign targets.
+ */
+async function processRunningCampaignBatch(client, campaign) {
+  const targets = await claimPendingTargets(client, campaign, TARGET_BATCH_SIZE);
+
+  if (targets.length > 0) {
+    let deliveryContext = null;
+    try {
+      deliveryContext = await getDeliveryContext(client, campaign);
+    } catch (err) {
+      deliveryContext = { type: 'error', error: err.message };
+    }
+
+    for (const target of targets) {
+      if (deliveryContext?.type === 'error') {
+        await markTargetFailed(client, campaign, target, deliveryContext.error);
+        continue;
+      }
+
+      try {
+        await deliverTarget(client, campaign, target, deliveryContext);
+        await markTargetCompleted(client, campaign, target);
+      } catch (err) {
+        await markTargetFailed(client, campaign, target, err.message || 'Unknown target error');
+      }
+    }
+  }
+
+  const progress = await computeCampaignProgress(client, campaign.id, campaign.tenant_id);
+  await updateCampaignProgress(client, campaign, progress);
+
+  await emitTenantWebhooks(pgPool, campaign.tenant_id, 'aicampaign.progress', {
+    id: campaign.id,
+    status: progress.pending === 0 && progress.processing === 0 ? 'completed' : 'running',
+    progress,
+  }).catch((err) => logger.error({ err }, '[CampaignWorker] Webhook emission failed'));
+}
+
+/**
+ * Claim pending targets for processing using row locks.
+ */
+async function claimPendingTargets(client, campaign, batchSize) {
+  const result = await client.query(
+    `
+    WITH to_claim AS (
+      SELECT id
+      FROM ai_campaign_targets
+      WHERE tenant_id = $1
+        AND campaign_id = $2
+        AND status = 'pending'
+      ORDER BY created_at ASC
+      FOR UPDATE SKIP LOCKED
+      LIMIT $3
+    )
+    UPDATE ai_campaign_targets t
+    SET status = 'processing',
+        started_at = NOW(),
+        attempt_count = COALESCE(t.attempt_count, 0) + 1,
+        last_attempt_at = NOW(),
+        updated_at = NOW()
+    FROM to_claim
+    WHERE t.id = to_claim.id
+    RETURNING t.*
+  `,
+    [campaign.tenant_id, campaign.id, batchSize],
+  );
+  return result.rows;
+}
+
+/**
+ * Load tenant-scoped delivery integration configuration.
+ */
+async function getDeliveryContext(client, campaign) {
+  const meta = campaign.metadata || {};
+  const type = campaign.campaign_type || meta.campaign_type || 'call';
+
+  if (type === 'email') {
+    const sendingProfileId = meta?.ai_email_config?.sending_profile_id;
+    if (!sendingProfileId) {
+      throw new Error('No sending profile configured for email campaign');
+    }
+
+    const integrationResult = await client.query(
+      'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
+      [campaign.tenant_id, sendingProfileId],
+    );
+    if (integrationResult.rows.length === 0) {
+      throw new Error('Sending profile not found or inactive');
+    }
+
+    return {
+      type: 'email',
+      integrationType: integrationResult.rows[0].integration_type,
+      credentials: integrationResult.rows[0].credentials || {},
+      subject: meta?.ai_email_config?.subject || 'No Subject',
+      bodyTemplate: meta?.ai_email_config?.body_template || '',
+    };
+  }
+
+  if (type === 'call') {
+    const callIntegrationId = meta?.ai_call_integration_id;
+    if (!callIntegrationId) {
+      throw new Error('No call integration configured');
+    }
+
+    const integrationResult = await client.query(
+      'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
+      [campaign.tenant_id, callIntegrationId],
+    );
+    if (integrationResult.rows.length === 0) {
+      throw new Error('Call integration not found or inactive');
+    }
+
+    return {
+      type: 'call',
+      integrationType: integrationResult.rows[0].integration_type,
+      credentials: integrationResult.rows[0].credentials || {},
+    };
+  }
+
+  return {
+    type: 'unsupported',
+    error: 'Unsupported campaign type',
   };
-
-  if (contacts.length === 0) {
-    return {
-      success: true,
-      progress,
-      details: { message: 'No contacts to process' },
-    };
-  }
-
-  // Execute based on type
-  try {
-    if (type === 'email') {
-      await executeEmailCampaign(campaign, contacts, progress, client);
-    } else if (type === 'call') {
-      await executeCallCampaign(campaign, contacts, progress, client);
-    } else {
-      throw new Error(`Unsupported campaign type: ${type}`);
-    }
-
-    return {
-      success: true,
-      progress,
-      details: { message: `Processed ${progress.processed} contacts` },
-    };
-  } catch (err) {
-    return {
-      success: false,
-      progress,
-      details: { error: err.message },
-    };
-  }
 }
 
 /**
- * Execute email campaign
+ * Deliver a single target based on campaign type.
  */
-async function executeEmailCampaign(campaign, contacts, progress, client) {
-  const { id, tenant_id, metadata } = campaign;
-
-  // Get sending profile (email integration)
-  const sendingProfileId = metadata?.ai_email_config?.sending_profile_id;
-  if (!sendingProfileId) {
-    throw new Error('No sending profile configured for email campaign');
+async function deliverTarget(_client, campaign, target, deliveryContext) {
+  const destination = target.destination || null;
+  if (!destination) {
+    throw new Error('Target destination is missing');
   }
 
-  // Load integration credentials (tenant-scoped)
-  const integrationResult = await client.query(
-    'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
-    [tenant_id, sendingProfileId],
-  );
+  const payload = target.target_payload || {};
+  const campaignMeta = campaign.metadata || {};
 
-  if (integrationResult.rows.length === 0) {
-    throw new Error('Sending profile not found or inactive');
+  if (deliveryContext.type === 'email') {
+    const templateInput = {
+      first_name: payload.first_name || payload.contact_name || '',
+      last_name: payload.last_name || '',
+      email: payload.email || destination,
+      phone: payload.phone || '',
+      company: payload.company || '',
+    };
+    const personalizedBody = personalizeTemplate(deliveryContext.bodyTemplate, templateInput);
+    await sendEmail(
+      deliveryContext.integrationType,
+      deliveryContext.credentials,
+      destination,
+      deliveryContext.subject,
+      personalizedBody,
+    );
+    return;
   }
 
-  const integration = integrationResult.rows[0];
-  const credentials = integration.credentials || {};
-
-  // Email template from metadata
-  const subject = metadata?.ai_email_config?.subject || 'No Subject';
-  const bodyTemplate = metadata?.ai_email_config?.body_template || '';
-
-  // Process each contact
-  for (const contact of contacts) {
-    try {
-      // Personalize email body (simple template replace)
-      const personalizedBody = personalizeTemplate(bodyTemplate, contact);
-
-      // Send email based on integration type
-      await sendEmail(
-        integration.integration_type,
-        credentials,
-        contact.email,
-        subject,
-        personalizedBody,
-      );
-
-      progress.success++;
-    } catch (err) {
-      logger.error({ err, email: contact.email }, '[CampaignWorker] Failed to send email');
-      progress.failed++;
-    }
-
-    progress.processed++;
-
-    // Emit progress webhook every 10 contacts
-    if (progress.processed % 10 === 0) {
-      await emitTenantWebhooks(pgPool, tenant_id, 'aicampaign.progress', {
-        id,
-        status: 'running',
-        progress: { ...progress },
-      }).catch(() => {});
-    }
+  if (deliveryContext.type === 'call') {
+    await triggerAICall(deliveryContext.integrationType, deliveryContext.credentials, destination, {
+      ...campaignMeta,
+      tenant_id: campaign.tenant_id,
+      campaign_id: campaign.id,
+      contact_id: target.contact_id,
+    });
+    return;
   }
+
+  throw new Error(deliveryContext.error || 'Unsupported campaign type');
 }
 
 /**
- * Execute AI call campaign
+ * Update target as completed and emit event.
  */
-async function executeCallCampaign(campaign, contacts, progress, client) {
-  const { id, tenant_id, metadata } = campaign;
-
-  // Get call integration
-  const callIntegrationId = metadata?.ai_call_integration_id;
-  if (!callIntegrationId) {
-    throw new Error('No call integration configured');
-  }
-
-  // Load integration credentials (tenant-scoped)
-  const integrationResult = await client.query(
-    'SELECT * FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = true LIMIT 1',
-    [tenant_id, callIntegrationId],
+async function markTargetCompleted(client, campaign, target) {
+  await client.query(
+    `
+    UPDATE ai_campaign_targets
+    SET status = 'completed',
+        error_message = NULL,
+        completed_at = NOW(),
+        updated_at = NOW()
+    WHERE id = $1
+      AND tenant_id = $2
+      AND campaign_id = $3
+  `,
+    [target.id, campaign.tenant_id, campaign.id],
   );
 
-  if (integrationResult.rows.length === 0) {
-    throw new Error('Call integration not found or inactive');
+  await insertCampaignEvent(client, {
+    tenant_id: campaign.tenant_id,
+    campaign_id: campaign.id,
+    contact_id: target.contact_id,
+    status: 'completed',
+    event_type: 'target_completed',
+    attempt_no: target.attempt_count || 0,
+    payload: {
+      target_id: target.id,
+      destination: target.destination || null,
+    },
+  });
+}
+
+/**
+ * Update target as failed and emit event.
+ */
+async function markTargetFailed(client, campaign, target, errorMessage) {
+  const safeMessage = String(errorMessage || 'Unknown target failure').slice(0, 2000);
+  await client.query(
+    `
+    UPDATE ai_campaign_targets
+    SET status = 'failed',
+        error_message = $4,
+        completed_at = NOW(),
+        updated_at = NOW()
+    WHERE id = $1
+      AND tenant_id = $2
+      AND campaign_id = $3
+  `,
+    [target.id, campaign.tenant_id, campaign.id, safeMessage],
+  );
+
+  await insertCampaignEvent(client, {
+    tenant_id: campaign.tenant_id,
+    campaign_id: campaign.id,
+    contact_id: target.contact_id,
+    status: 'failed',
+    event_type: 'target_failed',
+    attempt_no: target.attempt_count || 0,
+    payload: {
+      target_id: target.id,
+      destination: target.destination || null,
+      error_message: safeMessage,
+    },
+  });
+}
+
+/**
+ * Aggregate target status counts for campaign metadata rollup.
+ */
+async function computeCampaignProgress(client, campaignId, tenantId) {
+  const countsResult = await client.query(
+    `
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE status = 'pending')::int AS pending,
+      COUNT(*) FILTER (WHERE status = 'processing')::int AS processing,
+      COUNT(*) FILTER (WHERE status = 'completed')::int AS completed,
+      COUNT(*) FILTER (WHERE status = 'failed')::int AS failed
+    FROM ai_campaign_targets
+    WHERE campaign_id = $1
+      AND tenant_id = $2
+  `,
+    [campaignId, tenantId],
+  );
+  return (
+    countsResult.rows[0] || {
+      total: 0,
+      pending: 0,
+      processing: 0,
+      completed: 0,
+      failed: 0,
+    }
+  );
+}
+
+/**
+ * Persist progress and mark campaign complete when work is drained.
+ */
+async function updateCampaignProgress(client, campaign, progress) {
+  const shouldComplete = Number(progress.pending) === 0 && Number(progress.processing) === 0;
+
+  if (shouldComplete) {
+    const completeResult = await client.query(
+      `
+      UPDATE ai_campaign
+      SET status = 'completed',
+          metadata = jsonb_set(
+            jsonb_set(
+              COALESCE(metadata, '{}'::jsonb),
+              '{progress}',
+              $3::jsonb,
+              true
+            ),
+            '{lifecycle,completed_at}',
+            to_jsonb(NOW()::text),
+            true
+          ),
+          updated_at = NOW()
+      WHERE id = $1
+        AND tenant_id = $2
+        AND status = 'running'
+      RETURNING id
+    `,
+      [campaign.id, campaign.tenant_id, JSON.stringify(progress)],
+    );
+
+    if (completeResult.rows.length > 0) {
+      await insertCampaignEvent(client, {
+        tenant_id: campaign.tenant_id,
+        campaign_id: campaign.id,
+        contact_id: null,
+        status: 'completed',
+        event_type: 'campaign_completed',
+        attempt_no: 0,
+        payload: { progress },
+      });
+      await emitTenantWebhooks(pgPool, campaign.tenant_id, 'aicampaign.completed', {
+        id: campaign.id,
+        status: 'completed',
+        progress,
+      }).catch((err) => logger.error({ err }, '[CampaignWorker] Final webhook emission failed'));
+    }
+    return;
   }
 
-  const integration = integrationResult.rows[0];
-  const credentials = integration.credentials || {};
+  await client.query(
+    `
+    UPDATE ai_campaign
+    SET metadata = jsonb_set(
+          COALESCE(metadata, '{}'::jsonb),
+          '{progress}',
+          $3::jsonb,
+          true
+        ),
+        updated_at = NOW()
+    WHERE id = $1
+      AND tenant_id = $2
+  `,
+    [campaign.id, campaign.tenant_id, JSON.stringify(progress)],
+  );
+}
 
-  // Process each contact
-  for (const contact of contacts) {
-    try {
-      // Trigger AI call via integration
-      await triggerAICall(integration.integration_type, credentials, contact.phone, metadata);
-
-      progress.success++;
-    } catch (err) {
-      logger.error({ err, phone: contact.phone }, '[CampaignWorker] Failed to trigger call');
-      progress.failed++;
-    }
-
-    progress.processed++;
-
-    // Emit progress webhook every 10 contacts
-    if (progress.processed % 10 === 0) {
-      await emitTenantWebhooks(pgPool, tenant_id, 'aicampaign.progress', {
-        id,
-        status: 'running',
-        progress: { ...progress },
-      }).catch(() => {});
-    }
-  }
+/**
+ * Insert campaign execution event row.
+ */
+async function insertCampaignEvent(client, event) {
+  await client.query(
+    `
+    INSERT INTO ai_campaign_events (
+      tenant_id,
+      campaign_id,
+      contact_id,
+      status,
+      event_type,
+      attempt_no,
+      payload,
+      created_at
+    )
+    VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW())
+  `,
+    [
+      event.tenant_id,
+      event.campaign_id,
+      event.contact_id || null,
+      event.status || 'pending',
+      event.event_type,
+      Number(event.attempt_no || 0),
+      JSON.stringify(event.payload || {}),
+    ],
+  );
 }
 
 /**

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -66,13 +66,15 @@ async function processPendingCampaigns() {
   if (!supabase) return;
 
   try {
-    // Phase A: pickup due scheduled campaigns
+    // Phase A: pickup due scheduled campaigns.
+    // Fetch a generous page (50) so that future-dated rows don't starve
+    // due campaigns — isScheduledDue filters client-side after fetch.
     const { data: scheduledCampaigns, error: scheduledErr } = await supabase
       .from('ai_campaign')
       .select('id, tenant_id, name, metadata, campaign_type, status, workflow_id, created_at')
       .eq('status', 'scheduled')
       .order('created_at', { ascending: true })
-      .limit(10);
+      .limit(50);
     if (scheduledErr) throw scheduledErr;
 
     const dueScheduled = (scheduledCampaigns || []).filter(isScheduledDue);
@@ -299,18 +301,23 @@ async function dispatchViaWorkflow(campaign, target) {
     .from('workflow')
     .select('id, metadata')
     .eq('id', campaign.workflow_id)
+    .eq('tenant_id', campaign.tenant_id)
     .maybeSingle();
   if (workflowErr) throw workflowErr;
+  if (!workflow) {
+    throw new Error(`Workflow ${campaign.workflow_id} not found for tenant`);
+  }
 
-  console.log('Workflow object:', workflow);
   let webhookUrl = workflow?.metadata?.webhook_url;
   if (!webhookUrl) {
     throw new Error('No webhook URL configured');
   }
   // Resolve relative URLs — workflow saves path-only URLs like /api/workflows/:id/webhook
   if (webhookUrl.startsWith('/')) {
-    const port = process.env.BACKEND_PORT || process.env.PORT || 3001;
-    webhookUrl = `http://localhost:${port}${webhookUrl}`;
+    const backendUrl =
+      process.env.BACKEND_URL ||
+      `http://localhost:${process.env.BACKEND_PORT || process.env.PORT || 3001}`;
+    webhookUrl = `${backendUrl}${webhookUrl}`;
   }
 
   const targetPayload =
@@ -339,7 +346,7 @@ async function dispatchViaWorkflow(campaign, target) {
     idempotency_key: `${campaign.id}-${target.id}`,
   };
 
-  console.log('Dispatching campaign target', target.id);
+  logger.debug({ target_id: target.id, webhookUrl }, '[CampaignWorker] Dispatching target');
 
   const response = await fetch(webhookUrl, {
     method: 'POST',
@@ -350,11 +357,11 @@ async function dispatchViaWorkflow(campaign, target) {
 
   if (!response.ok) {
     const text = await response.text().catch(() => response.statusText);
-    console.log('Webhook failed', target.id, text);
+    logger.warn({ target_id: target.id, status: response.status }, '[CampaignWorker] Webhook failed');
     throw new Error(`Webhook returned ${response.status}: ${text}`);
   }
 
-  console.log('Webhook success', target.id);
+  logger.info({ target_id: target.id }, '[CampaignWorker] Webhook success');
 }
 
 /**

--- a/backend/lib/campaigns/buildAudienceFromPrompt.js
+++ b/backend/lib/campaigns/buildAudienceFromPrompt.js
@@ -1,0 +1,64 @@
+/**
+ * Phase 1: Parse plain-English audience prompts into normalized filters.
+ */
+
+const TARGET_TYPE_PATTERNS = [
+  { type: 'lead', regex: /\bleads?\b/ },
+  { type: 'source', regex: /\b(source|sources|biz\s*dev|bizdev)\b/ },
+  { type: 'opportunity', regex: /\bopportunit(?:y|ies)\b/ },
+  { type: 'contact', regex: /\bcontacts?\b/ },
+];
+
+const CHANNEL_PATTERNS = [
+  { channel: 'phone', regex: /\b(phone|call|calls|calling|sms|text|voice)\b/ },
+  { channel: 'email', regex: /\b(email|emails|e-mail|mail)\b/ },
+];
+
+function parseInactivityDays(text) {
+  if (!text) return null;
+
+  const dayMatch = text.match(/(\d+)\s*(day|days|d)\b/);
+  if (dayMatch) return Number(dayMatch[1]);
+
+  const weekMatch = text.match(/(\d+)\s*(week|weeks|w)\b/);
+  if (weekMatch) return Number(weekMatch[1]) * 7;
+
+  const monthMatch = text.match(/(\d+)\s*(month|months|mo)\b/);
+  if (monthMatch) return Number(monthMatch[1]) * 30;
+
+  return null;
+}
+
+function parseTargetType(text) {
+  for (const rule of TARGET_TYPE_PATTERNS) {
+    if (rule.regex.test(text)) return rule.type;
+  }
+  return 'contact';
+}
+
+function parseTemperature(text) {
+  if (/\bcold\b/.test(text)) return 'cold';
+  if (/\bwarm\b/.test(text)) return 'warm';
+  if (/\bhot\b/.test(text)) return 'hot';
+  return null;
+}
+
+function parseRequiredChannel(text) {
+  for (const rule of CHANNEL_PATTERNS) {
+    if (rule.regex.test(text)) return rule.channel;
+  }
+  return 'email';
+}
+
+export function buildAudienceFromPrompt(prompt = '') {
+  const text = String(prompt || '').toLowerCase();
+
+  return {
+    target_type: parseTargetType(text),
+    inactivity_days: parseInactivityDays(text),
+    temperature: parseTemperature(text),
+    required_channel: parseRequiredChannel(text),
+  };
+}
+
+export default buildAudienceFromPrompt;

--- a/backend/lib/campaigns/buildAudienceFromPrompt.js
+++ b/backend/lib/campaigns/buildAudienceFromPrompt.js
@@ -17,13 +17,13 @@ const CHANNEL_PATTERNS = [
 function parseInactivityDays(text) {
   if (!text) return null;
 
-  const dayMatch = text.match(/(\d+)\s*(day|days|d)\b/);
+  const dayMatch = text.match(/(\d{1,4}) ?(days?|d)\b/);
   if (dayMatch) return Number(dayMatch[1]);
 
-  const weekMatch = text.match(/(\d+)\s*(week|weeks|w)\b/);
+  const weekMatch = text.match(/(\d{1,4}) ?(weeks?|w)\b/);
   if (weekMatch) return Number(weekMatch[1]) * 7;
 
-  const monthMatch = text.match(/(\d+)\s*(month|months|mo)\b/);
+  const monthMatch = text.match(/(\d{1,4}) ?(months?|mo)\b/);
   if (monthMatch) return Number(monthMatch[1]) * 30;
 
   return null;

--- a/backend/lib/campaigns/resolveAudience.js
+++ b/backend/lib/campaigns/resolveAudience.js
@@ -1,6 +1,9 @@
 /**
  * Phase 1: Resolve audience rows from CRM entities.
+ * Uses Supabase JS client directly — avoids raw SQL subquery limitations.
  */
+
+import { getSupabaseDB } from '../supabaseFactory.js';
 
 function inferRequiredChannel(campaignType) {
   if (campaignType === 'email') return 'email';
@@ -14,99 +17,123 @@ function normalizeTargetType(targetType) {
   return 'contact';
 }
 
-function buildBaseQueryForTarget(targetType) {
-  if (targetType === 'lead') {
-    return `
-      SELECT
-        l.id AS contact_id,
-        TRIM(CONCAT(COALESCE(l.first_name, ''), ' ', COALESCE(l.last_name, ''))) AS contact_name,
-        l.email,
-        l.phone,
-        l.company,
-        COALESCE(to_jsonb(l)->>'status', '') AS status_text,
-        COALESCE((to_jsonb(l)->>'updated_at')::timestamptz, (to_jsonb(l)->>'created_at')::timestamptz) AS last_touched_at
-      FROM leads l
-      WHERE l.tenant_id = $1
-    `;
+async function fetchLeads(supabase, { tenant_id, inactivityDays, temperature, requiredChannel }) {
+  let query = supabase
+    .from('leads')
+    .select('id, first_name, last_name, email, phone, company, status, updated_at, created_at')
+    .eq('tenant_id', tenant_id);
+
+  if (inactivityDays > 0) {
+    const cutoff = new Date(Date.now() - inactivityDays * 86400000).toISOString();
+    query = query.lte('updated_at', cutoff);
+  }
+  if (temperature) {
+    query = query.ilike('status', `%${temperature}%`);
+  }
+  if (requiredChannel === 'phone') {
+    query = query.not('phone', 'is', null);
+  } else {
+    query = query.not('email', 'is', null);
   }
 
-  if (targetType === 'source') {
-    return `
-      SELECT
-        s.id AS contact_id,
-        COALESCE(NULLIF(s.contact_person, ''), s.source_name, s.company_name, 'Unknown') AS contact_name,
-        COALESCE(s.contact_email, s.email) AS email,
-        COALESCE(s.contact_phone, s.phone) AS phone,
-        COALESCE(s.company_name, s.source_name) AS company,
-        COALESCE(to_jsonb(s)->>'status', '') AS status_text,
-        COALESCE((to_jsonb(s)->>'updated_at')::timestamptz, (to_jsonb(s)->>'created_at')::timestamptz) AS last_touched_at
-      FROM bizdev_sources s
-      WHERE s.tenant_id = $1
-    `;
+  const { data, error } = await query.order('updated_at', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data || []).map((r) => ({
+    contact_id: r.id,
+    contact_name: `${r.first_name || ''} ${r.last_name || ''}`.trim() || 'Unknown',
+    email: r.email || null,
+    phone: r.phone || null,
+    company: r.company || null,
+  }));
+}
+
+async function fetchContacts(
+  supabase,
+  { tenant_id, inactivityDays, temperature, requiredChannel },
+) {
+  let query = supabase
+    .from('contacts')
+    .select(
+      'id, first_name, last_name, email, phone, mobile, account_name, status, updated_at, created_at',
+    )
+    .eq('tenant_id', tenant_id);
+
+  if (inactivityDays > 0) {
+    const cutoff = new Date(Date.now() - inactivityDays * 86400000).toISOString();
+    query = query.lte('updated_at', cutoff);
+  }
+  if (temperature) {
+    query = query.ilike('status', `%${temperature}%`);
+  }
+  if (requiredChannel === 'phone') {
+    query = query.not('phone', 'is', null);
+  } else {
+    query = query.not('email', 'is', null);
   }
 
-  return `
-    SELECT
-      c.id AS contact_id,
-      TRIM(CONCAT(COALESCE(c.first_name, ''), ' ', COALESCE(c.last_name, ''))) AS contact_name,
-      c.email,
-      COALESCE(c.phone, c.mobile) AS phone,
-      COALESCE(c.company, a.name, '') AS company,
-      COALESCE(to_jsonb(c)->>'status', '') AS status_text,
-      COALESCE((to_jsonb(c)->>'updated_at')::timestamptz, (to_jsonb(c)->>'created_at')::timestamptz) AS last_touched_at
-    FROM contacts c
-    LEFT JOIN accounts a ON a.id = c.account_id
-    WHERE c.tenant_id = $1
-  `;
+  const { data, error } = await query.order('updated_at', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data || []).map((r) => ({
+    contact_id: r.id,
+    contact_name: `${r.first_name || ''} ${r.last_name || ''}`.trim() || 'Unknown',
+    email: r.email || null,
+    phone: r.phone || r.mobile || null,
+    company: r.account_name || null,
+  }));
+}
+
+async function fetchSources(supabase, { tenant_id, inactivityDays, temperature, requiredChannel }) {
+  let query = supabase
+    .from('bizdev_sources')
+    .select(
+      'id, contact_person, company_name, source, contact_email, email, phone_number, status, updated_at, created_at',
+    )
+    .eq('tenant_id', tenant_id);
+
+  if (inactivityDays > 0) {
+    const cutoff = new Date(Date.now() - inactivityDays * 86400000).toISOString();
+    query = query.lte('updated_at', cutoff);
+  }
+  if (temperature) {
+    query = query.ilike('status', `%${temperature}%`);
+  }
+  if (requiredChannel === 'phone') {
+    query = query.not('phone_number', 'is', null);
+  } else {
+    query = query.or('contact_email.not.is.null,email.not.is.null');
+  }
+
+  const { data, error } = await query.order('updated_at', { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data || []).map((r) => ({
+    contact_id: r.id,
+    contact_name: r.contact_person || r.company_name || r.source || 'Unknown',
+    email: r.contact_email || r.email || null,
+    phone: r.phone_number || null,
+    company: r.company_name || r.source || null,
+  }));
 }
 
 export async function resolveAudience(
-  pgPool,
+  _pgPool,
   { tenant_id, audience = {}, campaignType = 'email' },
 ) {
-  if (!pgPool) throw new Error('pgPool is required');
   if (!tenant_id) throw new Error('tenant_id is required');
 
+  const supabase = getSupabaseDB();
   const targetType = normalizeTargetType(audience.target_type);
   const requiredChannel = audience.required_channel || inferRequiredChannel(campaignType);
   const inactivityDays = Number.isFinite(Number(audience.inactivity_days))
     ? Number(audience.inactivity_days)
-    : null;
+    : 0;
   const temperature = audience.temperature ? String(audience.temperature).toLowerCase() : null;
-
   const effectiveTarget = targetType === 'opportunity' ? 'contact' : targetType;
-  const baseQuery = buildBaseQueryForTarget(effectiveTarget);
 
-  let query = `SELECT * FROM (${baseQuery}) audience_rows WHERE 1=1`;
-  const params = [tenant_id];
+  const opts = { tenant_id, inactivityDays, temperature, requiredChannel };
 
-  if (inactivityDays && inactivityDays > 0) {
-    params.push(inactivityDays);
-    query += `\n AND COALESCE(audience_rows.last_touched_at, NOW()) <= NOW() - ($${params.length}::int * INTERVAL '1 day')`;
-  }
-
-  if (temperature) {
-    params.push(`%${temperature}%`);
-    query += `\n AND audience_rows.status_text ILIKE $${params.length}`;
-  }
-
-  if (requiredChannel === 'phone') {
-    query += `\n AND NULLIF(TRIM(COALESCE(audience_rows.phone, '')), '') IS NOT NULL`;
-  } else {
-    query += `\n AND NULLIF(TRIM(COALESCE(audience_rows.email, '')), '') IS NOT NULL`;
-  }
-
-  query += `\n ORDER BY audience_rows.last_touched_at ASC NULLS FIRST`;
-
-  const result = await pgPool.query(query, params);
-
-  return result.rows.map((row) => ({
-    contact_id: row.contact_id,
-    contact_name: row.contact_name || 'Unknown',
-    email: row.email || null,
-    phone: row.phone || null,
-    company: row.company || null,
-  }));
+  if (effectiveTarget === 'lead') return fetchLeads(supabase, opts);
+  if (effectiveTarget === 'source') return fetchSources(supabase, opts);
+  return fetchContacts(supabase, opts);
 }
 
 export default resolveAudience;

--- a/backend/lib/campaigns/resolveAudience.js
+++ b/backend/lib/campaigns/resolveAudience.js
@@ -1,0 +1,112 @@
+/**
+ * Phase 1: Resolve audience rows from CRM entities.
+ */
+
+function inferRequiredChannel(campaignType) {
+  if (campaignType === 'email') return 'email';
+  return 'phone';
+}
+
+function normalizeTargetType(targetType) {
+  if (targetType === 'lead') return 'lead';
+  if (targetType === 'source') return 'source';
+  if (targetType === 'opportunity') return 'opportunity';
+  return 'contact';
+}
+
+function buildBaseQueryForTarget(targetType) {
+  if (targetType === 'lead') {
+    return `
+      SELECT
+        l.id AS contact_id,
+        TRIM(CONCAT(COALESCE(l.first_name, ''), ' ', COALESCE(l.last_name, ''))) AS contact_name,
+        l.email,
+        l.phone,
+        l.company,
+        COALESCE(to_jsonb(l)->>'status', '') AS status_text,
+        COALESCE((to_jsonb(l)->>'updated_at')::timestamptz, (to_jsonb(l)->>'created_at')::timestamptz) AS last_touched_at
+      FROM leads l
+      WHERE l.tenant_id = $1
+    `;
+  }
+
+  if (targetType === 'source') {
+    return `
+      SELECT
+        s.id AS contact_id,
+        COALESCE(NULLIF(s.contact_person, ''), s.source_name, s.company_name, 'Unknown') AS contact_name,
+        COALESCE(s.contact_email, s.email) AS email,
+        COALESCE(s.contact_phone, s.phone) AS phone,
+        COALESCE(s.company_name, s.source_name) AS company,
+        COALESCE(to_jsonb(s)->>'status', '') AS status_text,
+        COALESCE((to_jsonb(s)->>'updated_at')::timestamptz, (to_jsonb(s)->>'created_at')::timestamptz) AS last_touched_at
+      FROM bizdev_sources s
+      WHERE s.tenant_id = $1
+    `;
+  }
+
+  return `
+    SELECT
+      c.id AS contact_id,
+      TRIM(CONCAT(COALESCE(c.first_name, ''), ' ', COALESCE(c.last_name, ''))) AS contact_name,
+      c.email,
+      COALESCE(c.phone, c.mobile) AS phone,
+      COALESCE(c.company, a.name, '') AS company,
+      COALESCE(to_jsonb(c)->>'status', '') AS status_text,
+      COALESCE((to_jsonb(c)->>'updated_at')::timestamptz, (to_jsonb(c)->>'created_at')::timestamptz) AS last_touched_at
+    FROM contacts c
+    LEFT JOIN accounts a ON a.id = c.account_id
+    WHERE c.tenant_id = $1
+  `;
+}
+
+export async function resolveAudience(
+  pgPool,
+  { tenant_id, audience = {}, campaignType = 'email' },
+) {
+  if (!pgPool) throw new Error('pgPool is required');
+  if (!tenant_id) throw new Error('tenant_id is required');
+
+  const targetType = normalizeTargetType(audience.target_type);
+  const requiredChannel = audience.required_channel || inferRequiredChannel(campaignType);
+  const inactivityDays = Number.isFinite(Number(audience.inactivity_days))
+    ? Number(audience.inactivity_days)
+    : null;
+  const temperature = audience.temperature ? String(audience.temperature).toLowerCase() : null;
+
+  const effectiveTarget = targetType === 'opportunity' ? 'contact' : targetType;
+  const baseQuery = buildBaseQueryForTarget(effectiveTarget);
+
+  let query = `SELECT * FROM (${baseQuery}) audience_rows WHERE 1=1`;
+  const params = [tenant_id];
+
+  if (inactivityDays && inactivityDays > 0) {
+    params.push(inactivityDays);
+    query += `\n AND COALESCE(audience_rows.last_touched_at, NOW()) <= NOW() - ($${params.length}::int * INTERVAL '1 day')`;
+  }
+
+  if (temperature) {
+    params.push(`%${temperature}%`);
+    query += `\n AND audience_rows.status_text ILIKE $${params.length}`;
+  }
+
+  if (requiredChannel === 'phone') {
+    query += `\n AND NULLIF(TRIM(COALESCE(audience_rows.phone, '')), '') IS NOT NULL`;
+  } else {
+    query += `\n AND NULLIF(TRIM(COALESCE(audience_rows.email, '')), '') IS NOT NULL`;
+  }
+
+  query += `\n ORDER BY audience_rows.last_touched_at ASC NULLS FIRST`;
+
+  const result = await pgPool.query(query, params);
+
+  return result.rows.map((row) => ({
+    contact_id: row.contact_id,
+    contact_name: row.contact_name || 'Unknown',
+    email: row.email || null,
+    phone: row.phone || null,
+    company: row.company || null,
+  }));
+}
+
+export default resolveAudience;

--- a/backend/migrations/091_ai_campaign_execution_hardening.sql
+++ b/backend/migrations/091_ai_campaign_execution_hardening.sql
@@ -1,0 +1,52 @@
+-- 091_ai_campaign_execution_hardening.sql
+-- Phase 1 hardening tables for campaign target execution and event audit.
+
+CREATE TABLE IF NOT EXISTS ai_campaign_targets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id TEXT NOT NULL,
+  campaign_id UUID NOT NULL,
+  contact_id UUID NOT NULL,
+  channel TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  destination TEXT,
+  target_payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 3,
+  started_at TIMESTAMPTZ,
+  last_attempt_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  next_attempt_at TIMESTAMPTZ,
+  error_message TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS ai_campaign_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id TEXT NOT NULL,
+  campaign_id UUID NOT NULL,
+  contact_id UUID,
+  status TEXT NOT NULL DEFAULT 'pending',
+  event_type TEXT NOT NULL,
+  attempt_no INTEGER NOT NULL DEFAULT 0,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_campaign_targets_campaign_status
+  ON ai_campaign_targets(campaign_id, status);
+
+ALTER TABLE ai_campaign_targets
+  ADD COLUMN IF NOT EXISTS channel TEXT;
+
+ALTER TABLE ai_campaign_targets
+  ADD COLUMN IF NOT EXISTS destination TEXT;
+
+ALTER TABLE ai_campaign_targets
+  ADD COLUMN IF NOT EXISTS target_payload JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE ai_campaign_targets
+  ADD COLUMN IF NOT EXISTS started_at TIMESTAMPTZ;
+
+ALTER TABLE ai_campaign_targets
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;

--- a/backend/migrations/091_ai_campaign_execution_hardening.sql
+++ b/backend/migrations/091_ai_campaign_execution_hardening.sql
@@ -3,7 +3,7 @@
 
 CREATE TABLE IF NOT EXISTS ai_campaign_targets (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id TEXT NOT NULL,
+  tenant_id UUID NOT NULL,
   campaign_id UUID NOT NULL,
   contact_id UUID NOT NULL,
   channel TEXT,
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS ai_campaign_targets (
 
 CREATE TABLE IF NOT EXISTS ai_campaign_events (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  tenant_id TEXT NOT NULL,
+  tenant_id UUID NOT NULL,
   campaign_id UUID NOT NULL,
   contact_id UUID,
   status TEXT NOT NULL DEFAULT 'pending',

--- a/backend/migrations/150_ai_campaign_workflow_id.sql
+++ b/backend/migrations/150_ai_campaign_workflow_id.sql
@@ -1,0 +1,6 @@
+-- Migration 150: Add workflow_id to ai_campaign for workflow webhook dispatch
+ALTER TABLE ai_campaign
+  ADD COLUMN IF NOT EXISTS workflow_id UUID REFERENCES workflow(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ai_campaign_workflow_id
+  ON ai_campaign(workflow_id) WHERE workflow_id IS NOT NULL;

--- a/backend/migrations/152_fix_campaign_tables_tenant_id_uuid.sql
+++ b/backend/migrations/152_fix_campaign_tables_tenant_id_uuid.sql
@@ -1,0 +1,10 @@
+-- 152_fix_campaign_tables_tenant_id_uuid.sql
+-- Fix: ai_campaign_targets and ai_campaign_events were created with tenant_id TEXT
+-- in migration 091. All tenant_id columns must be UUID to match the rest of the schema.
+-- Both tables are empty so no USING cast data loss risk.
+
+ALTER TABLE ai_campaign_targets
+  ALTER COLUMN tenant_id TYPE UUID USING tenant_id::uuid;
+
+ALTER TABLE ai_campaign_events
+  ALTER COLUMN tenant_id TYPE UUID USING tenant_id::uuid;

--- a/backend/routes/aicampaigns.js
+++ b/backend/routes/aicampaigns.js
@@ -5,6 +5,7 @@ import { validateTenantAccess, enforceEmployeeDataScope } from '../middleware/va
 import { emitTenantWebhooks } from '../lib/webhookEmitter.js';
 import logger from '../lib/logger.js';
 import { resolveAudience } from '../lib/campaigns/resolveAudience.js';
+import { buildAudienceFromPrompt } from '../lib/campaigns/buildAudienceFromPrompt.js';
 
 // Valid campaign types — must match DB CHECK constraint
 const VALID_CAMPAIGN_TYPES = [
@@ -51,9 +52,15 @@ export default function createAICampaignRoutes(pgPool) {
         return res.status(400).json({ status: 'error', message: 'tenant_id is required' });
       }
 
+      // If this is a smart/AI audience segment, parse the prompt into structured filters
+      const audience =
+        target_audience?.type === 'ai_segment' && target_audience?.prompt
+          ? buildAudienceFromPrompt(target_audience.prompt)
+          : target_audience;
+
       const rows = await resolveAudience(pgPool, {
         tenant_id,
-        audience: target_audience,
+        audience,
         campaignType: campaign_type,
       });
 
@@ -130,6 +137,29 @@ export default function createAICampaignRoutes(pgPool) {
     }
   });
 
+  // ─── GET /api/aicampaigns/:id/targets ──────────────────────────────────────
+  router.get('/:id/targets', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { tenant_id } = req.query || {};
+      if (!tenant_id)
+        return res.status(400).json({ status: 'error', message: 'tenant_id is required' });
+
+      const result = await pgPool.query(
+        `SELECT id, contact_id, channel, status, destination, target_payload,
+                error_message, attempt_count, started_at, completed_at, created_at
+         FROM ai_campaign_targets
+         WHERE tenant_id = $1 AND campaign_id = $2
+         ORDER BY created_at ASC`,
+        [tenant_id, id],
+      );
+      res.json({ status: 'success', data: result.rows });
+    } catch (err) {
+      logger.error('[AI Campaigns] Get targets error:', err.message);
+      res.status(500).json({ status: 'error', message: err.message });
+    }
+  });
+
   // ─── GET /api/aicampaigns/:id ───────────────────────────────────────────────
   router.get('/:id', async (req, res) => {
     try {
@@ -167,6 +197,7 @@ export default function createAICampaignRoutes(pgPool) {
         content = {},
         performance_metrics = {},
         metadata = {},
+        workflow_id = null,
         is_test_data = false,
       } = req.body;
 
@@ -184,13 +215,15 @@ export default function createAICampaignRoutes(pgPool) {
 
       const safeAssignedTo = normalizeOptionalUuid(assigned_to);
 
+      const safeWorkflowId = normalizeOptionalUuid(workflow_id);
+
       const query = `
         INSERT INTO ai_campaign (
           tenant_id, name, campaign_type, type, status, description,
           assigned_to, target_contacts, target_audience, content,
-          performance_metrics, metadata, is_test_data, created_at
+          performance_metrics, metadata, workflow_id, is_test_data, created_at
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW())
         RETURNING *
       `;
       const values = [
@@ -206,6 +239,7 @@ export default function createAICampaignRoutes(pgPool) {
         JSON.stringify(content),
         JSON.stringify(performance_metrics),
         JSON.stringify(metadata),
+        safeWorkflowId,
         is_test_data,
       ];
 
@@ -242,6 +276,7 @@ export default function createAICampaignRoutes(pgPool) {
         content,
         performance_metrics,
         metadata,
+        workflow_id,
       } = req.body;
       // Resolve tenant_id consistently: body → query → middleware-resolved tenant
       const tenant_id = body_tenant_id || req.query.tenant_id || req.tenant?.id;
@@ -258,6 +293,7 @@ export default function createAICampaignRoutes(pgPool) {
       }
 
       const safeAssignedTo = normalizeOptionalUuid(assigned_to);
+      const safeWorkflowId = normalizeOptionalUuid(workflow_id);
 
       const update = `
         UPDATE ai_campaign
@@ -272,6 +308,7 @@ export default function createAICampaignRoutes(pgPool) {
             content = COALESCE($10, content),
             performance_metrics = COALESCE($11, performance_metrics),
             metadata = COALESCE($12, metadata),
+            workflow_id = COALESCE($13, workflow_id),
             updated_at = NOW()
         WHERE tenant_id = $1 AND id = $2
         RETURNING *
@@ -289,6 +326,7 @@ export default function createAICampaignRoutes(pgPool) {
         content ? JSON.stringify(content) : null,
         performance_metrics ? JSON.stringify(performance_metrics) : null,
         metadata ? JSON.stringify(metadata) : null,
+        safeWorkflowId,
       ];
       const result = await pgPool.query(update, values);
 
@@ -317,6 +355,9 @@ export default function createAICampaignRoutes(pgPool) {
       if (result.rowCount === 0) {
         return res.status(404).json({ status: 'error', message: 'AI Campaign not found' });
       }
+      // Clean up child rows (no FK cascade on these tables)
+      await pgPool.query('DELETE FROM ai_campaign_targets WHERE campaign_id = $1', [id]);
+      await pgPool.query('DELETE FROM ai_campaign_events WHERE campaign_id = $1', [id]);
       res.json({ status: 'success', data: { id } });
     } catch (err) {
       logger.error('[AI Campaigns] Delete error:', err.message);
@@ -381,32 +422,54 @@ export default function createAICampaignRoutes(pgPool) {
 
       const requiredChannel = cType === 'email' ? 'email' : 'phone';
       let audienceRows = [];
+      let contactsArray = [];
+      if (Array.isArray(campaign.target_contacts)) {
+        contactsArray = campaign.target_contacts;
+      } else if (typeof campaign.target_contacts === 'string') {
+        try {
+          contactsArray = JSON.parse(campaign.target_contacts || '[]');
+        } catch (_e) {
+          contactsArray = [];
+        }
+      }
+      // target_audience may be stored as a JSON string (TEXT column) or already parsed (JSONB)
+      let rawTargetAudience = campaign.target_audience;
+      if (typeof rawTargetAudience === 'string') {
+        try {
+          rawTargetAudience = JSON.parse(rawTargetAudience);
+        } catch (_e) {
+          rawTargetAudience = null;
+        }
+      }
       const target_audience =
-        campaign.target_audience &&
-        typeof campaign.target_audience === 'object' &&
-        !Array.isArray(campaign.target_audience) &&
-        Object.keys(campaign.target_audience).length > 0
-          ? campaign.target_audience
+        rawTargetAudience &&
+        typeof rawTargetAudience === 'object' &&
+        !Array.isArray(rawTargetAudience) &&
+        Object.keys(rawTargetAudience).length > 0
+          ? rawTargetAudience
           : null;
-      const target_contacts = Array.isArray(campaign.target_contacts)
-        ? campaign.target_contacts
-        : [];
 
-      if (target_audience && (!target_contacts || target_contacts.length === 0)) {
+      if (target_audience && contactsArray.length === 0) {
+        // If stored as a smart/AI segment, parse the prompt into structured filters first
+        const resolvedAudience =
+          target_audience?.type === 'ai_segment' && target_audience?.prompt
+            ? buildAudienceFromPrompt(target_audience.prompt)
+            : target_audience;
         audienceRows = await resolveAudience(pgPool, {
           tenant_id,
-          audience: target_audience,
+          audience: resolvedAudience,
           campaignType: cType,
         });
         if (!Array.isArray(audienceRows) || audienceRows.length === 0) {
           return res.status(400).json({ status: 'error', message: 'No audience resolved' });
         }
-      } else if (target_contacts && target_contacts.length > 0) {
-        audienceRows = target_contacts
+      } else if (contactsArray.length > 0) {
+        audienceRows = contactsArray
           .map((item) => {
             if (item && typeof item === 'object') {
               return {
                 contact_id: item.contact_id || item.id || null,
+                entity_type: item.entity_type || 'contact',
                 contact_name: item.contact_name || item.name || null,
                 email: item.email || null,
                 phone: item.phone || null,
@@ -428,7 +491,8 @@ export default function createAICampaignRoutes(pgPool) {
       }
 
       const recipients = audienceRows.filter((row) => {
-        if (!row?.contact_id) return false;
+        const contactId = row?.contact_id ? String(row.contact_id).trim() : '';
+        if (!contactId || !UUID_REGEX.test(contactId)) return false;
         if (requiredChannel === 'email') return Boolean(row.email);
         return Boolean(row.phone);
       });
@@ -453,27 +517,21 @@ export default function createAICampaignRoutes(pgPool) {
             channel,
             status,
             destination,
-            target_payload,
-            created_at,
-            updated_at
+            target_payload
           )
-          VALUES ($1, $2, $3, $4, 'pending', $5, $6::jsonb, NOW(), NOW())
+          VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
         `;
 
         for (const row of uniqueRecipients) {
-          const destination = requiredChannel === 'email' ? row.email : row.phone;
+          const destination = row.email || row.phone;
           await pgPool.query(insertTargetSql, [
             tenant_id,
             id,
             row.contact_id,
-            requiredChannel,
+            campaign.campaign_type || cType,
+            'pending',
             destination,
-            JSON.stringify({
-              contact_name: row.contact_name || null,
-              company: row.company || null,
-              email: row.email || null,
-              phone: row.phone || null,
-            }),
+            JSON.stringify(row),
           ]);
         }
       }
@@ -513,12 +571,14 @@ export default function createAICampaignRoutes(pgPool) {
           attempt_no,
           payload,
           created_at
-        ) VALUES ($1, $2, NULL, $3, $4, 0, $5::jsonb, NOW())`,
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW())`,
         [
           tenant_id,
           id,
+          null,
           nextStatus,
           eventType,
+          0,
           JSON.stringify({
             campaign_type: cType,
             resolved_targets: uniqueRecipients.length,

--- a/backend/routes/aicampaigns.js
+++ b/backend/routes/aicampaigns.js
@@ -4,6 +4,7 @@ import express from 'express';
 import { validateTenantAccess, enforceEmployeeDataScope } from '../middleware/validateTenant.js';
 import { emitTenantWebhooks } from '../lib/webhookEmitter.js';
 import logger from '../lib/logger.js';
+import { resolveAudience } from '../lib/campaigns/resolveAudience.js';
 
 // Valid campaign types — must match DB CHECK constraint
 const VALID_CAMPAIGN_TYPES = [
@@ -41,6 +42,33 @@ export default function createAICampaignRoutes(pgPool) {
   const router = express.Router();
   router.use(validateTenantAccess);
   router.use(enforceEmployeeDataScope);
+
+  // POST /api/aicampaigns/audience-preview
+  router.post('/audience-preview', async (req, res) => {
+    try {
+      const { tenant_id, target_audience = {}, campaign_type = 'email' } = req.body || {};
+      if (!tenant_id) {
+        return res.status(400).json({ status: 'error', message: 'tenant_id is required' });
+      }
+
+      const rows = await resolveAudience(pgPool, {
+        tenant_id,
+        audience: target_audience,
+        campaignType: campaign_type,
+      });
+
+      return res.json({
+        status: 'success',
+        data: {
+          total: rows.length,
+          preview: rows.slice(0, 25),
+        },
+      });
+    } catch (err) {
+      logger.error('[AI Campaigns] Audience preview error:', err.message);
+      return res.status(500).json({ status: 'error', message: err.message });
+    }
+  });
 
   // ─── GET /api/aicampaigns — list with filters + pagination ──────────────────
   router.get('/', async (req, res) => {
@@ -312,12 +340,15 @@ export default function createAICampaignRoutes(pgPool) {
         return res.status(404).json({ status: 'error', message: 'AI Campaign not found' });
       }
       const campaign = getR.rows[0];
-      const meta = campaign.metadata || {};
-      const cType = campaign.campaign_type || meta.campaign_type || 'email';
+      let metadataObj =
+        typeof campaign.metadata === 'object' && campaign.metadata !== null
+          ? campaign.metadata
+          : {};
+      const cType = campaign.campaign_type || metadataObj.campaign_type || 'email';
 
       // Validate integration ownership for channel-specific types
       if (cType === 'email') {
-        const profileId = meta.ai_email_config?.sending_profile_id;
+        const profileId = metadataObj.ai_email_config?.sending_profile_id;
         if (profileId) {
           const profR = await pgPool.query(
             'SELECT id FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = TRUE LIMIT 1',
@@ -331,7 +362,7 @@ export default function createAICampaignRoutes(pgPool) {
           }
         }
       } else if (cType === 'call') {
-        const callId = meta.ai_call_integration_id;
+        const callId = metadataObj.ai_call_integration_id;
         if (callId) {
           const callR = await pgPool.query(
             'SELECT id FROM tenant_integrations WHERE tenant_id = $1 AND id = $2 AND is_active = TRUE LIMIT 1',
@@ -348,26 +379,160 @@ export default function createAICampaignRoutes(pgPool) {
       // Other types (sms, linkedin, whatsapp, api_connector, social_post)
       // will validate their own integrations when delivery adapters are built
 
+      const requiredChannel = cType === 'email' ? 'email' : 'phone';
+      let audienceRows = [];
+      const target_audience =
+        campaign.target_audience &&
+        typeof campaign.target_audience === 'object' &&
+        !Array.isArray(campaign.target_audience) &&
+        Object.keys(campaign.target_audience).length > 0
+          ? campaign.target_audience
+          : null;
+      const target_contacts = Array.isArray(campaign.target_contacts)
+        ? campaign.target_contacts
+        : [];
+
+      if (target_audience && (!target_contacts || target_contacts.length === 0)) {
+        audienceRows = await resolveAudience(pgPool, {
+          tenant_id,
+          audience: target_audience,
+          campaignType: cType,
+        });
+        if (!Array.isArray(audienceRows) || audienceRows.length === 0) {
+          return res.status(400).json({ status: 'error', message: 'No audience resolved' });
+        }
+      } else if (target_contacts && target_contacts.length > 0) {
+        audienceRows = target_contacts
+          .map((item) => {
+            if (item && typeof item === 'object') {
+              return {
+                contact_id: item.contact_id || item.id || null,
+                contact_name: item.contact_name || item.name || null,
+                email: item.email || null,
+                phone: item.phone || null,
+                company: item.company || null,
+              };
+            }
+            if (typeof item === 'string') {
+              return {
+                contact_id: item,
+                contact_name: null,
+                email: null,
+                phone: null,
+                company: null,
+              };
+            }
+            return null;
+          })
+          .filter(Boolean);
+      }
+
+      const recipients = audienceRows.filter((row) => {
+        if (!row?.contact_id) return false;
+        if (requiredChannel === 'email') return Boolean(row.email);
+        return Boolean(row.phone);
+      });
+
+      const seen = new Set();
+      const uniqueRecipients = recipients.filter((row) => {
+        if (seen.has(row.contact_id)) return false;
+        seen.add(row.contact_id);
+        return true;
+      });
+
+      if (uniqueRecipients.length === 0) {
+        return res.status(400).json({ status: 'error', message: 'No audience resolved' });
+      }
+
+      if (uniqueRecipients.length > 0) {
+        const insertTargetSql = `
+          INSERT INTO ai_campaign_targets (
+            tenant_id,
+            campaign_id,
+            contact_id,
+            channel,
+            status,
+            destination,
+            target_payload,
+            created_at,
+            updated_at
+          )
+          VALUES ($1, $2, $3, $4, 'pending', $5, $6::jsonb, NOW(), NOW())
+        `;
+
+        for (const row of uniqueRecipients) {
+          const destination = requiredChannel === 'email' ? row.email : row.phone;
+          await pgPool.query(insertTargetSql, [
+            tenant_id,
+            id,
+            row.contact_id,
+            requiredChannel,
+            destination,
+            JSON.stringify({
+              contact_name: row.contact_name || null,
+              company: row.company || null,
+              email: row.email || null,
+              phone: row.phone || null,
+            }),
+          ]);
+        }
+      }
+
+      const schedule = metadataObj.schedule || {};
+      const scheduledAtRaw = schedule.scheduled_at;
+      const scheduledAt = scheduledAtRaw ? new Date(scheduledAtRaw) : null;
+      const isFutureSchedule =
+        schedule.type === 'scheduled' &&
+        scheduledAt instanceof Date &&
+        !Number.isNaN(scheduledAt.getTime()) &&
+        scheduledAt.getTime() > Date.now();
+      const nextStatus = isFutureSchedule ? 'scheduled' : 'running';
+      const eventType = isFutureSchedule ? 'campaign_scheduled' : 'campaign_started';
+
       const lifecycle = {
-        ...(meta.lifecycle || {}),
-        scheduled_at: new Date().toISOString(),
+        ...(metadataObj.lifecycle || {}),
+        scheduled_at: isFutureSchedule ? scheduledAt.toISOString() : new Date().toISOString(),
         scheduled_by: req.user?.email || null,
       };
-      const newMeta = { ...meta, lifecycle };
+      const newMeta = { ...metadataObj, lifecycle };
 
       const updR = await pgPool.query(
-        `UPDATE ai_campaign SET status = 'scheduled', metadata = $3, updated_at = NOW()
+        `UPDATE ai_campaign SET status = $3, metadata = $4, updated_at = NOW()
          WHERE tenant_id = $1 AND id = $2 RETURNING *`,
-        [tenant_id, id, JSON.stringify(newMeta)],
+        [tenant_id, id, nextStatus, JSON.stringify(newMeta)],
       );
       const updated = updR.rows[0];
+
+      await pgPool.query(
+        `INSERT INTO ai_campaign_events (
+          tenant_id,
+          campaign_id,
+          contact_id,
+          status,
+          event_type,
+          attempt_no,
+          payload,
+          created_at
+        ) VALUES ($1, $2, NULL, $3, $4, 0, $5::jsonb, NOW())`,
+        [
+          tenant_id,
+          id,
+          nextStatus,
+          eventType,
+          JSON.stringify({
+            campaign_type: cType,
+            resolved_targets: uniqueRecipients.length,
+            channel: requiredChannel,
+          }),
+        ],
+      );
 
       emitTenantWebhooks(pgPool, tenant_id, 'aicampaign.start', {
         id: updated.id,
         status: updated.status,
         campaign_type: cType,
         counts: {
-          totalTargets: Array.isArray(updated.target_contacts) ? updated.target_contacts.length : 0,
+          totalTargets: uniqueRecipients.length,
         },
       }).catch(() => undefined);
 
@@ -393,13 +558,16 @@ export default function createAICampaignRoutes(pgPool) {
       if (getR.rows.length === 0)
         return res.status(404).json({ status: 'error', message: 'AI Campaign not found' });
 
-      const meta = getR.rows[0].metadata || {};
+      let metadataObj =
+        typeof getR.rows[0].metadata === 'object' && getR.rows[0].metadata !== null
+          ? getR.rows[0].metadata
+          : {};
       const lifecycle = {
-        ...(meta.lifecycle || {}),
+        ...(metadataObj.lifecycle || {}),
         paused_at: new Date().toISOString(),
         paused_by: req.user?.email || null,
       };
-      const newMeta = { ...meta, lifecycle };
+      const newMeta = { ...metadataObj, lifecycle };
 
       const upd = await pgPool.query(
         `UPDATE ai_campaign SET status = 'paused', metadata = $3, updated_at = NOW()
@@ -435,13 +603,16 @@ export default function createAICampaignRoutes(pgPool) {
       if (getR.rows.length === 0)
         return res.status(404).json({ status: 'error', message: 'AI Campaign not found' });
 
-      const meta = getR.rows[0].metadata || {};
+      let metadataObj =
+        typeof getR.rows[0].metadata === 'object' && getR.rows[0].metadata !== null
+          ? getR.rows[0].metadata
+          : {};
       const lifecycle = {
-        ...(meta.lifecycle || {}),
+        ...(metadataObj.lifecycle || {}),
         resumed_at: new Date().toISOString(),
         resumed_by: req.user?.email || null,
       };
-      const newMeta = { ...meta, lifecycle };
+      const newMeta = { ...metadataObj, lifecycle };
 
       const upd = await pgPool.query(
         `UPDATE ai_campaign SET status = 'scheduled', metadata = $3, updated_at = NOW()

--- a/backend/routes/aicampaigns.js
+++ b/backend/routes/aicampaigns.js
@@ -387,6 +387,14 @@ export default function createAICampaignRoutes(pgPool) {
           : {};
       const cType = campaign.campaign_type || metadataObj.campaign_type || 'email';
 
+      // Require a linked workflow — delivery goes exclusively through dispatchViaWorkflow
+      if (!campaign.workflow_id) {
+        return res.status(422).json({
+          status: 'error',
+          message: 'A workflow must be linked to this campaign before it can be started.',
+        });
+      }
+
       // Validate integration ownership for channel-specific types
       if (cType === 'email') {
         const profileId = metadataObj.ai_email_config?.sending_profile_id;

--- a/backend/routes/workflows.js
+++ b/backend/routes/workflows.js
@@ -324,6 +324,16 @@ export default function createWorkflowRoutes(pgPool) {
           const resolved = replaceVariables(`{{${m.webhook_field}}}`);
           return { targetField: m.contact_field, resolved };
         }
+        // Legacy account shape
+        if (m.account_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.account_field, resolved };
+        }
+        // Legacy opportunity shape
+        if (m.opportunity_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.opportunity_field, resolved };
+        }
         return null;
       }
 

--- a/backend/routes/workflows.js
+++ b/backend/routes/workflows.js
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Workflow Routes
  * CRUD operations for workflows and workflow executions
  */
@@ -298,6 +298,35 @@ export default function createWorkflowRoutes(pgPool) {
         return (workflow.nodes || []).find((n) => n.id === outgoing[0].to) || null;
       }
 
+      // Helper: normalise a field_mappings entry to { targetField, resolvedValue }.
+      // Handles both legacy shapes and the new unified shape from FieldMappingPanel.
+      //   Legacy create_lead/update_lead: { lead_field, webhook_field }
+      //   Legacy update_contact:          { contact_field, webhook_field }
+      //   New unified shape:              { target_field, source_value }
+      function resolveMapping(m) {
+        // New shape
+        if (m.target_field) {
+          const targetField = m.target_field;
+          const raw = m.source_value || '';
+          // source_value is already a token key (e.g. "email" or "found_lead.first_name").
+          // Wrap it in {{ }} for replaceVariables, or use it directly if it already contains {{ }}.
+          const template = raw.startsWith('{{') ? raw : raw ? `{{${raw}}}` : '';
+          const resolved = template ? replaceVariables(template) : '';
+          return { targetField, resolved };
+        }
+        // Legacy lead shape
+        if (m.lead_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.lead_field, resolved };
+        }
+        // Legacy contact shape
+        if (m.contact_field && m.webhook_field) {
+          const resolved = replaceVariables(`{{${m.webhook_field}}}`);
+          return { targetField: m.contact_field, resolved };
+        }
+        return null;
+      }
+
       // Helper: variable replacement
       function replaceVariables(template) {
         if (typeof template !== 'string') return template;
@@ -511,13 +540,11 @@ export default function createWorkflowRoutes(pgPool) {
               vals.push(new Date().toISOString());
               ph.push(`$${idx++}`);
               for (const m of mappings) {
-                if (m.lead_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== null && v !== undefined && v !== '') {
-                    cols.push(m.lead_field);
-                    vals.push(v);
-                    ph.push(`$${idx++}`);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+                  cols.push(rm.targetField);
+                  vals.push(rm.resolved);
+                  ph.push('$' + idx++);
                 }
               }
               const q = `INSERT INTO leads (${cols.join(',')}) VALUES (${ph.join(',')}) RETURNING *`;
@@ -538,12 +565,10 @@ export default function createWorkflowRoutes(pgPool) {
               const vals = [];
               let idx = 1;
               for (const m of mappings) {
-                if (m.lead_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                    sets.push(`${m.lead_field} = $${idx++}`);
-                    vals.push(v);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== ('{{' + rm.targetField + '}}')) {
+                  sets.push(rm.targetField + ' = $' + idx++);
+                  vals.push(rm.resolved);
                 }
               }
               if (!sets.length) {
@@ -589,12 +614,10 @@ export default function createWorkflowRoutes(pgPool) {
               const vals = [];
               let idx = 1;
               for (const m of mappings) {
-                if (m.contact_field && m.webhook_field) {
-                  const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                    sets.push(`${m.contact_field} = $${idx++}`);
-                    vals.push(v);
-                  }
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== ('{{' + rm.targetField + '}}')) {
+                  sets.push(rm.targetField + ' = $' + idx++);
+                  vals.push(rm.resolved);
                 }
               }
               if (!sets.length) {
@@ -742,30 +765,39 @@ export default function createWorkflowRoutes(pgPool) {
             }
             case 'create_activity': {
               const activityType = cfg.type || 'task';
-              const subject = replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
-              const description = replaceVariables(cfg.details || cfg.description || '');
+              // Resolve field_mappings (new unified shape) with fallback to legacy cfg.title/cfg.details
+              const fieldMappings = cfg.field_mappings || [];
+              const resolvedFields = {};
+              for (const m of fieldMappings) {
+                const rm = resolveMapping(m);
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+                  resolvedFields[rm.targetField] = rm.resolved;
+                }
+              }
+              const subject = resolvedFields.subject || replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
+              const body = resolvedFields.body || replaceVariables(cfg.details || cfg.description || '');
+              const status = resolvedFields.status || 'scheduled';
+              const due_date = resolvedFields.due_date || null;
+              const assigned_to = resolvedFields.assigned_to || null;
               const lead = context.variables.found_lead;
               const contact = context.variables.found_contact;
               const account = context.variables.found_account;
               const opportunity = context.variables.found_opportunity;
-              const related_to = lead
-                ? 'lead'
-                : contact
-                  ? 'contact'
-                  : account
-                    ? 'account'
-                    : opportunity
-                      ? 'opportunity'
-                      : null;
-              const related_id = lead
-                ? lead.id
-                : contact
-                  ? contact.id
-                  : account
-                    ? account.id
-                    : opportunity
-                      ? opportunity.id
-                      : null;
+              // Associate: 'auto' (default) = first found entity in context
+              const associate = cfg.associate || 'auto';
+              let related_to = null;
+              let related_id = null;
+              if (associate === 'auto') {
+                related_to = lead ? 'lead' : contact ? 'contact' : account ? 'account' : opportunity ? 'opportunity' : null;
+                related_id = lead ? lead.id : contact ? contact.id : account ? account.id : opportunity ? opportunity.id : null;
+              } else {
+                const entityMap = { lead, contact, account, opportunity };
+                const entity = entityMap[associate];
+                if (entity) { related_to = associate; related_id = entity.id; }
+              }
+              // field_mappings can explicitly override related_to / related_id
+              if (resolvedFields.related_to) related_to = resolvedFields.related_to;
+              if (resolvedFields.related_id) related_id = resolvedFields.related_id;
               const metadata = { created_by_workflow: workflow.id };
               const q = `
                 INSERT INTO activities (
@@ -774,22 +806,25 @@ export default function createWorkflowRoutes(pgPool) {
                   assigned_to, related_to, metadata, created_date, updated_date
                 ) VALUES (
                   $1, $2, $3, $4, $5, $6,
-                  NULL, NULL, NULL, NULL, NULL,
-                  NULL, $7, $8, NOW(), NOW()
+                  NULL, NULL, NULL, $7, NULL,
+                  $8, $9, $10, NOW(), NOW()
                 ) RETURNING *
               `;
               const vals = [
                 workflow.tenant_id,
                 activityType,
                 subject || null,
-                description || null,
-                'scheduled',
+                body || null,
+                status,
                 related_id,
+                due_date,
+                assigned_to,
                 related_to,
                 JSON.stringify(metadata),
               ];
               const r = await pgPool.query(q, vals);
               log.output = { activity: r.rows[0] };
+              context.variables.created_activity = r.rows[0];
               break;
             }
             case 'condition': {

--- a/backend/routes/workflows.js
+++ b/backend/routes/workflows.js
@@ -551,7 +551,8 @@ export default function createWorkflowRoutes(pgPool) {
               ph.push(`$${idx++}`);
               for (const m of mappings) {
                 const rm = resolveMapping(m);
-                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '') {
+                const isUnresolved = typeof rm?.resolved === 'string' && rm.resolved.startsWith('{{') && rm.resolved.endsWith('}}');
+                if (rm && rm.targetField && rm.resolved !== null && rm.resolved !== undefined && rm.resolved !== '' && !isUnresolved) {
                   cols.push(rm.targetField);
                   vals.push(rm.resolved);
                   ph.push('$' + idx++);
@@ -711,7 +712,8 @@ export default function createWorkflowRoutes(pgPool) {
               for (const m of mappings) {
                 if (m.opportunity_field && m.webhook_field) {
                   const v = replaceVariables(`{{${m.webhook_field}}}`);
-                  if (v !== null && v !== undefined && v !== '') {
+                  const vUnresolved = typeof v === 'string' && v.startsWith('{{') && v.endsWith('}}');
+                  if (v !== null && v !== undefined && v !== '' && !vUnresolved) {
                     cols.push(m.opportunity_field);
                     vals.push(v);
                     ph.push(`$${idx++}`);

--- a/backend/server.js
+++ b/backend/server.js
@@ -921,9 +921,12 @@ server.listen(PORT, async () => {
     }
   }, 1000); // Delay 1 second to ensure server is fully started
 
-  // Start campaign worker
-  startCampaignWorker(pgPool, 5000);
-  console.log('Campaign worker started');
+  // Start campaign worker if enabled
+  if (process.env.CAMPAIGN_WORKER_ENABLED === 'true' && pgPool) {
+    const campaignInterval = parseInt(process.env.CAMPAIGN_WORKER_INTERVAL_MS || '5000', 10);
+    startCampaignWorker(pgPool, campaignInterval);
+    logger.info('[CampaignWorker] Started');
+  }
 
   // Start AI triggers worker if enabled (Phase 3 Autonomous Operations)
   if (process.env.AI_TRIGGERS_WORKER_ENABLED === 'true' && pgPool) {

--- a/backend/server.js
+++ b/backend/server.js
@@ -921,13 +921,9 @@ server.listen(PORT, async () => {
     }
   }, 1000); // Delay 1 second to ensure server is fully started
 
-  // Start campaign worker if enabled
-  if (process.env.CAMPAIGN_WORKER_ENABLED === 'true' && pgPool) {
-    const workerInterval = parseInt(process.env.CAMPAIGN_WORKER_INTERVAL_MS || '30000', 10);
-    startCampaignWorker(pgPool, workerInterval);
-  } else {
-    logger.debug('[CampaignWorker] Disabled (set CAMPAIGN_WORKER_ENABLED=true to enable)');
-  }
+  // Start campaign worker
+  startCampaignWorker(pgPool, 5000);
+  console.log('Campaign worker started');
 
   // Start AI triggers worker if enabled (Phase 3 Autonomous Operations)
   if (process.env.AI_TRIGGERS_WORKER_ENABLED === 'true' && pgPool) {

--- a/backend/services/workflowExecutionService.js
+++ b/backend/services/workflowExecutionService.js
@@ -211,6 +211,28 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
 
       try {
         switch (node.type) {
+          
+      // Resolve a field_mappings entry — handles unified {target_field, source_value}
+      // and all legacy {entity_field, webhook_field} shapes.
+      function resolveServiceMapping(m) {
+        if (m.target_field) {
+          const raw = m.source_value || '';
+          const template = raw.startsWith('{{') ? raw : raw ? `{{${raw}}}` : '';
+          const resolved = template ? replaceVariables(template) : '';
+          const isUnresolved = typeof resolved === 'string' && resolved.startsWith('{{') && resolved.endsWith('}}');
+          return isUnresolved || resolved === '' ? null : { field: m.target_field, value: resolved };
+        }
+        const legacyField =
+          m.lead_field || m.contact_field || m.account_field ||
+          m.opportunity_field || m.activity_field;
+        const legacySrc = m.webhook_field;
+        if (legacyField && legacySrc) {
+          const resolved = replaceVariables(`{{${legacySrc}}}`);
+          const isUnresolved = resolved === `{{${legacySrc}}}`;
+          return isUnresolved ? null : { field: legacyField, value: resolved };
+        }
+        return null;
+      }
           case 'webhook_trigger': {
             log.output = { payload: context.payload };
             break;
@@ -604,12 +626,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
 
             const insertData = { tenant_id: workflow.tenant_id };
             for (const m of mappings) {
-              if (m.lead_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== null && v !== undefined && v !== '') {
-                  insertData[m.lead_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) insertData[rm.field] = rm.value;
             }
 
             const { data: newLead, error: createError } = await supabase
@@ -639,12 +657,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
             const mappings = cfg.field_mappings || [];
             const updateData = {};
             for (const m of mappings) {
-              if (m.lead_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                  updateData[m.lead_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) updateData[rm.field] = rm.value;
             }
 
             if (!Object.keys(updateData).length) {
@@ -705,12 +719,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
             const mappings = cfg.field_mappings || [];
             const updateData = {};
             for (const m of mappings) {
-              if (m.contact_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                  updateData[m.contact_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) updateData[rm.field] = rm.value;
             }
 
             if (!Object.keys(updateData).length) {
@@ -771,12 +781,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
             const mappings = cfg.field_mappings || [];
             const updateData = {};
             for (const m of mappings) {
-              if (m.account_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                  updateData[m.account_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) updateData[rm.field] = rm.value;
             }
 
             if (!Object.keys(updateData).length) {
@@ -813,12 +819,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
 
             const insertData = { tenant_id: workflow.tenant_id };
             for (const m of mappings) {
-              if (m.opportunity_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== null && v !== undefined && v !== '') {
-                  insertData[m.opportunity_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) insertData[rm.field] = rm.value;
             }
 
             // Associate to account or lead if present
@@ -854,12 +856,8 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
             const mappings = cfg.field_mappings || [];
             const updateData = {};
             for (const m of mappings) {
-              if (m.opportunity_field && m.webhook_field) {
-                const v = replaceVariables(`{{${m.webhook_field}}}`);
-                if (v !== `{{${m.webhook_field}}}` && v !== null && v !== undefined) {
-                  updateData[m.opportunity_field] = v;
-                }
-              }
+              const rm = resolveServiceMapping(m);
+              if (rm) updateData[rm.field] = rm.value;
             }
 
             if (!Object.keys(updateData).length) {

--- a/backend/services/workflowExecutionService.js
+++ b/backend/services/workflowExecutionService.js
@@ -996,6 +996,7 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
               log.error = `Failed to create activity: ${actError.message}`;
             } else {
               logger.info(`[WorkflowExecution] Activity created: ${actData?.id}`);
+              context.variables.created_activity = actData;
               log.output = { activity: actData };
             }
             break;

--- a/backend/services/workflowExecutionService.js
+++ b/backend/services/workflowExecutionService.js
@@ -163,10 +163,14 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
           return context.payload[trimmed];
         }
 
-        // Check nested paths
+        // Check nested paths (dot-notation: e.g. contact.email, found_lead.first_name)
         const parts = trimmed.split('.');
         if (parts.length > 1) {
+          // Check context.variables first, then fall back to context.payload
           let value = context.variables[parts[0]];
+          if (value === undefined && context.payload) {
+            value = context.payload[parts[0]];
+          }
           for (let i = 1; i < parts.length; i++) {
             if (value && value[parts[i]] !== undefined) value = value[parts[i]];
             else {
@@ -175,7 +179,7 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
             }
           }
           if (value !== undefined) {
-            logger.debug(`[replaceVariables] Found "${trimmed}" in nested variables:`, value);
+            logger.debug(`[replaceVariables] Found "${trimmed}" in nested path:`, value);
             return value;
           }
         } else if (context.variables && context.variables[trimmed] !== undefined) {
@@ -884,15 +888,21 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
 
           case 'create_activity': {
             const activityType = cfg.type || 'task';
-            const subject = replaceVariables(cfg.title || cfg.subject || 'Workflow activity');
-            const description = replaceVariables(cfg.details || cfg.description || '');
+            // Default subject to campaign name if node has no title configured
+            const campaignName = context.payload?.campaign?.name || null;
+            const defaultSubject = campaignName ? `Campaign: ${campaignName}` : 'Workflow activity';
+            const subject = replaceVariables(cfg.title || cfg.subject || defaultSubject);
+            // Default body includes campaign name so the activity is self-describing
+            const defaultDetails = campaignName ? `Dispatched via campaign: ${campaignName}` : '';
+            const description = replaceVariables(cfg.details || cfg.description || defaultDetails);
 
             const lead = context.variables.found_lead;
             const contact = context.variables.found_contact;
             const account = context.variables.found_account;
             const opportunity = context.variables.found_opportunity;
 
-            const related_to = lead
+            // If a find_* node ran upstream, use that result for association
+            let related_to = lead
               ? 'lead'
               : contact
                 ? 'contact'
@@ -901,7 +911,7 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
                   : opportunity
                     ? 'opportunity'
                     : null;
-            const related_id = lead
+            let related_id = lead
               ? lead.id
               : contact
                 ? contact.id
@@ -911,7 +921,52 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
                     ? opportunity.id
                     : null;
 
-            const { data: actData, error: _actError } = await supabase
+            // If node has explicit associate override (not 'auto'), use it
+            const associateOverride =
+              cfg.associate && cfg.associate !== 'auto' ? cfg.associate : null;
+
+            // Normalize entity type aliases → canonical DB values used in activities.related_to
+            const normalizeEntityType = (t) => {
+              if (t === 'potential_lead' || t === 'source') return 'bizdev_source';
+              return t || 'contact';
+            };
+
+            // Fallback: use entity_type + contact_id directly from the campaign dispatch payload
+            if (!related_id && context.payload?.contact) {
+              const cp = context.payload.contact;
+              const entityType = normalizeEntityType(associateOverride || cp.entity_type);
+              const entityId = cp.contact_id;
+              if (entityId) {
+                related_to = entityType;
+                related_id = entityId;
+              }
+            } else if (related_id && associateOverride) {
+              // Override the entity type from find_* node with explicit config
+              related_to = normalizeEntityType(associateOverride);
+            }
+
+            // Resolve assigned_to: UUID from campaign > email fallback
+            const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+            const assignedToRaw =
+              replaceVariables(cfg.assigned_to || '') ||
+              context.payload?.assigned_to ||
+              context.payload?.campaign?.assigned_to ||
+              null;
+            const assignedToUuid =
+              assignedToRaw && UUID_RE.test(String(assignedToRaw)) ? assignedToRaw : null;
+            const assignedToEmail = assignedToRaw && !assignedToUuid ? assignedToRaw : null;
+
+            logger.info(`[WorkflowExecution] create_activity insert payload:`, {
+              tenant_id: workflow.tenant_id,
+              type: activityType,
+              subject,
+              related_to,
+              related_id,
+              assigned_to_uuid: assignedToUuid,
+              assigned_to_email: assignedToEmail,
+            });
+
+            const { data: actData, error: actError } = await supabase
               .from('activities')
               .insert({
                 tenant_id: workflow.tenant_id,
@@ -921,14 +976,28 @@ export async function executeWorkflowById(workflow_id, triggerPayload) {
                 status: 'scheduled',
                 related_id: related_id,
                 related_to: related_to,
-                metadata: { created_by_workflow: workflow.id },
+                ...(assignedToUuid ? { assigned_to: assignedToUuid } : {}),
+                metadata: {
+                  created_by_workflow: workflow.id,
+                  ...(assignedToEmail ? { assigned_to_email: assignedToEmail } : {}),
+                },
                 created_date: new Date().toISOString(),
                 updated_date: new Date().toISOString(),
               })
               .select()
               .single();
 
-            log.output = { activity: actData };
+            if (actError) {
+              logger.error(
+                `[WorkflowExecution] Failed to create activity: ${actError.message}`,
+                actError,
+              );
+              log.status = 'error';
+              log.error = `Failed to create activity: ${actError.message}`;
+            } else {
+              logger.info(`[WorkflowExecution] Activity created: ${actData?.id}`);
+              log.output = { activity: actData };
+            }
             break;
           }
 

--- a/src/components/campaigns/AICampaignDetailPanel.jsx
+++ b/src/components/campaigns/AICampaignDetailPanel.jsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { BACKEND_URL, supabase } from '@/api/entities';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -29,6 +30,7 @@ const statusColors = {
   running: 'bg-green-900/30 text-green-400 border-green-700',
   paused: 'bg-yellow-900/30 text-yellow-400 border-yellow-700',
   completed: 'bg-purple-900/30 text-purple-400 border-purple-700',
+  failed: 'bg-red-900/30 text-red-400 border-red-700',
   cancelled: 'bg-red-900/30 text-red-400 border-red-700',
 };
 
@@ -41,12 +43,43 @@ export default function AICampaignDetailPanel({
   onStatusChange,
 }) {
   const [activeTab, setActiveTab] = useState('overview');
+  const [liveTargets, setLiveTargets] = useState(null);
+  const [targetsLoading, setTargetsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !campaign?.id) return;
+    setLiveTargets(null);
+    setTargetsLoading(true);
+    const tenant_id = campaign.tenant_id;
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      const authHeaders = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : {};
+      fetch(
+        `${BACKEND_URL}/api/aicampaigns/${campaign.id}/targets?tenant_id=${encodeURIComponent(tenant_id)}`,
+        { headers: authHeaders, credentials: 'include' },
+      )
+        .then((r) => r.json())
+        .then((r) => setLiveTargets(Array.isArray(r.data) ? r.data : null))
+        .catch(() => setLiveTargets(null))
+        .finally(() => setTargetsLoading(false));
+    });
+  }, [open, campaign?.id]);
 
   if (!campaign) return null;
 
   const contacts = parseContacts(campaign.target_contacts);
 
+  // Prefer live progress from metadata (set by worker) over stale target_contacts statuses
+  const metaProgress = campaign.metadata?.progress || null;
+
   const getProgressPercentage = () => {
+    if (metaProgress) {
+      const total = Number(metaProgress.total || 0);
+      if (total === 0) return 0;
+      const done = Number(metaProgress.completed || 0) + Number(metaProgress.failed || 0);
+      return Math.round((done / total) * 100);
+    }
     if (contacts.length === 0) return 0;
     const completedContacts = contacts.filter((c) =>
       ['completed', 'failed', 'skipped'].includes(c.status),
@@ -54,17 +87,20 @@ export default function AICampaignDetailPanel({
     return Math.round((completedContacts / contacts.length) * 100);
   };
 
-  const getStatusCounts = () => {
-    return contacts.reduce(
-      (counts, contact) => {
-        counts[contact.status] = (counts[contact.status] || 0) + 1;
-        return counts;
-      },
-      { pending: 0, completed: 0, failed: 0, scheduled: 0 },
-    );
-  };
-
-  const statusCounts = getStatusCounts();
+  const statusCounts = metaProgress
+    ? {
+        pending: Number(metaProgress.pending || 0),
+        scheduled: Number(metaProgress.processing || 0),
+        completed: Number(metaProgress.completed || 0),
+        failed: Number(metaProgress.failed || 0),
+      }
+    : contacts.reduce(
+        (counts, contact) => {
+          counts[contact.status] = (counts[contact.status] || 0) + 1;
+          return counts;
+        },
+        { pending: 0, completed: 0, failed: 0, scheduled: 0 },
+      );
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -238,11 +274,80 @@ export default function AICampaignDetailPanel({
               <CardHeader>
                 <CardTitle className="text-lg flex items-center gap-2 text-slate-100">
                   <Users className="w-5 h-5" />
-                  Target Contacts ({contacts.length})
+                  Target Contacts ({liveTargets ? liveTargets.length : contacts.length})
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                {contacts.length === 0 ? (
+                {targetsLoading ? (
+                  <div className="text-center py-8 text-slate-500">Loading...</div>
+                ) : liveTargets && liveTargets.length > 0 ? (
+                  <div className="space-y-3">
+                    {liveTargets.map((t) => {
+                      const payload =
+                        typeof t.target_payload === 'string'
+                          ? (() => {
+                              try {
+                                return JSON.parse(t.target_payload);
+                              } catch {
+                                return {};
+                              }
+                            })()
+                          : t.target_payload || {};
+                      const name =
+                        payload.contact_name || payload.first_name || t.destination || t.contact_id;
+                      const sub = t.destination || payload.phone || payload.email;
+                      const statusIcon = {
+                        completed: <CheckCircle className="w-4 h-4 text-green-400" />,
+                        failed: <XCircle className="w-4 h-4 text-red-400" />,
+                        processing: <Clock className="w-4 h-4 text-blue-400" />,
+                        pending: <Clock className="w-4 h-4 text-slate-500" />,
+                      }[t.status] || <Clock className="w-4 h-4 text-slate-500" />;
+                      const badgeClass =
+                        {
+                          completed: 'border-green-700 text-green-400',
+                          failed: 'border-red-700 text-red-400',
+                          processing: 'border-blue-700 text-blue-400',
+                          pending: 'border-slate-600 text-slate-300',
+                        }[t.status] || 'border-slate-600 text-slate-300';
+                      return (
+                        <div
+                          key={t.id}
+                          className="flex items-start justify-between p-3 border border-slate-700 rounded-lg bg-slate-800/50"
+                        >
+                          <div className="flex items-start gap-3">
+                            <div className="mt-0.5">{statusIcon}</div>
+                            <div>
+                              <div className="font-medium text-slate-200">{name}</div>
+                              {sub && sub !== name && (
+                                <div className="text-sm text-slate-400">{sub}</div>
+                              )}
+                              {t.error_message && (
+                                <div className="text-xs text-red-400 mt-1 max-w-xs">
+                                  ⚠ {t.error_message}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                          <div className="text-right text-sm flex-shrink-0 ml-4">
+                            <Badge variant="outline" className={`capitalize ${badgeClass}`}>
+                              {t.status}
+                            </Badge>
+                            {t.completed_at && (
+                              <div className="text-xs text-slate-500 mt-1">
+                                {format(new Date(t.completed_at), 'MMM d, HH:mm')}
+                              </div>
+                            )}
+                            {!t.completed_at && t.created_at && (
+                              <div className="text-xs text-slate-500 mt-1">
+                                {format(new Date(t.created_at), 'MMM d, HH:mm')}
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                ) : contacts.length === 0 ? (
                   <div className="text-center py-8 text-slate-500">
                     <Users className="w-12 h-12 mx-auto mb-4 text-slate-600" />
                     <p>No contacts configured for this campaign</p>
@@ -255,47 +360,20 @@ export default function AICampaignDetailPanel({
                         className="flex items-center justify-between p-3 border border-slate-700 rounded-lg bg-slate-800/50"
                       >
                         <div className="flex items-center gap-3">
-                          <div className="flex items-center gap-2">
-                            {contact.status === 'completed' && (
-                              <CheckCircle className="w-4 h-4 text-green-400" />
-                            )}
-                            {contact.status === 'failed' && (
-                              <XCircle className="w-4 h-4 text-red-400" />
-                            )}
-                            {contact.status === 'scheduled' && (
-                              <Clock className="w-4 h-4 text-blue-400" />
-                            )}
-                            {contact.status === 'pending' && (
-                              <Clock className="w-4 h-4 text-slate-500" />
-                            )}
-                          </div>
+                          <Clock className="w-4 h-4 text-slate-500" />
                           <div>
                             <div className="font-medium text-slate-200">{contact.contact_name}</div>
-                            <div className="text-sm text-slate-400">{contact.phone}</div>
-                            {contact.company && (
-                              <div className="text-sm text-slate-400">{contact.company}</div>
-                            )}
+                            <div className="text-sm text-slate-400">
+                              {contact.phone || contact.email}
+                            </div>
                           </div>
                         </div>
-                        <div className="text-right text-sm">
-                          <Badge
-                            variant="outline"
-                            className="capitalize border-slate-600 text-slate-300"
-                          >
-                            {contact.status}
-                          </Badge>
-                          {contact.scheduled_date && (
-                            <div className="text-xs text-slate-500 mt-1">
-                              {format(new Date(contact.scheduled_date), 'MMM d')} at{' '}
-                              {contact.scheduled_time}
-                            </div>
-                          )}
-                          {contact.outcome && (
-                            <div className="text-xs text-slate-400 mt-1 max-w-48 truncate">
-                              {contact.outcome}
-                            </div>
-                          )}
-                        </div>
+                        <Badge
+                          variant="outline"
+                          className="capitalize border-slate-600 text-slate-300"
+                        >
+                          {contact.status || 'pending'}
+                        </Badge>
                       </div>
                     ))}
                   </div>
@@ -309,89 +387,138 @@ export default function AICampaignDetailPanel({
               <CardHeader>
                 <CardTitle className="text-lg flex items-center gap-2 text-slate-100">
                   <BarChart3 className="w-5 h-5" />
-                  Performance Metrics
+                  {campaign.campaign_type === 'call' ? 'Call Performance' : 'Execution Metrics'}
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-slate-100">
-                      {campaign.performance_metrics?.total_calls || 0}
+                {campaign.campaign_type === 'call' ? (
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-slate-100">
+                        {campaign.performance_metrics?.total_calls || 0}
+                      </div>
+                      <div className="text-sm text-slate-400">Total Calls</div>
                     </div>
-                    <div className="text-sm text-slate-400">Total Calls</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-green-400">
-                      {campaign.performance_metrics?.successful_calls || 0}
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-green-400">
+                        {campaign.performance_metrics?.successful_calls || 0}
+                      </div>
+                      <div className="text-sm text-slate-400">Successful</div>
                     </div>
-                    <div className="text-sm text-slate-400">Successful</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-red-400">
-                      {campaign.performance_metrics?.failed_calls || 0}
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-red-400">
+                        {campaign.performance_metrics?.failed_calls || 0}
+                      </div>
+                      <div className="text-sm text-slate-400">Failed</div>
                     </div>
-                    <div className="text-sm text-slate-400">Failed</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-blue-400">
-                      {campaign.performance_metrics?.appointments_set || 0}
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-blue-400">
+                        {campaign.performance_metrics?.appointments_set || 0}
+                      </div>
+                      <div className="text-sm text-slate-400">Appointments</div>
                     </div>
-                    <div className="text-sm text-slate-400">Appointments</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-purple-400">
-                      {campaign.performance_metrics?.leads_qualified || 0}
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-purple-400">
+                        {campaign.performance_metrics?.leads_qualified || 0}
+                      </div>
+                      <div className="text-sm text-slate-400">Qualified</div>
                     </div>
-                    <div className="text-sm text-slate-400">Qualified</div>
-                  </div>
-                  <div className="text-center">
-                    <div className="text-3xl font-bold text-orange-400">
-                      {campaign.performance_metrics?.average_duration || 0}s
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-orange-400">
+                        {campaign.performance_metrics?.average_duration || 0}s
+                      </div>
+                      <div className="text-sm text-slate-400">Avg Duration</div>
                     </div>
-                    <div className="text-sm text-slate-400">Avg Duration</div>
                   </div>
-                </div>
+                ) : (
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-slate-100">
+                        {statusCounts.pending +
+                          statusCounts.scheduled +
+                          statusCounts.completed +
+                          statusCounts.failed}
+                      </div>
+                      <div className="text-sm text-slate-400">Total Contacts</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-green-400">
+                        {statusCounts.completed}
+                      </div>
+                      <div className="text-sm text-slate-400">Completed</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-red-400">{statusCounts.failed}</div>
+                      <div className="text-sm text-slate-400">Failed</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-yellow-400">
+                        {statusCounts.pending}
+                      </div>
+                      <div className="text-sm text-slate-400">Pending</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-blue-400">
+                        {statusCounts.scheduled}
+                      </div>
+                      <div className="text-sm text-slate-400">Processing</div>
+                    </div>
+                    <div className="text-center">
+                      <div className="text-3xl font-bold text-purple-400">
+                        {(() => {
+                          const total = statusCounts.completed + statusCounts.failed;
+                          return total > 0
+                            ? `${Math.round((statusCounts.completed / total) * 100)}%`
+                            : '—';
+                        })()}
+                      </div>
+                      <div className="text-sm text-slate-400">Success Rate</div>
+                    </div>
+                  </div>
+                )}
               </CardContent>
             </Card>
           </TabsContent>
 
           <TabsContent value="settings" className="space-y-4">
-            <Card className="bg-slate-800 border-slate-700">
-              <CardHeader>
-                <CardTitle className="text-lg flex items-center gap-2 text-slate-100">
-                  <Target className="w-5 h-5" />
-                  Call Settings
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <div className="text-sm font-medium text-slate-400">Max Duration</div>
-                    <div className="text-lg font-semibold text-slate-200">
-                      {campaign.call_settings?.max_duration || 300}s
+            {campaign.campaign_type === 'call' && (
+              <Card className="bg-slate-800 border-slate-700">
+                <CardHeader>
+                  <CardTitle className="text-lg flex items-center gap-2 text-slate-100">
+                    <Target className="w-5 h-5" />
+                    Call Settings
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <div className="text-sm font-medium text-slate-400">Max Duration</div>
+                      <div className="text-lg font-semibold text-slate-200">
+                        {campaign.call_settings?.max_duration || 300}s
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-slate-400">Retry Attempts</div>
+                      <div className="text-lg font-semibold text-slate-200">
+                        {campaign.call_settings?.retry_attempts || 2}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-slate-400">Business Hours Only</div>
+                      <div className="text-lg font-semibold text-slate-200">
+                        {campaign.call_settings?.business_hours_only ? 'Yes' : 'No'}
+                      </div>
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-slate-400">Delay Between Calls</div>
+                      <div className="text-lg font-semibold text-slate-200">
+                        {campaign.call_settings?.delay_between_calls || 60}s
+                      </div>
                     </div>
                   </div>
-                  <div>
-                    <div className="text-sm font-medium text-slate-400">Retry Attempts</div>
-                    <div className="text-lg font-semibold text-slate-200">
-                      {campaign.call_settings?.retry_attempts || 2}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="text-sm font-medium text-slate-400">Business Hours Only</div>
-                    <div className="text-lg font-semibold text-slate-200">
-                      {campaign.call_settings?.business_hours_only ? 'Yes' : 'No'}
-                    </div>
-                  </div>
-                  <div>
-                    <div className="text-sm font-medium text-slate-400">Delay Between Calls</div>
-                    <div className="text-lg font-semibold text-slate-200">
-                      {campaign.call_settings?.delay_between_calls || 60}s
-                    </div>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            )}
 
             <Card className="bg-slate-800 border-slate-700">
               <CardHeader>

--- a/src/components/campaigns/AICampaignForm.jsx
+++ b/src/components/campaigns/AICampaignForm.jsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Checkbox } from '@/components/ui/checkbox';
+import { getBackendUrl } from '@/api/backendUrl';
 // [2026-02-23 Claude] — AiCampaigns overhaul: expanded campaign types, fixed form rendering
 import {
   Users,
@@ -30,7 +31,15 @@ import {
 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 // [2026-02-23 Claude] — added BizDevSource for campaign targeting
-import { Contact, Lead, BizDevSource, TenantIntegration } from '@/api/entities';
+import {
+  Contact,
+  Lead,
+  BizDevSource,
+  TenantIntegration,
+  Workflow,
+  supabase,
+  BACKEND_URL,
+} from '@/api/entities';
 // Replaced direct User.me() usage with global user context hook
 import { useUser } from '@/components/shared/useUser.js';
 import { getTenantFilter } from '../shared/tenantUtils';
@@ -86,6 +95,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
     campaign_type: 'call',
     name: '',
     description: '',
+    workflow_id: null,
     ai_provider: 'callfluent',
     ai_prompt_template: '',
     call_objective: 'follow_up',
@@ -112,6 +122,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   const [selectedContacts, setSelectedContacts] = useState([]);
   const [emailSendingProfiles, setEmailSendingProfiles] = useState([]);
   const [callProviders, setCallProviders] = useState([]);
+  const [availableWorkflows, setAvailableWorkflows] = useState([]);
   const [audienceMode, setAudienceMode] = useState('manual');
   const [smartAudiencePrompt, setSmartAudiencePrompt] = useState('');
   const [audiencePreview, setAudiencePreview] = useState({ total: 0, preview: [] });
@@ -132,8 +143,12 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
       try {
         const tenantFilter = getTenantFilter(currentUser, selectedTenantId);
 
-        const contactsData = await Contact.filter(tenantFilter);
-        const leadsData = await Lead.filter(tenantFilter);
+        const [contactsData, leadsData, workflowsData] = await Promise.all([
+          Contact.filter(tenantFilter),
+          Lead.filter(tenantFilter),
+          Workflow.list(tenantFilter).catch(() => []),
+        ]);
+        setAvailableWorkflows(workflowsData || []);
         let sourcesData = [];
         try {
           sourcesData = await BizDevSource.filter(tenantFilter);
@@ -169,6 +184,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
         setAvailableContacts(combinedContacts);
 
         if (campaign) {
+          let missingFromFilter = [];
           const meta = campaign.metadata || {};
           const existingTargetContacts = Array.isArray(campaign.target_contacts)
             ? campaign.target_contacts
@@ -182,6 +198,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
             campaign_type: meta.campaign_type || campaign.campaign_type || 'call',
             name: campaign.name || '',
             description: campaign.description || '',
+            workflow_id: campaign.workflow_id || null,
             ai_provider: meta.ai_provider || campaign.ai_provider || 'callfluent',
             ai_prompt_template: campaign.ai_prompt_template || meta.ai_prompt_template || '',
             call_objective: campaign.call_objective || meta.call_objective || 'follow_up',
@@ -228,6 +245,121 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
           if (existingTargetContacts.length > 0) {
             const contactIds = existingTargetContacts.map((tc) => tc.contact_id);
             setSelectedContacts(contactIds);
+
+            // Ensure already-selected recipients are visible even if they fail the channel filter
+            // (e.g. a BizDev source with no email in an email campaign)
+            const filteredIds = new Set(combinedContacts.map((c) => c.id));
+            missingFromFilter = existingTargetContacts
+              .filter((tc) => !filteredIds.has(tc.contact_id))
+              .map((tc) => {
+                // Try to find the full record in allContacts (unfiltered)
+                const found = combinedContactsAll.find((c) => c.id === tc.contact_id);
+                if (found) return { ...found, missing_channel: true };
+                // Reconstruct from stored target_contacts data as fallback
+                const nameStr = tc.contact_name || '';
+                const parts = nameStr.split(' ');
+                return {
+                  id: tc.contact_id,
+                  type:
+                    tc.entity_type === 'lead'
+                      ? 'lead'
+                      : tc.entity_type === 'bizdev_source'
+                        ? 'source'
+                        : 'contact',
+                  first_name: parts[0] || '',
+                  last_name: parts.slice(1).join(' ') || '',
+                  email: tc.email || null,
+                  phone: tc.phone || null,
+                  company: tc.company || '',
+                  missing_channel: true,
+                };
+              });
+            if (missingFromFilter.length > 0) {
+              setAvailableContacts([...combinedContacts, ...missingFromFilter]);
+            }
+          }
+
+          // Fetch actual dispatch targets to restore any recipients filtered by the API
+          // (e.g. BizDev sources suppressed by team visibility scope — the canonical
+          // source of truth is ai_campaign_targets, not target_contacts snapshot)
+          if (campaign.id && campaign.tenant_id) {
+            try {
+              const {
+                data: { session },
+              } = await supabase.auth.getSession();
+              const authHeaders = session?.access_token
+                ? { Authorization: `Bearer ${session.access_token}` }
+                : {};
+              const targetsRes = await fetch(
+                `${BACKEND_URL}/api/aicampaigns/${campaign.id}/targets?tenant_id=${encodeURIComponent(campaign.tenant_id)}`,
+                { headers: authHeaders, credentials: 'include' },
+              );
+              const targetsJson = await targetsRes.json();
+              const dispatchedTargets = Array.isArray(targetsJson.data) ? targetsJson.data : [];
+
+              if (dispatchedTargets.length > 0) {
+                // Override selected contacts with who was ACTUALLY dispatched
+                const dispatchedIds = [
+                  ...new Set(dispatchedTargets.map((t) => t.contact_id).filter(Boolean)),
+                ];
+                setSelectedContacts(dispatchedIds);
+
+                // Restore contacts missing from ALL API responses (visibility-filtered, etc.)
+                const knownIds = new Set(combinedContactsAll.map((c) => c.id));
+                const seenRestoredIds = new Set();
+                const restoredContacts = dispatchedTargets
+                  .filter((t) => {
+                    if (
+                      !t.contact_id ||
+                      knownIds.has(t.contact_id) ||
+                      seenRestoredIds.has(t.contact_id)
+                    ) {
+                      return false;
+                    }
+                    seenRestoredIds.add(t.contact_id);
+                    return true;
+                  })
+                  .map((t) => {
+                    let payload;
+                    try {
+                      payload =
+                        typeof t.target_payload === 'string'
+                          ? JSON.parse(t.target_payload)
+                          : t.target_payload || {};
+                    } catch {
+                      payload = {};
+                    }
+                    const nameStr = payload.contact_name || '';
+                    const parts = nameStr.split(' ');
+                    return {
+                      id: t.contact_id,
+                      type:
+                        payload.entity_type === 'lead'
+                          ? 'lead'
+                          : payload.entity_type === 'bizdev_source'
+                            ? 'source'
+                            : 'contact',
+                      first_name: parts[0] || '',
+                      last_name: parts.slice(1).join(' ') || '',
+                      email: payload.email || t.destination || null,
+                      phone: payload.phone || null,
+                      company: payload.company || '',
+                      restored_from_history: true,
+                    };
+                  });
+
+                if (restoredContacts.length > 0) {
+                  setAllContacts((prev) => [...prev, ...restoredContacts]);
+                  setAvailableContacts([
+                    ...combinedContacts,
+                    ...missingFromFilter,
+                    ...restoredContacts,
+                  ]);
+                }
+              }
+            } catch (e) {
+              console.warn('[AICampaignForm] Could not restore targets from history:', e.message);
+            }
           }
           const modeFromCampaign =
             existingTargetContacts.length > 0
@@ -279,7 +411,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   // Load tenant integrations
   useEffect(() => {
     if (!currentUser && !selectedTenantId) return;
-    const tenant_id = currentUser?.tenant_id || selectedTenantId;
+    const tenant_id = selectedTenantId || currentUser?.tenant_id;
     if (!tenant_id) return;
     (async () => {
       try {
@@ -351,7 +483,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   };
 
   const handlePreviewAudience = async () => {
-    const tenant_id = currentUser?.tenant_id || selectedTenantId;
+    const tenant_id = selectedTenantId || currentUser?.tenant_id;
     if (!tenant_id) {
       setAudiencePreviewError('No tenant selected');
       return;
@@ -364,7 +496,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
     setAudiencePreviewLoading(true);
     setAudiencePreviewError('');
     try {
-      const response = await fetch('/api/aicampaigns/audience-preview', {
+      const response = await fetch(`${getBackendUrl()}/api/aicampaigns/audience-preview`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -397,7 +529,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   // [2026-02-23 Claude] — aligned submission with backend schema
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const tenant_id = currentUser?.tenant_id || selectedTenantId;
+    const tenant_id = selectedTenantId || currentUser?.tenant_id;
 
     if (!tenant_id) {
       alert('Cannot save: No client selected');
@@ -430,6 +562,12 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
             const contactName = contact ? `${contact.first_name} ${contact.last_name}`.trim() : '';
             return {
               contact_id: contact?.id,
+              entity_type:
+                contact?.type === 'lead'
+                  ? 'lead'
+                  : contact?.type === 'source'
+                    ? 'bizdev_source'
+                    : 'contact',
               contact_name: contactName,
               email: contact?.email || null,
               phone: contact?.phone || null,
@@ -499,6 +637,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
       tenant_id,
       assigned_to: currentUser?.email,
       status: 'draft',
+      workflow_id: formData.workflow_id || null,
       metadata,
       performance_metrics: {
         total_sent: 0,
@@ -607,6 +746,34 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
                 rows={3}
                 className="bg-slate-800 border-slate-700 text-slate-200 placeholder:text-slate-400"
               />
+            </div>
+
+            {/* Linked Workflow */}
+            <div>
+              <Label className="text-slate-200">Linked Workflow</Label>
+              <Select
+                value={formData.workflow_id || 'none'}
+                onValueChange={(v) =>
+                  setFormData((prev) => ({ ...prev, workflow_id: v === 'none' ? null : v }))
+                }
+              >
+                <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
+                  <SelectValue placeholder="Select a workflow..." />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-800 border-slate-700 text-slate-200 z-[10000]">
+                  <SelectItem value="none" className="focus:bg-slate-700">
+                    — No workflow —
+                  </SelectItem>
+                  {availableWorkflows.map((wf) => (
+                    <SelectItem key={wf.id} value={wf.id} className="focus:bg-slate-700">
+                      {wf.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {formData.workflow_id && (
+                <p className="text-xs text-slate-500 mt-1 font-mono">{formData.workflow_id}</p>
+              )}
             </div>
 
             {/* Provider Selection (Calls only) */}
@@ -1174,12 +1341,20 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
                             {contact.company && (
                               <span className="text-slate-400">- {contact.company}</span>
                             )}
+                            {contact.missing_channel && (
+                              <Badge
+                                variant="outline"
+                                className="text-xs border-red-600 text-red-400"
+                              >
+                                no {formData.campaign_type === 'email' ? 'email' : 'phone'}
+                              </Badge>
+                            )}
                           </div>
                           <div className="text-sm text-slate-400">
                             {formData.campaign_type === 'email'
-                              ? contact.email
+                              ? contact.email || '—'
                               : ['call', 'sms', 'whatsapp'].includes(formData.campaign_type)
-                                ? contact.phone
+                                ? contact.phone || '—'
                                 : contact.email || contact.phone || '-'}
                           </div>
                         </div>
@@ -1459,6 +1634,52 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
                 <Label htmlFor="business_hours_only" className="text-slate-200">
                   Only call during business hours
                 </Label>
+              </div>
+
+              {/* Excluded Days */}
+              <div className="space-y-2">
+                <Label className="text-slate-200">Excluded Days</Label>
+                <div className="flex flex-wrap gap-2">
+                  {[
+                    'monday',
+                    'tuesday',
+                    'wednesday',
+                    'thursday',
+                    'friday',
+                    'saturday',
+                    'sunday',
+                  ].map((day) => {
+                    const excluded = (formData.schedule_config.excluded_days || []).includes(day);
+                    return (
+                      <button
+                        key={day}
+                        type="button"
+                        onClick={() =>
+                          setFormData((prev) => {
+                            const current = prev.schedule_config.excluded_days || [];
+                            const next = excluded
+                              ? current.filter((d) => d !== day)
+                              : [...current, day];
+                            return {
+                              ...prev,
+                              schedule_config: { ...prev.schedule_config, excluded_days: next },
+                            };
+                          })
+                        }
+                        className={`px-3 py-1 rounded text-xs font-medium transition-colors capitalize ${
+                          excluded
+                            ? 'bg-red-900/50 border border-red-700 text-red-400'
+                            : 'bg-slate-800 border border-slate-600 text-slate-400 hover:border-slate-500'
+                        }`}
+                      >
+                        {day.slice(0, 3).charAt(0).toUpperCase() + day.slice(1, 3)}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="text-xs text-slate-500">
+                  Click to toggle — red = excluded from calling
+                </p>
               </div>
             </div>
           )}

--- a/src/components/campaigns/AICampaignForm.jsx
+++ b/src/components/campaigns/AICampaignForm.jsx
@@ -71,6 +71,16 @@ const promptTemplates = {
   survey: `Hello {{contact_name}}, I'm calling from {{company_name}} to get your valuable feedback on our recent service. This will only take 2-3 minutes of your time. Would you mind sharing your experience with us?`,
 };
 
+function toDateTimeLocal(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return '';
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(
+    d.getMinutes(),
+  )}`;
+}
+
 export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   const [formData, setFormData] = useState({
     campaign_type: 'call',
@@ -102,6 +112,14 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
   const [selectedContacts, setSelectedContacts] = useState([]);
   const [emailSendingProfiles, setEmailSendingProfiles] = useState([]);
   const [callProviders, setCallProviders] = useState([]);
+  const [audienceMode, setAudienceMode] = useState('manual');
+  const [smartAudiencePrompt, setSmartAudiencePrompt] = useState('');
+  const [audiencePreview, setAudiencePreview] = useState({ total: 0, preview: [] });
+  const [audiencePreviewLoading, setAudiencePreviewLoading] = useState(false);
+  const [audiencePreviewError, setAudiencePreviewError] = useState('');
+  const [scheduleType, setScheduleType] = useState('immediate');
+  const [scheduleAt, setScheduleAt] = useState('');
+  const [scheduleTimezone, setScheduleTimezone] = useState('America/New_York');
 
   const { user: currentUser } = useUser();
   const [previewPrompt, setPreviewPrompt] = useState('');
@@ -152,6 +170,14 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
 
         if (campaign) {
           const meta = campaign.metadata || {};
+          const existingTargetContacts = Array.isArray(campaign.target_contacts)
+            ? campaign.target_contacts
+            : [];
+          const existingTargetAudience =
+            campaign.target_audience && typeof campaign.target_audience === 'object'
+              ? campaign.target_audience
+              : {};
+
           setFormData({
             campaign_type: meta.campaign_type || campaign.campaign_type || 'call',
             name: campaign.name || '',
@@ -161,7 +187,7 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
             call_objective: campaign.call_objective || meta.call_objective || 'follow_up',
             email_subject: meta.ai_email_config?.subject || '',
             email_body_template: meta.ai_email_config?.body_template || '',
-            target_contacts: campaign.target_contacts || [],
+            target_contacts: existingTargetContacts,
             call_settings: {
               max_duration:
                 campaign.call_settings?.max_duration || meta.call_settings?.max_duration || 300,
@@ -199,10 +225,25 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
             },
           });
 
-          if (campaign.target_contacts) {
-            const contactIds = campaign.target_contacts.map((tc) => tc.contact_id);
+          if (existingTargetContacts.length > 0) {
+            const contactIds = existingTargetContacts.map((tc) => tc.contact_id);
             setSelectedContacts(contactIds);
           }
+          const modeFromCampaign =
+            existingTargetContacts.length > 0
+              ? 'manual'
+              : existingTargetAudience?.type === 'ai_segment'
+                ? 'smart'
+                : 'manual';
+          setAudienceMode(modeFromCampaign);
+          setSmartAudiencePrompt(existingTargetAudience?.prompt || '');
+          setAudiencePreview({ total: 0, preview: [] });
+          setAudiencePreviewError('');
+
+          const schedule = meta.schedule || {};
+          setScheduleType(schedule.type === 'scheduled' ? 'scheduled' : 'immediate');
+          setScheduleAt(toDateTimeLocal(schedule.scheduled_at));
+          setScheduleTimezone(schedule.timezone || 'America/New_York');
         } else {
           const tomorrow = new Date();
           tomorrow.setDate(tomorrow.getDate() + 1);
@@ -217,6 +258,13 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
               end_date: nextWeek.toISOString().split('T')[0],
             },
           }));
+          setAudienceMode('manual');
+          setSmartAudiencePrompt('');
+          setAudiencePreview({ total: 0, preview: [] });
+          setAudiencePreviewError('');
+          setScheduleType('immediate');
+          setScheduleAt('');
+          setScheduleTimezone('America/New_York');
         }
       } catch (error) {
         console.error('Failed to load data:', error);
@@ -302,38 +350,106 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
     }
   };
 
+  const handlePreviewAudience = async () => {
+    const tenant_id = currentUser?.tenant_id || selectedTenantId;
+    if (!tenant_id) {
+      setAudiencePreviewError('No tenant selected');
+      return;
+    }
+    if (!smartAudiencePrompt.trim()) {
+      setAudiencePreviewError('Enter an audience prompt to preview');
+      return;
+    }
+
+    setAudiencePreviewLoading(true);
+    setAudiencePreviewError('');
+    try {
+      const response = await fetch('/api/aicampaigns/audience-preview', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          tenant_id,
+          campaign_type: formData.campaign_type,
+          target_audience: {
+            type: 'ai_segment',
+            prompt: smartAudiencePrompt.trim(),
+          },
+        }),
+      });
+
+      const result = await response.json();
+      if (!response.ok || result?.status !== 'success') {
+        throw new Error(result?.message || 'Failed to preview audience');
+      }
+      const data = result?.data || {};
+      setAudiencePreview({
+        total: Number(data.total || 0),
+        preview: Array.isArray(data.preview) ? data.preview : [],
+      });
+    } catch (error) {
+      setAudiencePreview({ total: 0, preview: [] });
+      setAudiencePreviewError(error.message || 'Failed to preview audience');
+    } finally {
+      setAudiencePreviewLoading(false);
+    }
+  };
+
   // [2026-02-23 Claude] — aligned submission with backend schema
   const handleSubmit = async (e) => {
     e.preventDefault();
+    const tenant_id = currentUser?.tenant_id || selectedTenantId;
 
-    if (!currentUser?.tenant_id && !selectedTenantId) {
+    if (!tenant_id) {
       alert('Cannot save: No client selected');
       return;
     }
 
     const noContactTypes = ['social_post', 'api_connector'];
-    if (!noContactTypes.includes(formData.campaign_type) && selectedContacts.length === 0) {
+    if (
+      audienceMode === 'manual' &&
+      !noContactTypes.includes(formData.campaign_type) &&
+      selectedContacts.length === 0
+    ) {
       alert('Please select at least one contact for the campaign');
       return;
     }
+    if (audienceMode === 'smart' && !smartAudiencePrompt.trim()) {
+      alert('Please enter a smart audience prompt');
+      return;
+    }
+    if (scheduleType === 'scheduled' && !scheduleAt) {
+      alert('Please choose a scheduled date and time');
+      return;
+    }
 
-    const targetContacts = selectedContacts.map((contactId) => {
-      const contact = availableContacts.find((c) => c.id === contactId);
-      const contactName = contact ? `${contact.first_name} ${contact.last_name}`.trim() : '';
-      return {
-        contact_id: contact?.id,
-        contact_name: contactName,
-        email: contact?.email || null,
-        phone: contact?.phone || null,
-        company: contact?.company || '',
-        scheduled_date: formData.schedule_config.start_date,
-        scheduled_time: formData.schedule_config.preferred_hours.start,
-        status: 'pending',
-      };
-    });
+    const targetContacts =
+      audienceMode === 'smart'
+        ? []
+        : selectedContacts.map((contactId) => {
+            const contact = availableContacts.find((c) => c.id === contactId);
+            const contactName = contact ? `${contact.first_name} ${contact.last_name}`.trim() : '';
+            return {
+              contact_id: contact?.id,
+              contact_name: contactName,
+              email: contact?.email || null,
+              phone: contact?.phone || null,
+              company: contact?.company || '',
+              scheduled_date: formData.schedule_config.start_date,
+              scheduled_time: formData.schedule_config.preferred_hours.start,
+              status: 'pending',
+            };
+          });
 
-    // [2026-02-23 Claude] — pack channel-specific fields into metadata
-    const metadata = { schedule_config: formData.schedule_config };
+    // [2026-02-23 Claude] - pack channel-specific fields into metadata
+    const metadata = {
+      schedule_config: formData.schedule_config,
+      schedule: {
+        type: scheduleType,
+        scheduled_at:
+          scheduleType === 'scheduled' && scheduleAt ? new Date(scheduleAt).toISOString() : null,
+        timezone: scheduleTimezone || 'America/New_York',
+      },
+    };
     const ct = formData.campaign_type;
     if (ct === 'call') {
       metadata.ai_provider = formData.ai_provider;
@@ -373,7 +489,14 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
       description: formData.description,
       campaign_type: formData.campaign_type,
       target_contacts: targetContacts,
-      tenant_id: currentUser?.tenant_id || selectedTenantId,
+      target_audience:
+        audienceMode === 'smart'
+          ? {
+              type: 'ai_segment',
+              prompt: smartAudiencePrompt.trim(),
+            }
+          : null,
+      tenant_id,
       assigned_to: currentUser?.email,
       status: 'draft',
       metadata,
@@ -978,73 +1101,133 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
               Target Recipients ({selectedContacts.length} selected)
             </h3>
 
-            <div className="flex items-center gap-2 mb-4">
-              <Checkbox
-                id="select-all"
-                checked={
-                  selectedContacts.length === availableContacts.length &&
-                  availableContacts.length > 0
-                }
-                onCheckedChange={handleSelectAllContacts}
-              />
-              <Label htmlFor="select-all" className="text-slate-200">
-                Select All ({availableContacts.length} recipients)
-              </Label>
+            <div className="space-y-2">
+              <Label className="text-slate-200">Audience Mode</Label>
+              <Select value={audienceMode} onValueChange={setAudienceMode}>
+                <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-800 border-slate-700 text-slate-200 z-[10000]">
+                  <SelectItem value="manual" className="focus:bg-slate-700">
+                    Manual Selection
+                  </SelectItem>
+                  <SelectItem value="smart" className="focus:bg-slate-700">
+                    Smart Audience
+                  </SelectItem>
+                </SelectContent>
+              </Select>
             </div>
 
-            <div className="max-h-60 overflow-y-auto border border-slate-700 rounded-md p-4 space-y-2">
-              {availableContacts.length === 0 ? (
-                <p className="text-sm text-slate-500">
-                  {formData.campaign_type === 'email'
-                    ? 'No contacts with email addresses found'
-                    : ['call', 'sms', 'whatsapp'].includes(formData.campaign_type)
-                      ? 'No contacts with phone numbers found'
-                      : 'No contacts found'}
-                </p>
-              ) : (
-                availableContacts.map((contact) => (
-                  <div
-                    key={contact.id}
-                    className="flex items-center gap-3 p-2 hover:bg-slate-800 rounded"
+            {audienceMode === 'manual' ? (
+              <>
+                <div className="flex items-center gap-2 mb-4">
+                  <Checkbox
+                    id="select-all"
+                    checked={
+                      selectedContacts.length === availableContacts.length &&
+                      availableContacts.length > 0
+                    }
+                    onCheckedChange={handleSelectAllContacts}
+                  />
+                  <Label htmlFor="select-all" className="text-slate-200">
+                    Select All ({availableContacts.length} recipients)
+                  </Label>
+                </div>
+
+                <div className="max-h-60 overflow-y-auto border border-slate-700 rounded-md p-4 space-y-2">
+                  {availableContacts.length === 0 ? (
+                    <p className="text-sm text-slate-500">
+                      {formData.campaign_type === 'email'
+                        ? 'No contacts with email addresses found'
+                        : ['call', 'sms', 'whatsapp'].includes(formData.campaign_type)
+                          ? 'No contacts with phone numbers found'
+                          : 'No contacts found'}
+                    </p>
+                  ) : (
+                    availableContacts.map((contact) => (
+                      <div
+                        key={contact.id}
+                        className="flex items-center gap-3 p-2 hover:bg-slate-800 rounded"
+                      >
+                        <Checkbox
+                          id={`contact-${contact.id}`}
+                          checked={selectedContacts.includes(contact.id)}
+                          onCheckedChange={(checked) => handleContactSelection(contact.id, checked)}
+                        />
+                        <div className="flex-grow">
+                          <div className="flex items-center gap-2">
+                            <Badge
+                              variant="outline"
+                              className={`text-xs ${
+                                contact.type === 'contact'
+                                  ? 'border-blue-600 text-blue-300'
+                                  : contact.type === 'lead'
+                                    ? 'border-green-600 text-green-300'
+                                    : 'border-amber-600 text-amber-300'
+                              }`}
+                            >
+                              {contact.type === 'source' ? 'potential' : contact.type}
+                            </Badge>
+                            <span className="font-medium text-slate-200">
+                              {contact.first_name} {contact.last_name}
+                            </span>
+                            {contact.company && (
+                              <span className="text-slate-400">- {contact.company}</span>
+                            )}
+                          </div>
+                          <div className="text-sm text-slate-400">
+                            {formData.campaign_type === 'email'
+                              ? contact.email
+                              : ['call', 'sms', 'whatsapp'].includes(formData.campaign_type)
+                                ? contact.phone
+                                : contact.email || contact.phone || '-'}
+                          </div>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </>
+            ) : (
+              <div className="space-y-3 border border-slate-700 rounded-md p-4">
+                <div>
+                  <Label className="text-slate-200">Audience Prompt</Label>
+                  <Textarea
+                    value={smartAudiencePrompt}
+                    onChange={(e) => setSmartAudiencePrompt(e.target.value)}
+                    placeholder="Example: warm leads inactive 30 days with email"
+                    rows={3}
+                    className="bg-slate-800 border-slate-700 text-slate-200 placeholder:text-slate-400"
+                  />
+                </div>
+                <div>
+                  <Button
+                    type="button"
+                    onClick={handlePreviewAudience}
+                    disabled={audiencePreviewLoading}
+                    className="bg-slate-700 hover:bg-slate-600"
                   >
-                    <Checkbox
-                      id={`contact-${contact.id}`}
-                      checked={selectedContacts.includes(contact.id)}
-                      onCheckedChange={(checked) => handleContactSelection(contact.id, checked)}
-                    />
-                    <div className="flex-grow">
-                      <div className="flex items-center gap-2">
-                        <Badge
-                          variant="outline"
-                          className={`text-xs ${
-                            contact.type === 'contact'
-                              ? 'border-blue-600 text-blue-300'
-                              : contact.type === 'lead'
-                                ? 'border-green-600 text-green-300'
-                                : 'border-amber-600 text-amber-300'
-                          }`}
-                        >
-                          {contact.type === 'source' ? 'potential' : contact.type}
-                        </Badge>
-                        <span className="font-medium text-slate-200">
-                          {contact.first_name} {contact.last_name}
-                        </span>
-                        {contact.company && (
-                          <span className="text-slate-400">- {contact.company}</span>
-                        )}
+                    {audiencePreviewLoading ? 'Previewing...' : 'Preview Audience'}
+                  </Button>
+                </div>
+                {audiencePreviewError ? (
+                  <p className="text-sm text-red-400">{audiencePreviewError}</p>
+                ) : null}
+                <div className="text-sm text-slate-400">Total matches: {audiencePreview.total}</div>
+                {audiencePreview.preview.length > 0 ? (
+                  <div className="max-h-60 overflow-y-auto border border-slate-700 rounded-md p-3 space-y-2">
+                    {audiencePreview.preview.slice(0, 25).map((item, idx) => (
+                      <div key={`${item.contact_id || idx}`} className="text-sm text-slate-300">
+                        <div className="font-medium">
+                          {item.contact_name || 'Unknown'} {item.company ? `- ${item.company}` : ''}
+                        </div>
+                        <div className="text-slate-400">{item.email || item.phone || '-'}</div>
                       </div>
-                      <div className="text-sm text-slate-400">
-                        {formData.campaign_type === 'email'
-                          ? contact.email
-                          : ['call', 'sms', 'whatsapp'].includes(formData.campaign_type)
-                            ? contact.phone
-                            : contact.email || contact.phone || '—'}
-                      </div>
-                    </div>
+                    ))}
                   </div>
-                ))
-              )}
-            </div>
+                ) : null}
+              </div>
+            )}
           </div>
 
           <Separator className="bg-slate-700" />
@@ -1055,6 +1238,50 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
               <Calendar className="w-5 h-5" />
               Schedule
             </h3>
+            <div className="space-y-2">
+              <Label className="text-slate-200">Schedule Type</Label>
+              <Select value={scheduleType} onValueChange={setScheduleType}>
+                <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="bg-slate-800 border-slate-700 text-slate-200 z-[10000]">
+                  <SelectItem value="immediate" className="focus:bg-slate-700">
+                    Send Immediately
+                  </SelectItem>
+                  <SelectItem value="scheduled" className="focus:bg-slate-700">
+                    Schedule for Later
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {scheduleType === 'scheduled' && (
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-2">
+                  <Label htmlFor="scheduled_at" className="text-slate-200">
+                    Scheduled Date & Time
+                  </Label>
+                  <Input
+                    id="scheduled_at"
+                    type="datetime-local"
+                    value={scheduleAt}
+                    onChange={(e) => setScheduleAt(e.target.value)}
+                    className="w-full bg-slate-800 border-slate-700 text-slate-200"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="schedule_timezone" className="text-slate-200">
+                    Timezone
+                  </Label>
+                  <Input
+                    id="schedule_timezone"
+                    value={scheduleTimezone}
+                    onChange={(e) => setScheduleTimezone(e.target.value)}
+                    placeholder="America/New_York"
+                    className="w-full bg-slate-800 border-slate-700 text-slate-200"
+                  />
+                </div>
+              </div>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div className="space-y-2">
                 <Label htmlFor="start_date" className="text-slate-200">

--- a/src/components/campaigns/AICampaignForm.jsx
+++ b/src/components/campaigns/AICampaignForm.jsx
@@ -496,9 +496,16 @@ export default function AICampaignForm({ campaign, onSubmit, onCancel }) {
     setAudiencePreviewLoading(true);
     setAudiencePreviewError('');
     try {
+      const {
+        data: { session: previewSession },
+      } = await supabase.auth.getSession();
+      const previewAuthHeaders = previewSession?.access_token
+        ? { Authorization: `Bearer ${previewSession.access_token}` }
+        : {};
       const response = await fetch(`${getBackendUrl()}/api/aicampaigns/audience-preview`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...previewAuthHeaders },
+        credentials: 'include',
         body: JSON.stringify({
           tenant_id,
           campaign_type: formData.campaign_type,

--- a/src/components/campaigns/CampaignMonitor.jsx
+++ b/src/components/campaigns/CampaignMonitor.jsx
@@ -4,13 +4,13 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { useUser } from '@/components/shared/useUser.js';
 import { useTenant } from '@/components/shared/tenantContext';
-import { AICampaign, BACKEND_URL } from '@/api/entities';
+import { AICampaign, BACKEND_URL, supabase } from '@/api/entities';
 
 // [2026-02-23 Claude] — AiCampaigns overhaul: aligned with DB schema
 export default function CampaignMonitor() {
   const { user } = useUser();
   const { selectedTenantId } = useTenant();
-  const tenant_id = user?.tenant_id || selectedTenantId;
+  const tenant_id = selectedTenantId || user?.tenant_id;
   const [loading, setLoading] = useState(false);
   const [campaigns, setCampaigns] = useState([]);
 
@@ -35,9 +35,15 @@ export default function CampaignMonitor() {
   const startCampaign = async (id) => {
     if (!tenant_id) return;
     try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const authHeaders = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : {};
       await fetch(`${BACKEND_URL}/api/aicampaigns/${id}/start`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         credentials: 'include',
         body: JSON.stringify({ tenant_id }),
       });
@@ -54,9 +60,15 @@ export default function CampaignMonitor() {
   const pauseCampaign = async (id) => {
     if (!tenant_id) return;
     try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const authHeaders = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : {};
       await fetch(`${BACKEND_URL}/api/aicampaigns/${id}/pause`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         credentials: 'include',
         body: JSON.stringify({ tenant_id }),
       });
@@ -69,9 +81,15 @@ export default function CampaignMonitor() {
   const resumeCampaign = async (id) => {
     if (!tenant_id) return;
     try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const authHeaders = session?.access_token
+        ? { Authorization: `Bearer ${session.access_token}` }
+        : {};
       await fetch(`${BACKEND_URL}/api/aicampaigns/${id}/resume`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         credentials: 'include',
         body: JSON.stringify({ tenant_id }),
       });

--- a/src/components/workflows/FieldMappingPanel.jsx
+++ b/src/components/workflows/FieldMappingPanel.jsx
@@ -1,0 +1,222 @@
+/**
+ * FieldMappingPanel
+ *
+ * Reusable Zapier-style field mapper. Each row has:
+ *  - left:  target field (Select from a schema definition)
+ *  - right: source value (token pill picker from upstream node outputs OR free text)
+ *
+ * Props:
+ *  mappings        {Array<{target_field, source_type, source_value}>}
+ *  onChange        (newMappings) => void
+ *  targetSchema    Array<{value, label}> – the entity fields on the left
+ *  upstreamTokens  Array<{key, label, stepIndex, stepLabel, nodeType}> – tokens from upstream nodes
+ *  addLabel        string (default "Add Field")
+ */
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Plus, X, ChevronDown, Tag } from 'lucide-react';
+
+// Groups upstream tokens by step for display
+function groupTokensByStep(tokens) {
+  const groups = {};
+  for (const t of tokens) {
+    const key = `${t.stepIndex}`;
+    if (!groups[key]) groups[key] = { stepIndex: t.stepIndex, stepLabel: t.stepLabel, tokens: [] };
+    groups[key].tokens.push(t);
+  }
+  return Object.values(groups).sort((a, b) => a.stepIndex - b.stepIndex);
+}
+
+function TokenPicker({ value, tokens, onSelect, placeholder }) {
+  const [open, setOpen] = useState(false);
+
+  // Resolve display label for current value
+  const selected = tokens.find((t) => t.key === value);
+  const displayLabel = selected ? `${selected.stepIndex}. ${selected.label}` : value ? value : null;
+
+  const groups = groupTokensByStep(tokens);
+
+  return (
+    <div className="relative flex-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className={`w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-md border text-sm
+          bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 transition-colors min-h-[36px]`}
+      >
+        {selected ? (
+          <span className="flex items-center gap-1.5 truncate">
+            <span className="inline-flex items-center gap-1 bg-purple-600/30 border border-purple-500/40 text-purple-300 rounded px-1.5 py-0.5 text-xs font-mono truncate max-w-[180px]">
+              <Tag className="w-3 h-3 shrink-0" />
+              {selected.stepIndex}. {selected.label}
+            </span>
+          </span>
+        ) : displayLabel ? (
+          <span className="text-slate-400 text-xs truncate font-mono">{displayLabel}</span>
+        ) : (
+          <span className="text-slate-500 text-xs">{placeholder || 'Select or type value…'}</span>
+        )}
+        <ChevronDown className="w-3.5 h-3.5 shrink-0 text-slate-400" />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-1 w-72 bg-slate-900 border border-slate-700 rounded-lg shadow-xl overflow-hidden">
+          {/* Free text input at top */}
+          <div className="p-2 border-b border-slate-700">
+            <Input
+              placeholder="Type static value or {{variable}}"
+              className="bg-slate-800 border-slate-600 text-slate-200 text-xs h-7"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && e.target.value) {
+                  onSelect(e.target.value);
+                  setOpen(false);
+                }
+              }}
+            />
+            <p className="text-[10px] text-slate-500 mt-1">Press Enter to set free-text value</p>
+          </div>
+
+          {/* Token groups */}
+          <div className="max-h-64 overflow-y-auto">
+            {groups.length === 0 ? (
+              <div className="p-3 text-xs text-slate-500">
+                No upstream data available. Run the webhook trigger first to capture a payload.
+              </div>
+            ) : (
+              groups.map((group) => (
+                <div key={group.stepIndex}>
+                  <div className="px-3 py-1.5 bg-slate-800/60 text-[10px] font-semibold text-slate-400 uppercase tracking-wider sticky top-0">
+                    {group.stepIndex}. {group.stepLabel}
+                  </div>
+                  {group.tokens.map((token) => (
+                    <button
+                      key={token.key}
+                      type="button"
+                      onClick={() => {
+                        onSelect(token.key);
+                        setOpen(false);
+                      }}
+                      className="w-full px-3 py-2 text-left hover:bg-slate-700/60 flex items-center gap-2 transition-colors"
+                    >
+                      <Tag className="w-3 h-3 text-purple-400 shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <div className="text-xs text-slate-200 font-mono truncate">
+                          {token.label}
+                        </div>
+                        {token.example !== undefined && (
+                          <div className="text-[10px] text-slate-500 truncate">
+                            {String(token.example).slice(0, 40)}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Click-away backdrop */}
+      {open && <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />}
+    </div>
+  );
+}
+
+export default function FieldMappingPanel({
+  mappings = [],
+  onChange,
+  targetSchema = [],
+  upstreamTokens = [],
+  addLabel = 'Add Field',
+}) {
+  const updateRow = (index, patch) => {
+    const next = mappings.map((m, i) => (i === index ? { ...m, ...patch } : m));
+    onChange(next);
+  };
+
+  const removeRow = (index) => {
+    onChange(mappings.filter((_, i) => i !== index));
+  };
+
+  const addRow = () => {
+    onChange([...mappings, { target_field: '', source_type: 'token', source_value: '' }]);
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Header row */}
+      {mappings.length > 0 && (
+        <div className="flex gap-2 items-center mb-1">
+          <span className="flex-1 text-[10px] text-slate-500 uppercase tracking-wider">
+            Target Field
+          </span>
+          <span className="flex-1 text-[10px] text-slate-500 uppercase tracking-wider">
+            Source Value
+          </span>
+          <span className="w-7" />
+        </div>
+      )}
+
+      {mappings.map((mapping, index) => (
+        <div key={index} className="flex gap-2 items-center">
+          {/* Target field selector */}
+          <div className="flex-1">
+            <Select
+              value={mapping.target_field || ''}
+              onValueChange={(v) => updateRow(index, { target_field: v })}
+            >
+              <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200 text-sm h-9">
+                <SelectValue placeholder="Field…" />
+              </SelectTrigger>
+              <SelectContent className="bg-slate-900 border-slate-700 max-h-64">
+                {targetSchema.map((f) => (
+                  <SelectItem key={f.value} value={f.value}>
+                    {f.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Source value: token picker */}
+          <TokenPicker
+            value={mapping.source_value || ''}
+            tokens={upstreamTokens}
+            onSelect={(v) => updateRow(index, { source_value: v, source_type: 'token' })}
+            placeholder="Pick value…"
+          />
+
+          {/* Remove */}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => removeRow(index)}
+            className="w-7 h-7 shrink-0 text-red-400 hover:text-red-300 hover:bg-red-900/20"
+          >
+            <X className="w-3.5 h-3.5" />
+          </Button>
+        </div>
+      ))}
+
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={addRow}
+        className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 w-full mt-1"
+      >
+        <Plus className="w-4 h-4 mr-2" />
+        {addLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1094,106 +1094,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to lead fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.lead_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, lead_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Lead Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="score">Score</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="source">Source</SelectItem>
-                        <SelectItem value="next_action">Next Action</SelectItem>
-                        <SelectItem value="score_reason">Score Reason</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { lead_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to lead fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.lead}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Lead Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2351,105 +2259,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to contact fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.contact_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, contact_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Contact Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="first_name">First Name</SelectItem>
-                        <SelectItem value="last_name">Last Name</SelectItem>
-                        <SelectItem value="email">Email</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { contact_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to contact fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.contact}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Contact Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2868,36 +2685,23 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
             </div>
 
             <div>
-              <Label className="text-slate-200">Subject/Title</Label>
-              <Input
-                value={node.config?.title || ''}
-                onChange={(e) => {
-                  updateNodeConfig(node.id, { ...node.config, title: e.target.value });
-                }}
-                placeholder="e.g., Follow-up email"
-                className="bg-slate-800 border-slate-700 text-slate-200"
-              />
-            </div>
-
-            <div>
-              <Label className="text-slate-200">Details</Label>
-              <textarea
-                value={node.config?.details || ''}
-                onChange={(e) => {
-                  updateNodeConfig(node.id, { ...node.config, details: e.target.value });
-                }}
-                placeholder="Activity details (supports {{field}} replacements)"
-                className="w-full min-h-[120px] rounded-md bg-slate-800 border border-slate-700 text-slate-200 p-2"
-              />
-              <p className="text-xs text-slate-500 mt-1">
-                Use {'{{field_name}}'} to reference webhook data
+              <Label className="text-slate-200">Field Mappings</Label>
+              <p className="text-sm text-slate-400 mb-3">
+                Map inbound data to activity fields. Subject, Body, Status, Due Date, Assigned To.
               </p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.activity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Activity Field"
+              />
             </div>
 
             <div>
               <Label className="text-slate-200">Associate With</Label>
               <Select
-                value={node.config?.associate || 'lead'}
+                value={node.config?.associate || 'auto'}
                 onValueChange={(value) => {
                   updateNodeConfig(node.id, { ...node.config, associate: value });
                 }}
@@ -2906,12 +2710,17 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-700">
+                  <SelectItem value="auto">Auto-detect from upstream (recommended)</SelectItem>
                   <SelectItem value="lead">Lead</SelectItem>
                   <SelectItem value="contact">Contact</SelectItem>
                   <SelectItem value="account">Account</SelectItem>
                   <SelectItem value="opportunity">Opportunity</SelectItem>
                 </SelectContent>
               </Select>
+              <p className="text-xs text-slate-500 mt-1">
+                Auto-detect uses the first found_lead / found_contact / found_account /
+                found_opportunity from upstream nodes.
+              </p>
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -733,11 +733,15 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           rows: [
             row('id', 'ID', '(existing)'),
             ...mappings.map((m) => {
-              const val = m.webhook_field
-                ? (resolvePayloadPath(m.webhook_field, testPayload) ?? null)
+              const targetField = m.target_field || m.contact_field || m.lead_field;
+              const sourceValue = m.source_value || m.webhook_field;
+              if (!targetField) return null;
+              const val = sourceValue
+                ? (resolvePayloadPath(sourceValue, testPayload) ??
+                   resolvePreviewVar(`{{${sourceValue}}}`, testPayload))
                 : null;
-              return row(m.contact_field || m.lead_field, m.contact_field || m.lead_field, val);
-            }),
+              return row(targetField, targetField, val);
+            }).filter(Boolean),
             row('updated_at', 'Updated At', '(now)'),
           ],
         };
@@ -2765,7 +2769,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                 onChange={(e) => {
                   updateNodeConfig(node.id, { ...node.config, details: e.target.value });
                 }}
-                placeholder="Activity details â€” click a variable in the output preview to insert"
+                placeholder="Activity details — click a variable in the output preview to insert"
                 className="w-full min-h-[120px] rounded-md bg-slate-800 border border-slate-700 text-slate-200 p-2"
               />
             </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -30,6 +30,20 @@ import NodeLibrary from './NodeLibrary';
 import WorkflowTemplatesBrowser from './WorkflowTemplatesBrowser';
 import FieldMappingPanel from './FieldMappingPanel';
 import { getUpstreamTokens, ENTITY_SCHEMAS } from './upstreamTokens';
+// Normalise legacy {entity_field, webhook_field} mapping shapes to unified {target_field, source_value}
+// so FieldMappingPanel renders correctly for workflows saved before this change.
+function normaliseMappings(mappings) {
+  if (!Array.isArray(mappings)) return [];
+  return mappings.map((m) => {
+    if (m.target_field !== undefined) return m;
+    const legacyKey =
+      m.lead_field || m.contact_field || m.account_field || m.opportunity_field || m.activity_field;
+    if (legacyKey) {
+      return { target_field: legacyKey, source_value: m.webhook_field || m.source_value || '' };
+    }
+    return m;
+  });
+}
 import { useToast } from '@/components/ui/use-toast';
 import { WorkflowExecution } from '@/api/entities';
 import { Switch } from '@/components/ui/switch';
@@ -663,15 +677,17 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               varPath: `${prefix}.id`,
             },
             ...mappings.map((m) => {
-              const val = m.webhook_field
-                ? (resolvePayloadPath(m.webhook_field, testPayload) ??
-                  resolvePreviewVar(`{{${m.webhook_field}}}`, testPayload))
+              const targetField = m.target_field || m.lead_field;
+              const sourceValue = m.source_value || m.webhook_field;
+              const val = sourceValue
+                ? (resolvePayloadPath(sourceValue, testPayload) ??
+                  resolvePreviewVar(`{{${sourceValue}}}`, testPayload))
                 : null;
               return {
-                field: m.lead_field,
-                label: m.lead_field,
+                field: targetField,
+                label: targetField,
                 value: val,
-                varPath: `${prefix}.${m.lead_field}`,
+                varPath: `${prefix}.${targetField}`,
               };
             }),
             {
@@ -800,39 +816,39 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
         return {
           description: 'Newly created activity — click any row to insert into a focused field',
           rows: [
-            { field: 'id', label: 'ID', value: '(generated)', varPath: 'activity.id' },
-            { field: 'type', label: 'Type', value: actType, varPath: 'activity.type' },
+            { field: 'id', label: 'ID', value: '(generated)', varPath: 'created_activity.id' },
+            { field: 'type', label: 'Type', value: actType, varPath: 'created_activity.type' },
             {
               field: 'subject',
               label: 'Subject',
               value: subject || null,
-              varPath: 'activity.subject',
+              varPath: 'created_activity.subject',
             },
-            { field: 'body', label: 'Body', value: body || null, varPath: 'activity.body' },
-            { field: 'status', label: 'Status', value: 'scheduled', varPath: 'activity.status' },
+            { field: 'body', label: 'Body', value: body || null, varPath: 'created_activity.body' },
+            { field: 'status', label: 'Status', value: 'scheduled', varPath: 'created_activity.status' },
             {
               field: 'related_to',
               label: 'Related To',
               value: relatedTo,
-              varPath: 'activity.related_to',
+              varPath: 'created_activity.related_to',
             },
             {
               field: 'related_id',
               label: 'Related ID',
               value: relatedId,
-              varPath: 'activity.related_id',
+              varPath: 'created_activity.related_id',
             },
             {
               field: 'assigned_to',
               label: 'Assigned To',
               value: assignedToRaw || null,
-              varPath: 'activity.assigned_to',
+              varPath: 'created_activity.assigned_to',
             },
             {
               field: 'created_date',
               label: 'Created Date',
               value: '(now)',
-              varPath: 'activity.created_date',
+              varPath: 'created_activity.created_date',
             },
           ],
         };
@@ -1393,7 +1409,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to new lead fields</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.lead}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -1411,7 +1427,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to lead fields to update</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.lead}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -2576,7 +2592,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to contact fields to update</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.contact}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -2657,7 +2673,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to account fields to update</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.account}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -2676,7 +2692,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to new opportunity fields</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.opportunity}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -2695,7 +2711,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               <Label className="text-slate-200">Field Mappings</Label>
               <p className="text-sm text-slate-400 mb-3">Map inbound data to opportunity fields to update</p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.opportunity}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
@@ -2770,7 +2786,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                 Leave blank to use campaign owner automatically
               </p>
               <FieldMappingPanel
-                mappings={node.config?.field_mappings || []}
+                mappings={normaliseMappings(node.config?.field_mappings || [])}
                 onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
                 targetSchema={ENTITY_SCHEMAS.activity}
                 upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -28,6 +28,8 @@ import {
 import WorkflowCanvas from './WorkflowCanvas';
 import NodeLibrary from './NodeLibrary';
 import WorkflowTemplatesBrowser from './WorkflowTemplatesBrowser';
+import FieldMappingPanel from './FieldMappingPanel';
+import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from './upstreamTokens';
 import { useToast } from '@/components/ui/use-toast';
 import { WorkflowExecution } from '@/api/entities';
 import { Switch } from '@/components/ui/switch';
@@ -1074,108 +1076,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to new lead fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.lead_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, lead_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Lead Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="first_name">First Name</SelectItem>
-                        <SelectItem value="last_name">Last Name</SelectItem>
-                        <SelectItem value="email">Email</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="score">Score</SelectItem>
-                        <SelectItem value="job_title">Job Title</SelectItem>
-                        <SelectItem value="source">Source</SelectItem>
-                        <SelectItem value="next_action">Next Action</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { lead_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to new lead fields</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.lead}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Lead Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -58,6 +58,29 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
 
   const [autoConnect, setAutoConnect] = useState(true);
   const [showTemplates, setShowTemplates] = useState(false);
+
+  // Track the most recently focused text input/textarea inside a node config panel
+  // so that clicking an output-preview row can insert {{variable}} at cursor position.
+  const lastFocusedInputRef = useRef(null);
+
+  const insertAtFocused = useCallback((token) => {
+    const el = lastFocusedInputRef.current;
+    if (!el || (el.tagName !== 'INPUT' && el.tagName !== 'TEXTAREA')) return;
+    const start = el.selectionStart ?? el.value.length;
+    const end = el.selectionEnd ?? el.value.length;
+    const newVal = el.value.slice(0, start) + token + el.value.slice(end);
+    // Update via React's internal setter so onChange fires properly
+    const proto =
+      el.tagName === 'TEXTAREA'
+        ? window.HTMLTextAreaElement.prototype
+        : window.HTMLInputElement.prototype;
+    const nativeSetter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+    if (nativeSetter) nativeSetter.call(el, newVal);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    const cursor = start + token.length;
+    el.setSelectionRange(cursor, cursor);
+    el.focus();
+  }, []);
 
   // Template handler
   const handleSelectTemplate = (template) => {
@@ -498,9 +521,42 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
     return Object.keys(testPayload);
   };
 
+  // Resolve a template string like "{{contact.email}}" against testPayload
+  const resolvePreviewVar = (template, payload) => {
+    if (!template || !payload) return template;
+    return String(template).replace(/\{\{([^}]+)\}\}/g, (_, path) => {
+      const parts = path.trim().split('.');
+      let val = payload;
+      for (const p of parts) {
+        if (val == null) break;
+        val = val[p];
+      }
+      return val != null ? String(val) : `{{${path.trim()}}}`;
+    });
+  };
+
+  // Resolve a deep path like "contact.email" against testPayload
+  const resolvePayloadPath = (path, payload) => {
+    if (!payload) return undefined;
+    return path.split('.').reduce((obj, key) => (obj != null ? obj[key] : undefined), payload);
+  };
+
   // Generate output preview for a node
   const generateNodeOutputPreview = (node) => {
     if (!node) return null;
+    const cfg = node.config || {};
+
+    // Helper: produce a field-value map for Zapier-style display
+    // Each entry: { field, label, value, fromVar? }
+    const row = (field, label, value) => ({ field, label, value: value ?? null });
+
+    // row helper extended with varPath (the {{...}} expression to insert)
+    const rowV = (field, label, value, varPath) => ({
+      field,
+      label,
+      value: value ?? null,
+      varPath: varPath || field,
+    });
 
     switch (node.type) {
       case 'webhook_trigger':
@@ -508,235 +564,385 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           return {
             description:
               'No webhook data captured yet. Use "Wait for Real Webhook" or "Use Sample Payload".',
-            fields: [],
-            example: null,
+            rows: [],
           };
         }
         return {
-          description: 'Webhook payload data available to downstream nodes',
-          fields: Object.keys(testPayload),
-          example: testPayload,
+          description:
+            'Live data from the last received webhook — click any row to insert into a focused field',
+          rows: Object.entries(testPayload).flatMap(([k, v]) =>
+            v !== null && typeof v === 'object'
+              ? Object.entries(v).map(([k2, v2]) =>
+                  rowV(
+                    `${k}.${k2}`,
+                    `${k} → ${k2}`,
+                    typeof v2 === 'object' ? JSON.stringify(v2) : v2,
+                    `${k}.${k2}`,
+                  ),
+                )
+              : [rowV(k, k, typeof v === 'object' ? JSON.stringify(v) : v, k)],
+          ),
         };
 
-      case 'find_lead':
+      case 'find_lead': {
+        const firstName =
+          resolvePayloadPath('contact.contact_name', testPayload)?.split(' ')[0] ||
+          resolvePayloadPath('first_name', testPayload) ||
+          null;
+        const lastName =
+          resolvePayloadPath('contact.contact_name', testPayload)?.split(' ').slice(1).join(' ') ||
+          resolvePayloadPath('last_name', testPayload) ||
+          null;
+        const email =
+          resolvePayloadPath('contact.email', testPayload) ||
+          resolvePayloadPath('email', testPayload) ||
+          null;
         return {
-          description: 'Lead data if found, otherwise empty',
-          fields: [
-            'id',
-            'first_name',
-            'last_name',
-            'email',
-            'phone',
-            'company',
-            'status',
-            'score',
-            'job_title',
-            'source',
-            'next_action',
-            'notes',
-            'created_at',
-            'updated_at',
+          description:
+            'Lead record if a match is found — click any row to insert into a focused field',
+          rows: [
+            {
+              field: 'id',
+              label: 'ID',
+              value: testPayload ? '(resolved at runtime)' : null,
+              varPath: 'found_lead.id',
+            },
+            {
+              field: 'first_name',
+              label: 'First Name',
+              value: firstName,
+              varPath: 'found_lead.first_name',
+            },
+            {
+              field: 'last_name',
+              label: 'Last Name',
+              value: lastName,
+              varPath: 'found_lead.last_name',
+            },
+            { field: 'email', label: 'Email', value: email, varPath: 'found_lead.email' },
+            {
+              field: 'phone',
+              label: 'Phone',
+              value: resolvePayloadPath('contact.phone', testPayload) || null,
+              varPath: 'found_lead.phone',
+            },
+            {
+              field: 'company',
+              label: 'Company',
+              value: resolvePayloadPath('contact.company', testPayload) || null,
+              varPath: 'found_lead.company',
+            },
+            { field: 'status', label: 'Status', value: null, varPath: 'found_lead.status' },
+            { field: 'score', label: 'Score', value: null, varPath: 'found_lead.score' },
+            {
+              field: 'created_at',
+              label: 'Created At',
+              value: null,
+              varPath: 'found_lead.created_at',
+            },
           ],
-          example: testPayload
-            ? {
-                id: 'lead_uuid',
-                first_name: testPayload.first_name || 'John',
-                last_name: testPayload.last_name || 'Doe',
-                email: testPayload.email || 'john@example.com',
-                phone: testPayload.phone || '+1234567890',
-                company: testPayload.company || 'Example Corp',
-                status: 'new',
-                score: null,
-                job_title: testPayload.job_title || null,
-                source: testPayload.source || null,
-                created_at: '2024-01-01T00:00:00Z',
-                updated_at: '2024-01-01T00:00:00Z',
-              }
-            : null,
         };
+      }
 
       case 'create_lead':
-        const createMappings = node.config?.field_mappings || [];
-        const createFields = createMappings.map((m) => m.lead_field).filter(Boolean);
-        const createExample = {};
-        if (testPayload && createMappings.length > 0) {
-          createMappings.forEach((mapping) => {
-            if (mapping.lead_field && mapping.webhook_field) {
-              createExample[mapping.lead_field] =
-                testPayload[mapping.webhook_field] || `{{${mapping.webhook_field}}}`;
-            }
-          });
-        }
+      case 'update_lead': {
+        const mappings = cfg.field_mappings || [];
+        const prefix = node.type === 'create_lead' ? 'created_lead' : 'updated_lead';
         return {
-          description: 'Newly created lead with mapped fields',
-          fields: ['id', ...createFields, 'created_at', 'updated_at'],
-          example:
-            Object.keys(createExample).length > 0
-              ? { id: 'new_lead_uuid', ...createExample, created_at: '2024-01-01T00:00:00Z' }
-              : null,
+          description:
+            node.type === 'create_lead'
+              ? 'Newly created lead record — click any row to insert into a focused field'
+              : 'Updated lead record — click any row to insert into a focused field',
+          rows: [
+            {
+              field: 'id',
+              label: 'ID',
+              value: node.type === 'create_lead' ? '(generated)' : '(existing)',
+              varPath: `${prefix}.id`,
+            },
+            ...mappings.map((m) => {
+              const val = m.webhook_field
+                ? (resolvePayloadPath(m.webhook_field, testPayload) ??
+                  resolvePreviewVar(`{{${m.webhook_field}}}`, testPayload))
+                : null;
+              return {
+                field: m.lead_field,
+                label: m.lead_field,
+                value: val,
+                varPath: `${prefix}.${m.lead_field}`,
+              };
+            }),
+            {
+              field: node.type === 'create_lead' ? 'created_at' : 'updated_at',
+              label: node.type === 'create_lead' ? 'Created At' : 'Updated At',
+              value: '(now)',
+              varPath: `${prefix}.${node.type === 'create_lead' ? 'created_at' : 'updated_at'}`,
+            },
+          ],
         };
-
-      case 'update_lead':
-        const updateMappings = node.config?.field_mappings || [];
-        const updateFields = updateMappings.map((m) => m.lead_field).filter(Boolean);
-        const updateExample = {};
-        if (testPayload && updateMappings.length > 0) {
-          updateMappings.forEach((mapping) => {
-            if (mapping.lead_field && mapping.webhook_field) {
-              updateExample[mapping.lead_field] =
-                testPayload[mapping.webhook_field] || `{{${mapping.webhook_field}}}`;
-            }
-          });
-        }
-        return {
-          description: 'Updated lead with modified fields',
-          fields: ['id', ...updateFields, 'updated_at'],
-          example:
-            Object.keys(updateExample).length > 0
-              ? { id: 'lead_uuid', ...updateExample, updated_at: '2024-01-01T00:00:00Z' }
-              : null,
-        };
+      }
 
       case 'find_contact':
         return {
-          description: 'Contact data if found',
-          fields: [
-            'id',
-            'first_name',
-            'last_name',
-            'email',
-            'phone',
-            'title',
-            'department',
-            'account_id',
-            'created_at',
+          description: 'Contact record if a match is found',
+          rows: [
+            row('id', 'ID', null),
+            row(
+              'first_name',
+              'First Name',
+              resolvePayloadPath('contact.contact_name', testPayload)?.split(' ')[0] || null,
+            ),
+            row(
+              'last_name',
+              'Last Name',
+              resolvePayloadPath('contact.contact_name', testPayload)
+                ?.split(' ')
+                .slice(1)
+                .join(' ') || null,
+            ),
+            row('email', 'Email', resolvePayloadPath('contact.email', testPayload) || null),
+            row('phone', 'Phone', resolvePayloadPath('contact.phone', testPayload) || null),
+            row('title', 'Title', null),
+            row('department', 'Department', null),
+            row('account_id', 'Account ID', null),
           ],
-          example: null,
         };
 
-      case 'update_contact':
+      case 'update_contact': {
+        const mappings = cfg.field_mappings || [];
         return {
-          description: 'Updated contact data',
-          fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'title', 'updated_at'],
-          example: null,
+          description: 'Updated contact record',
+          rows: [
+            row('id', 'ID', '(existing)'),
+            ...mappings.map((m) => {
+              const val = m.webhook_field
+                ? (resolvePayloadPath(m.webhook_field, testPayload) ?? null)
+                : null;
+              return row(m.contact_field || m.lead_field, m.contact_field || m.lead_field, val);
+            }),
+            row('updated_at', 'Updated At', '(now)'),
+          ],
         };
+      }
 
       case 'find_account':
         return {
-          description: 'Account data if found',
-          fields: ['id', 'name', 'website', 'industry', 'size', 'phone', 'created_at'],
-          example: null,
+          description: 'Account record if a match is found',
+          rows: [
+            row('id', 'ID', null),
+            row('name', 'Name', resolvePayloadPath('contact.company', testPayload) || null),
+            row('website', 'Website', null),
+            row('industry', 'Industry', null),
+            row('size', 'Size', null),
+            row('phone', 'Phone', null),
+          ],
         };
 
       case 'update_account':
         return {
-          description: 'Updated account data',
-          fields: ['id', 'name', 'website', 'industry', 'size', 'updated_at'],
-          example: null,
+          description: 'Updated account record',
+          rows: [
+            row('id', 'ID', '(existing)'),
+            row('name', 'Name', null),
+            row('website', 'Website', null),
+            row('industry', 'Industry', null),
+            row('updated_at', 'Updated At', '(now)'),
+          ],
         };
 
       case 'create_opportunity':
         return {
           description: 'Newly created opportunity',
-          fields: ['id', 'name', 'amount', 'stage', 'close_date', 'account_id', 'created_at'],
-          example: null,
+          rows: [
+            row('id', 'ID', '(generated)'),
+            row('name', 'Name', resolvePreviewVar(cfg.name || '', testPayload) || null),
+            row('amount', 'Amount', cfg.amount || null),
+            row('stage', 'Stage', cfg.stage || null),
+            row('close_date', 'Close Date', cfg.close_date || null),
+            row('account_id', 'Account ID', null),
+            row('created_at', 'Created At', '(now)'),
+          ],
         };
 
       case 'update_opportunity':
         return {
-          description: 'Updated opportunity data',
-          fields: ['id', 'name', 'amount', 'stage', 'close_date', 'updated_at'],
-          example: null,
+          description: 'Updated opportunity',
+          rows: [
+            row('id', 'ID', '(existing)'),
+            row('name', 'Name', resolvePreviewVar(cfg.name || '', testPayload) || null),
+            row('amount', 'Amount', cfg.amount || null),
+            row('stage', 'Stage', cfg.stage || null),
+            row('updated_at', 'Updated At', '(now)'),
+          ],
         };
 
-      case 'create_activity':
+      case 'create_activity': {
+        const actType = cfg.type || 'task';
+        const campaignName = resolvePayloadPath('campaign.name', testPayload) || null;
+        const defaultSubject = campaignName ? `Campaign: ${campaignName}` : 'Workflow activity';
+        const defaultBody = campaignName ? `Dispatched via campaign: ${campaignName}` : '';
+        const subject = resolvePreviewVar(cfg.title || cfg.subject || defaultSubject, testPayload);
+        const body = resolvePreviewVar(cfg.details || cfg.description || defaultBody, testPayload);
+        const entityTypeRaw =
+          cfg.associate && cfg.associate !== 'auto'
+            ? cfg.associate
+            : resolvePayloadPath('contact.entity_type', testPayload) || 'contact';
+        const normalizeET = (t) =>
+          t === 'potential_lead' || t === 'source' ? 'bizdev_source' : t || 'contact';
+        const relatedTo = normalizeET(entityTypeRaw);
+        const relatedId = resolvePayloadPath('contact.contact_id', testPayload) || null;
+        const assignedToRaw =
+          resolvePreviewVar(cfg.assigned_to || '', testPayload) ||
+          resolvePayloadPath('assigned_to', testPayload) ||
+          null;
         return {
-          description: 'Newly created activity',
-          fields: ['id', 'type', 'subject', 'description', 'due_date', 'created_at'],
-          example: null,
+          description: 'Newly created activity — click any row to insert into a focused field',
+          rows: [
+            { field: 'id', label: 'ID', value: '(generated)', varPath: 'activity.id' },
+            { field: 'type', label: 'Type', value: actType, varPath: 'activity.type' },
+            {
+              field: 'subject',
+              label: 'Subject',
+              value: subject || null,
+              varPath: 'activity.subject',
+            },
+            { field: 'body', label: 'Body', value: body || null, varPath: 'activity.body' },
+            { field: 'status', label: 'Status', value: 'scheduled', varPath: 'activity.status' },
+            {
+              field: 'related_to',
+              label: 'Related To',
+              value: relatedTo,
+              varPath: 'activity.related_to',
+            },
+            {
+              field: 'related_id',
+              label: 'Related ID',
+              value: relatedId,
+              varPath: 'activity.related_id',
+            },
+            {
+              field: 'assigned_to',
+              label: 'Assigned To',
+              value: assignedToRaw || null,
+              varPath: 'activity.assigned_to',
+            },
+            {
+              field: 'created_date',
+              label: 'Created Date',
+              value: '(now)',
+              varPath: 'activity.created_date',
+            },
+          ],
         };
+      }
 
       case 'http_request':
         return {
-          description: 'HTTP response data',
-          fields: ['status', 'headers', 'body', 'data'],
-          example: {
-            status: 200,
-            headers: { 'content-type': 'application/json' },
-            body: '{"success": true}',
-            data: { success: true },
-          },
+          description: `${cfg.method || 'GET'} ${cfg.url || '(url not set)'}`,
+          rows: [
+            row('status', 'HTTP Status', '200'),
+            row('body', 'Response Body', '(from server)'),
+            row('data', 'Parsed Data', '(if JSON)'),
+          ],
         };
 
       case 'ai_classify_opportunity_stage':
         return {
-          description: 'AI-classified opportunity stage',
-          fields: ['stage', 'confidence', 'reasoning'],
-          example: {
-            stage: 'qualification',
-            confidence: 0.85,
-            reasoning: 'Based on conversation context...',
-          },
+          description: 'AI classifies the opportunity stage from conversation',
+          rows: [
+            row('stage', 'Stage', 'qualification'),
+            row('confidence', 'Confidence', '0.85'),
+            row('reasoning', 'Reasoning', '(AI explanation)'),
+          ],
         };
 
       case 'ai_generate_email':
         return {
           description: 'AI-generated email content',
-          fields: ['subject', 'body', 'tone'],
-          example: {
-            subject: 'Follow up on our conversation',
-            body: 'Hi John,\n\nThank you for...',
-            tone: 'professional',
-          },
+          rows: [
+            row(
+              'subject',
+              'Subject',
+              resolvePreviewVar(cfg.subject || '', testPayload) || '(AI generated)',
+            ),
+            row('body', 'Body', '(AI generated)'),
+            row('tone', 'Tone', cfg.tone || 'professional'),
+          ],
         };
 
       case 'ai_enrich_account':
         return {
-          description: 'Enriched account data from AI',
-          fields: ['industry', 'size', 'description', 'technologies', 'social_links'],
-          example: null,
+          description: 'Enriched company data from AI research',
+          rows: [
+            row('industry', 'Industry', null),
+            row('size', 'Size', null),
+            row('description', 'Description', null),
+            row('technologies', 'Technologies', null),
+            row('social_links', 'Social Links', null),
+          ],
         };
 
       case 'ai_route_activity':
         return {
           description: 'AI routing decision',
-          fields: ['assigned_to', 'priority', 'reasoning'],
-          example: null,
+          rows: [
+            row('assigned_to', 'Assigned To', null),
+            row('priority', 'Priority', null),
+            row('reasoning', 'Reasoning', null),
+          ],
         };
 
       case 'pep_query':
         return {
-          description: 'Query results from PEP (Plain English Programming)',
-          fields: ['results', 'count', 'query'],
-          example: null,
+          description: 'Results from PEP (Plain English Programming) query',
+          rows: [
+            row('results', 'Results', '[ ... ]'),
+            row('count', 'Count', null),
+            row('query', 'Query', cfg.query || null),
+          ],
         };
 
       case 'send_email':
         return {
-          description: 'Email send status',
-          fields: ['sent', 'message_id', 'error'],
-          example: { sent: true, message_id: 'msg_12345', error: null },
+          description: 'Email send result',
+          rows: [
+            row('sent', 'Sent', 'true'),
+            row('message_id', 'Message ID', '(generated)'),
+            row('error', 'Error', null),
+          ],
         };
 
       case 'initiate_call':
         return {
-          description: 'Call initiation status',
-          fields: ['call_id', 'status', 'started_at'],
-          example: null,
+          description: 'Call initiation result',
+          rows: [
+            row('call_id', 'Call ID', '(generated)'),
+            row('status', 'Status', 'initiated'),
+            row('started_at', 'Started At', '(now)'),
+          ],
         };
 
       case 'condition':
         return {
-          description: 'Condition evaluation result',
-          fields: ['matched', 'branch_taken'],
-          example: { matched: true, branch_taken: 'true_branch' },
+          description: 'Branch taken based on condition evaluation',
+          rows: [
+            row('matched', 'Condition Met', 'true / false'),
+            row('branch_taken', 'Branch Taken', 'true_branch / false_branch'),
+          ],
         };
 
       case 'care_trigger':
         return {
-          description: 'CARE workflow data',
-          fields: ['entity_type', 'entity_id', 'event_type'],
-          example: null,
+          description: 'CARE workflow context',
+          rows: [
+            row(
+              'entity_type',
+              'Entity Type',
+              resolvePayloadPath('entity_type', testPayload) || null,
+            ),
+            row('entity_id', 'Entity ID', resolvePayloadPath('entity_id', testPayload) || null),
+            row('event_type', 'Event Type', resolvePayloadPath('event_type', testPayload) || null),
+          ],
         };
 
       default:
@@ -744,43 +950,152 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
     }
   };
 
-  // Render output preview section
+  // Render output preview — Zapier-style field → value rows, each row clickable to insert {{varPath}}
   const renderOutputPreview = (node) => {
     const preview = generateNodeOutputPreview(node);
     if (!preview) return null;
+
+    const hasAnyValue = preview.rows?.some((r) => r.value !== null && r.value !== undefined);
 
     return (
       <div className="mt-4 border-t border-slate-700 pt-4">
         <div className="flex items-center gap-2 mb-2">
           <Sparkles className="w-4 h-4 text-purple-400" />
           <Label className="text-slate-200">Output Preview</Label>
+          {hasAnyValue && <span className="text-xs text-emerald-400 ml-auto">live data</span>}
         </div>
         <p className="text-xs text-slate-400 mb-2">{preview.description}</p>
 
-        {preview.fields.length > 0 && (
-          <div className="bg-slate-950 border border-slate-700 rounded p-3">
-            <div className="text-xs text-slate-500 mb-1">Available fields:</div>
-            <div className="flex flex-wrap gap-1">
-              {preview.fields.map((field) => (
-                <span
+        {preview.rows?.length > 0 && (
+          <div className="bg-slate-950 border border-slate-700 rounded overflow-hidden">
+            {preview.rows.map(({ field, label, value, varPath }, i) => {
+              const token = `{{${varPath || field}}}`;
+              return (
+                <div
                   key={field}
-                  className="px-2 py-1 bg-purple-900/30 text-purple-300 rounded text-xs"
+                  title={`Click to insert ${token} into the focused field`}
+                  className={`group flex items-start gap-0 text-xs cursor-pointer select-none
+                    hover:bg-blue-900/20 active:bg-blue-900/40 transition-colors
+                    ${i !== 0 ? 'border-t border-slate-800' : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => insertAtFocused(token)}
                 >
-                  {field}
-                </span>
+                  <div className="w-32 shrink-0 px-3 py-2 text-slate-400 font-mono bg-slate-900/60 border-r border-slate-800 self-stretch flex items-center gap-1">
+                    <span className="opacity-0 group-hover:opacity-100 text-blue-400 text-[10px]">
+                      +
+                    </span>
+                    {label}
+                  </div>
+                  <div
+                    className={`flex-1 px-3 py-2 font-mono break-all ${value !== null && value !== undefined ? 'text-slate-200' : 'text-slate-600 italic'}`}
+                  >
+                    {value !== null && value !== undefined ? String(value) : 'not set'}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <p className="text-xs text-slate-600 mt-1">
+          Click a row to insert its variable into the focused field above
+        </p>
+      </div>
+    );
+  };
+
+  // Variable paths exposed by each node type (matches workflowExecutionService context)
+  const NODE_VARIABLE_SCHEMA = {
+    webhook_trigger: [
+      { path: 'event', label: 'Event type' },
+      { path: 'channel', label: 'Channel' },
+      { path: 'destination', label: 'Destination' },
+      { path: 'assigned_to', label: 'Assigned to (campaign owner)' },
+      { path: 'contact.entity_type', label: 'Entity type (lead/contact/potential)' },
+      { path: 'contact.contact_id', label: 'Contact/Lead ID' },
+      { path: 'contact.contact_name', label: 'Contact name' },
+      { path: 'contact.email', label: 'Contact email' },
+      { path: 'contact.phone', label: 'Contact phone' },
+      { path: 'contact.company', label: 'Contact company' },
+      { path: 'campaign.name', label: 'Campaign name' },
+      { path: 'campaign.assigned_to', label: 'Campaign owner email' },
+      { path: 'campaign_id', label: 'Campaign ID' },
+    ],
+    find_lead: [
+      { path: 'found_lead.id', label: 'Lead ID' },
+      { path: 'found_lead.first_name', label: 'First name' },
+      { path: 'found_lead.last_name', label: 'Last name' },
+      { path: 'found_lead.email', label: 'Email' },
+      { path: 'found_lead.phone', label: 'Phone' },
+      { path: 'found_lead.company', label: 'Company' },
+      { path: 'found_lead.status', label: 'Status' },
+    ],
+    find_contact: [
+      { path: 'found_contact.id', label: 'Contact ID' },
+      { path: 'found_contact.first_name', label: 'First name' },
+      { path: 'found_contact.last_name', label: 'Last name' },
+      { path: 'found_contact.email', label: 'Email' },
+      { path: 'found_contact.phone', label: 'Phone' },
+    ],
+    find_account: [
+      { path: 'found_account.id', label: 'Account ID' },
+      { path: 'found_account.name', label: 'Account name' },
+    ],
+    find_opportunity: [
+      { path: 'found_opportunity.id', label: 'Opportunity ID' },
+      { path: 'found_opportunity.name', label: 'Name' },
+      { path: 'found_opportunity.stage', label: 'Stage' },
+      { path: 'found_opportunity.amount', label: 'Amount' },
+    ],
+  };
+
+  // Walk connections backwards to collect all upstream node types for a given node
+  const getUpstreamVariables = (nodeId) => {
+    const visited = new Set();
+    const upstream = [];
+    const queue = [nodeId];
+    while (queue.length) {
+      const current = queue.shift();
+      if (visited.has(current)) continue;
+      visited.add(current);
+      const parents = connections.filter((c) => c.to === current).map((c) => c.from);
+      for (const parentId of parents) {
+        const parentNode = nodes.find((n) => n.id === parentId);
+        if (parentNode && NODE_VARIABLE_SCHEMA[parentNode.type]) {
+          upstream.push({ nodeType: parentNode.type, vars: NODE_VARIABLE_SCHEMA[parentNode.type] });
+        }
+        queue.push(parentId);
+      }
+    }
+    return upstream;
+  };
+
+  // Render clickable variable chip pills for text fields in create_activity
+  const renderVariablePicker = (nodeId, onInsert) => {
+    const upstreamVars = getUpstreamVariables(nodeId);
+    if (!upstreamVars.length) return null;
+    return (
+      <div className="mt-3 p-3 bg-slate-900 border border-slate-700 rounded-lg space-y-2">
+        <p className="text-xs font-medium text-slate-400 uppercase tracking-wide">
+          Available variables
+        </p>
+        {upstreamVars.map(({ nodeType, vars }) => (
+          <div key={nodeType}>
+            <p className="text-xs text-slate-500 mb-1 capitalize">{nodeType.replace(/_/g, ' ')}</p>
+            <div className="flex flex-wrap gap-1">
+              {vars.map(({ path, label }) => (
+                <button
+                  key={path}
+                  type="button"
+                  title={`Insert {{${path}}}`}
+                  onClick={() => onInsert(`{{${path}}}`)}
+                  className="text-xs px-2 py-0.5 rounded bg-blue-900/40 border border-blue-700/60 text-blue-300 hover:bg-blue-700/50 hover:text-blue-100 transition-colors"
+                >
+                  {label}
+                </button>
               ))}
             </div>
           </div>
-        )}
-
-        {preview.example && (
-          <div className="mt-2 bg-slate-950 border border-slate-700 rounded p-3">
-            <div className="text-xs text-slate-500 mb-1">Example output:</div>
-            <pre className="text-xs text-slate-300 overflow-x-auto whitespace-pre-wrap break-all">
-              {JSON.stringify(preview.example, null, 2)}
-            </pre>
-          </div>
-        )}
+        ))}
       </div>
     );
   };
@@ -2936,13 +3251,13 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
         );
 
       // Activities: Create
-      case 'create_activity':
+      case 'create_activity': {
         return (
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Activity Type</Label>
               <Select
-                value={node.config?.type || 'note'}
+                value={node.config?.type || 'task'}
                 onValueChange={(value) => {
                   updateNodeConfig(node.id, { ...node.config, type: value });
                 }}
@@ -2966,7 +3281,7 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                 onChange={(e) => {
                   updateNodeConfig(node.id, { ...node.config, title: e.target.value });
                 }}
-                placeholder="e.g., Follow-up email"
+                placeholder="e.g., Follow-up with {{contact.contact_name}}"
                 className="bg-slate-800 border-slate-700 text-slate-200"
               />
             </div>
@@ -2978,18 +3293,32 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                 onChange={(e) => {
                   updateNodeConfig(node.id, { ...node.config, details: e.target.value });
                 }}
-                placeholder="Activity details (supports {{field}} replacements)"
+                placeholder="Activity details — click a variable in the output preview to insert"
                 className="w-full min-h-[120px] rounded-md bg-slate-800 border border-slate-700 text-slate-200 p-2"
               />
+            </div>
+
+            {renderVariablePicker(node.id, insertAtFocused)}
+
+            <div>
+              <Label className="text-slate-200">Assigned To</Label>
+              <Input
+                value={node.config?.assigned_to || ''}
+                onChange={(e) => {
+                  updateNodeConfig(node.id, { ...node.config, assigned_to: e.target.value });
+                }}
+                placeholder="e.g. {{assigned_to}} or user@email.com"
+                className="bg-slate-800 border-slate-700 text-slate-200"
+              />
               <p className="text-xs text-slate-500 mt-1">
-                Use {'{{field_name}}'} to reference webhook data
+                Leave blank to use campaign owner automatically
               </p>
             </div>
 
             <div>
               <Label className="text-slate-200">Associate With</Label>
               <Select
-                value={node.config?.associate || 'lead'}
+                value={node.config?.associate || 'auto'}
                 onValueChange={(value) => {
                   updateNodeConfig(node.id, { ...node.config, associate: value });
                 }}
@@ -2998,16 +3327,22 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent className="bg-slate-800 border-slate-700">
+                  <SelectItem value="auto">Auto (from payload)</SelectItem>
                   <SelectItem value="lead">Lead</SelectItem>
                   <SelectItem value="contact">Contact</SelectItem>
+                  <SelectItem value="bizdev_source">Potential Lead</SelectItem>
                   <SelectItem value="account">Account</SelectItem>
                   <SelectItem value="opportunity">Opportunity</SelectItem>
                 </SelectContent>
               </Select>
+              <p className="text-xs text-slate-500 mt-1">
+                Auto detects the entity type from the campaign payload
+              </p>
             </div>
             {renderOutputPreview(node)}
           </div>
         );
+      }
 
       // AI: Classify Opportunity Stage
       case 'ai_classify_opportunity_stage':
@@ -4347,7 +4682,15 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
               : 'Node Configuration'}
           </h3>
           {selectedNode ? (
-            renderNodeConfig(selectedNode)
+            <div
+              onFocusCapture={(e) => {
+                if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') {
+                  lastFocusedInputRef.current = e.target;
+                }
+              }}
+            >
+              {renderNodeConfig(selectedNode)}
+            </div>
           ) : (
             <p className="text-slate-400 text-sm">Select a node to configure</p>
           )}

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+﻿import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -2340,102 +2340,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">Map webhook fields to account fields</p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.account_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, account_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Account Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="company">Company</SelectItem>
-                        <SelectItem value="website">Website</SelectItem>
-                        <SelectItem value="phone">Phone</SelectItem>
-                        <SelectItem value="status">Status</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { account_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to account fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.account}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Account Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2447,105 +2359,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">
-                Map webhook fields to opportunity fields
-              </p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.opportunity_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, opportunity_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Opportunity Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="name">Name</SelectItem>
-                        <SelectItem value="stage">Stage</SelectItem>
-                        <SelectItem value="amount">Amount</SelectItem>
-                        <SelectItem value="probability">Probability</SelectItem>
-                        <SelectItem value="close_date">Close Date</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { opportunity_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to new opportunity fields</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.opportunity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Opportunity Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>
@@ -2557,104 +2378,14 @@ export default function WorkflowBuilder({ workflow, onSave, onCancel }) {
           <div className="space-y-4">
             <div>
               <Label className="text-slate-200">Field Mappings</Label>
-              <p className="text-sm text-slate-400 mb-3">
-                Map webhook fields to opportunity fields
-              </p>
-
-              <div className="max-h-96 overflow-y-auto pr-2 space-y-2">
-                {(node.config?.field_mappings || []).map((mapping, index) => (
-                  <div key={index} className="flex gap-2 items-center">
-                    <Select
-                      value={mapping.opportunity_field}
-                      onValueChange={(value) => {
-                        const newMappings = [...(node.config?.field_mappings || [])];
-                        newMappings[index] = { ...mapping, opportunity_field: value };
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                    >
-                      <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                        <SelectValue placeholder="Opportunity Field" />
-                      </SelectTrigger>
-                      <SelectContent className="bg-slate-800 border-slate-700">
-                        <SelectItem value="stage">Stage</SelectItem>
-                        <SelectItem value="amount">Amount</SelectItem>
-                        <SelectItem value="probability">Probability</SelectItem>
-                        <SelectItem value="close_date">Close Date</SelectItem>
-                        <SelectItem value="notes">Notes</SelectItem>
-                      </SelectContent>
-                    </Select>
-
-                    {getAvailableFields().length > 0 ? (
-                      <Select
-                        value={mapping.webhook_field}
-                        onValueChange={(value) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                      >
-                        <SelectTrigger className="bg-slate-800 border-slate-700 text-slate-200">
-                          <SelectValue placeholder="Webhook Field" />
-                        </SelectTrigger>
-                        <SelectContent className="bg-slate-800 border-slate-700">
-                          {getAvailableFields().map((field) => (
-                            <SelectItem key={field} value={field}>
-                              {field}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    ) : (
-                      <Input
-                        value={mapping.webhook_field}
-                        onChange={(e) => {
-                          const newMappings = [...(node.config?.field_mappings || [])];
-                          newMappings[index] = { ...mapping, webhook_field: e.target.value };
-                          updateNodeConfig(node.id, {
-                            ...node.config,
-                            field_mappings: newMappings,
-                          });
-                        }}
-                        placeholder="webhook_field"
-                        className="bg-slate-800 border-slate-700 text-slate-200"
-                      />
-                    )}
-
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        const newMappings = (node.config?.field_mappings || []).filter(
-                          (_, i) => i !== index,
-                        );
-                        updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                      }}
-                      className="text-red-400 hover:text-red-300 hover:bg-red-900/20 flex-shrink-0"
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  const newMappings = [
-                    ...(node.config?.field_mappings || []),
-                    { opportunity_field: '', webhook_field: '' },
-                  ];
-                  updateNodeConfig(node.id, { ...node.config, field_mappings: newMappings });
-                }}
-                className="bg-slate-800 border-slate-700 text-slate-200 hover:bg-slate-700 mt-2 w-full"
-              >
-                <Plus className="w-4 h-4 mr-2" />
-                Add Mapping
-              </Button>
+              <p className="text-sm text-slate-400 mb-3">Map inbound data to opportunity fields to update</p>
+              <FieldMappingPanel
+                mappings={node.config?.field_mappings || []}
+                onChange={(m) => updateNodeConfig(node.id, { ...node.config, field_mappings: m })}
+                targetSchema={ENTITY_SCHEMAS.opportunity}
+                upstreamTokens={getUpstreamTokens(node.id, nodes, connections, testPayload)}
+                addLabel="Add Opportunity Field"
+              />
             </div>
             {renderOutputPreview(node)}
           </div>

--- a/src/components/workflows/WorkflowBuilder.jsx
+++ b/src/components/workflows/WorkflowBuilder.jsx
@@ -29,7 +29,7 @@ import WorkflowCanvas from './WorkflowCanvas';
 import NodeLibrary from './NodeLibrary';
 import WorkflowTemplatesBrowser from './WorkflowTemplatesBrowser';
 import FieldMappingPanel from './FieldMappingPanel';
-import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from './upstreamTokens';
+import { getUpstreamTokens, ENTITY_SCHEMAS } from './upstreamTokens';
 import { useToast } from '@/components/ui/use-toast';
 import { WorkflowExecution } from '@/api/entities';
 import { Switch } from '@/components/ui/switch';

--- a/src/components/workflows/__tests__/FieldMappingPanel.test.jsx
+++ b/src/components/workflows/__tests__/FieldMappingPanel.test.jsx
@@ -1,0 +1,217 @@
+/**
+ * FieldMappingPanel.test.jsx
+ *
+ * Tests for the reusable Zapier-style field mapping component.
+ *
+ * Coverage:
+ *  1. Renders empty state with only the "Add Field" button
+ *  2. Renders existing mappings
+ *  3. Add row — calls onChange with new empty entry appended
+ *  4. Remove row — calls onChange with that entry removed
+ *  5. Target field change — calls onChange with updated target_field
+ *  6. addLabel prop overrides button text
+ *  7. Header row is shown only when mappings exist
+ *  8. TokenPicker shows placeholder text when no value selected
+ *  9. TokenPicker shows no upstream tokens message when tokens array is empty
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FieldMappingPanel from '../FieldMappingPanel.jsx';
+
+// ─── UI component mocks ───────────────────────────────────────────────────
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, ...props }) => (
+    <button onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ui/input', () => ({
+  Input: ({ ...props }) => <input {...props} />,
+}));
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, onValueChange, value }) => (
+    <div data-testid="select" data-value={value}>
+      {/* Expose a hidden button to trigger value change in tests */}
+      <button
+        data-testid="select-trigger-change"
+        onClick={() => onValueChange && onValueChange('email')}
+      >
+        {value || 'Select'}
+      </button>
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }) => <div>{children}</div>,
+  SelectItem: ({ children, value }) => <div data-value={value}>{children}</div>,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+const targetSchema = [
+  { value: 'email', label: 'Email' },
+  { value: 'first_name', label: 'First Name' },
+  { value: 'last_name', label: 'Last Name' },
+];
+
+const upstreamTokens = [
+  { key: 'email', label: 'email', stepIndex: 1, stepLabel: 'Webhook Trigger', nodeType: 'webhook_trigger', example: 'test@example.com' },
+  { key: 'first_name', label: 'first_name', stepIndex: 1, stepLabel: 'Webhook Trigger', nodeType: 'webhook_trigger', example: 'Jane' },
+];
+
+const baseMappings = [
+  { target_field: 'email', source_type: 'token', source_value: 'email' },
+  { target_field: 'first_name', source_type: 'token', source_value: 'first_name' },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('[WORKFLOWS] FieldMappingPanel', () => {
+  let onChange;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it('renders Add Field button when mappings are empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Add Field')).toBeTruthy();
+  });
+
+  it('does not render header row when mappings are empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.queryByText('Target Field')).toBeNull();
+  });
+
+  it('renders header row when mappings exist', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Target Field')).toBeTruthy();
+    expect(screen.getByText('Source Value')).toBeTruthy();
+  });
+
+  it('renders one row per mapping', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    // 2 mappings = 2 Select components for target fields
+    const selects = screen.getAllByTestId('select');
+    expect(selects.length).toBe(2);
+  });
+
+  it('calls onChange with appended empty entry when Add button clicked', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    fireEvent.click(screen.getByText('Add Field'));
+    expect(onChange).toHaveBeenCalledOnce();
+    const result = onChange.mock.calls[0][0];
+    expect(result).toHaveLength(3);
+    expect(result[2]).toEqual({ target_field: '', source_type: 'token', source_value: '' });
+  });
+
+  it('calls onChange with row removed when X button clicked', () => {
+    render(
+      <FieldMappingPanel
+        mappings={baseMappings}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    // The Select mock renders one button per row (select-trigger-change).
+    // The remove (X) buttons are the last button in each row — find by
+    // filtering out the 'Add Field' button and the select-trigger-change buttons.
+    const allButtons = screen.getAllByRole('button');
+    // Layout per row: [select-trigger-change, TokenPicker-chevron, remove-X]
+    // Plus final 'Add Field' button. With 2 rows: 6 buttons + 1 = 7 total.
+    // Remove buttons are at indices 2 and 5 (every 3rd, 0-indexed).
+    // Clicking the first remove (index 2) should remove row 0 (email).
+    const removeButtons = allButtons.filter(
+      (btn) => !btn.textContent.includes('Add') && !btn.textContent.includes('email') &&
+               !btn.textContent.includes('first_name') && !btn.textContent.includes('Select'),
+    );
+    fireEvent.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledOnce();
+    const result = onChange.mock.calls[0][0];
+    expect(result).toHaveLength(1);
+    expect(result[0].target_field).toBe('first_name');
+  });
+
+  it('overrides add button label via addLabel prop', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+        addLabel="Add Activity Field"
+      />,
+    );
+    expect(screen.getByText('Add Activity Field')).toBeTruthy();
+  });
+
+  it('renders TokenPicker with placeholder when source_value is empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[{ target_field: 'email', source_type: 'token', source_value: '' }]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={upstreamTokens}
+      />,
+    );
+    expect(screen.getByText('Pick value…')).toBeTruthy();
+  });
+
+  it('shows no-tokens message in popover when upstreamTokens is empty', () => {
+    render(
+      <FieldMappingPanel
+        mappings={[{ target_field: 'email', source_type: 'token', source_value: '' }]}
+        onChange={onChange}
+        targetSchema={targetSchema}
+        upstreamTokens={[]}
+      />,
+    );
+    // Open the picker popover
+    fireEvent.click(screen.getByText('Pick value…'));
+    expect(
+      screen.getByText(/No upstream data available/),
+    ).toBeTruthy();
+  });
+});

--- a/src/components/workflows/__tests__/upstreamTokens.test.js
+++ b/src/components/workflows/__tests__/upstreamTokens.test.js
@@ -1,0 +1,184 @@
+/**
+ * upstreamTokens.test.js
+ *
+ * Tests for the upstream token resolver and ENTITY_SCHEMAS.
+ *
+ * Coverage:
+ *  1. getUpstreamTokens — webhook_trigger uses testPayload keys
+ *  2. getUpstreamTokens — find_lead emits prefixed tokens
+ *  3. getUpstreamTokens — multi-node graph, correct stepIndex labels
+ *  4. getUpstreamTokens — target node itself is excluded
+ *  5. getUpstreamTokens — http_request emits last_http_status / last_http_response
+ *  6. getUpstreamTokens — returns empty array when no upstream nodes
+ *  7. getUpstreamTokens — unknown node type is silently skipped
+ *  8. tokenToTemplate — wraps bare key in {{ }}
+ *  9. tokenToTemplate — leaves existing {{ }} untouched
+ * 10. tokenToTemplate — returns empty string for falsy input
+ * 11. ENTITY_SCHEMAS — all five entities have required fields
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getUpstreamTokens, tokenToTemplate, ENTITY_SCHEMAS } from '../upstreamTokens.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+const triggerNode = { id: 'n1', type: 'webhook_trigger' };
+const findLeadNode = { id: 'n2', type: 'find_lead' };
+const createActivityNode = { id: 'n3', type: 'create_activity' };
+const httpNode = { id: 'n4', type: 'http_request' };
+const unknownNode = { id: 'n5', type: 'some_future_node_type' };
+
+const linearConnections = [
+  { from: 'n1', to: 'n2' },
+  { from: 'n2', to: 'n3' },
+];
+
+const testPayload = { email: 'test@example.com', first_name: 'Jane', company: 'Acme' };
+
+// ─── getUpstreamTokens ─────────────────────────────────────────────────────
+
+describe('[upstreamTokens] getUpstreamTokens', () => {
+  it('returns payload keys as tokens for webhook_trigger', () => {
+    // Target = n2, upstream = n1 (webhook_trigger)
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, testPayload);
+    const keys = tokens.map((t) => t.key);
+    expect(keys).toContain('email');
+    expect(keys).toContain('first_name');
+    expect(keys).toContain('company');
+  });
+
+  it('returns empty token list for webhook_trigger when no testPayload', () => {
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, null);
+    expect(tokens.filter((t) => t.nodeType === 'webhook_trigger')).toHaveLength(0);
+  });
+
+  it('attaches example value from testPayload to webhook tokens', () => {
+    const tokens = getUpstreamTokens('n2', [triggerNode, findLeadNode], linearConnections, testPayload);
+    const emailToken = tokens.find((t) => t.key === 'email');
+    expect(emailToken.example).toBe('test@example.com');
+  });
+
+  it('emits prefixed tokens for find_lead (found_lead.field)', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const leadTokens = tokens.filter((t) => t.nodeType === 'find_lead');
+    expect(leadTokens.length).toBeGreaterThan(0);
+    const keys = leadTokens.map((t) => t.key);
+    expect(keys).toContain('found_lead.email');
+    expect(keys).toContain('found_lead.first_name');
+    expect(keys).toContain('found_lead.id');
+  });
+
+  it('sets correct stepIndex — trigger is step 1, find_lead is step 2', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const triggerTokens = tokens.filter((t) => t.nodeType === 'webhook_trigger');
+    const leadTokens = tokens.filter((t) => t.nodeType === 'find_lead');
+    expect(triggerTokens[0].stepIndex).toBe(1);
+    expect(leadTokens[0].stepIndex).toBe(2);
+  });
+
+  it('does not include the target node itself in tokens', () => {
+    const tokens = getUpstreamTokens(
+      'n3',
+      [triggerNode, findLeadNode, createActivityNode],
+      linearConnections,
+      testPayload,
+    );
+    const activityTokens = tokens.filter((t) => t.nodeType === 'create_activity');
+    expect(activityTokens).toHaveLength(0);
+  });
+
+  it('returns empty array when target is the first node (no upstream)', () => {
+    const tokens = getUpstreamTokens('n1', [triggerNode], [], testPayload);
+    expect(tokens).toHaveLength(0);
+  });
+
+  it('emits last_http_status and last_http_response for http_request node', () => {
+    const nodes = [triggerNode, httpNode, createActivityNode];
+    const conns = [{ from: 'n1', to: 'n4' }, { from: 'n4', to: 'n3' }];
+    const tokens = getUpstreamTokens('n3', nodes, conns, testPayload);
+    const httpTokens = tokens.filter((t) => t.nodeType === 'http_request');
+    const keys = httpTokens.map((t) => t.key);
+    expect(keys).toContain('last_http_status');
+    expect(keys).toContain('last_http_response');
+  });
+
+  it('silently skips unknown node types', () => {
+    const nodes = [triggerNode, unknownNode, createActivityNode];
+    const conns = [{ from: 'n1', to: 'n5' }, { from: 'n5', to: 'n3' }];
+    // Should not throw
+    expect(() =>
+      getUpstreamTokens('n3', nodes, conns, testPayload),
+    ).not.toThrow();
+    const tokens = getUpstreamTokens('n3', nodes, conns, testPayload);
+    const unknownTokens = tokens.filter((t) => t.nodeType === 'some_future_node_type');
+    expect(unknownTokens).toHaveLength(0);
+  });
+});
+
+// ─── tokenToTemplate ───────────────────────────────────────────────────────
+
+describe('[upstreamTokens] tokenToTemplate', () => {
+  it('wraps a bare key in {{ }}', () => {
+    expect(tokenToTemplate('email')).toBe('{{email}}');
+  });
+
+  it('wraps a dotted key in {{ }}', () => {
+    expect(tokenToTemplate('found_lead.email')).toBe('{{found_lead.email}}');
+  });
+
+  it('leaves an already-wrapped key untouched', () => {
+    expect(tokenToTemplate('{{email}}')).toBe('{{email}}');
+  });
+
+  it('returns empty string for null', () => {
+    expect(tokenToTemplate(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(tokenToTemplate(undefined)).toBe('');
+  });
+
+  it('returns empty string for empty string', () => {
+    expect(tokenToTemplate('')).toBe('');
+  });
+});
+
+// ─── ENTITY_SCHEMAS ────────────────────────────────────────────────────────
+
+describe('[upstreamTokens] ENTITY_SCHEMAS', () => {
+  const requiredByEntity = {
+    lead: ['first_name', 'last_name', 'email', 'phone', 'company'],
+    contact: ['first_name', 'last_name', 'email', 'phone'],
+    account: ['name', 'industry', 'website'],
+    opportunity: ['name', 'amount', 'stage'],
+    activity: ['subject', 'body', 'status', 'due_date', 'assigned_to'],
+  };
+
+  for (const [entity, required] of Object.entries(requiredByEntity)) {
+    it(`ENTITY_SCHEMAS.${entity} contains required fields`, () => {
+      const values = ENTITY_SCHEMAS[entity].map((f) => f.value);
+      for (const field of required) {
+        expect(values).toContain(field);
+      }
+    });
+
+    it(`ENTITY_SCHEMAS.${entity} entries each have value and label`, () => {
+      for (const entry of ENTITY_SCHEMAS[entity]) {
+        expect(typeof entry.value).toBe('string');
+        expect(entry.value.length).toBeGreaterThan(0);
+        expect(typeof entry.label).toBe('string');
+        expect(entry.label.length).toBeGreaterThan(0);
+      }
+    });
+  }
+});

--- a/src/components/workflows/upstreamTokens.js
+++ b/src/components/workflows/upstreamTokens.js
@@ -1,0 +1,350 @@
+/**
+ * upstreamTokens.js
+ *
+ * Given a target node ID and the full nodes/connections array, walks the
+ * execution graph backwards and returns a flat list of all variable tokens
+ * that are available to that node.
+ *
+ * Token shape:
+ *  {
+ *    key:       string  – the variable key to embed, e.g. "email" or "found_lead.first_name"
+ *    label:     string  – human label, e.g. "email" or "found_lead · first_name"
+ *    stepIndex: number  – 1-based position of the source node in execution order
+ *    stepLabel: string  – human name of the source node
+ *    nodeType:  string  – e.g. "webhook_trigger"
+ *    example:   any     – optional example value from testPayload
+ *  }
+ *
+ * Variable resolution rules (mirrors backend replaceVariables):
+ *  - webhook_trigger fields  → "{{fieldName}}"
+ *  - find_lead / create_lead → "{{found_lead.fieldName}}"
+ *  - find_contact            → "{{found_contact.fieldName}}"
+ *  - find_account            → "{{found_account.fieldName}}"
+ *  - find_opportunity        → "{{found_opportunity.fieldName}}"
+ *  - create_activity         → "{{created_activity.fieldName}}"
+ *  - http_request            → "{{last_http_response}}", "{{last_http_status}}"
+ *  - ai_* nodes              → "{{ai_stage.stage}}", etc.
+ */
+
+// Static field definitions per node type (mirrors generateNodeOutputPreview)
+const NODE_OUTPUT_FIELDS = {
+  webhook_trigger: {
+    label: 'Webhook Trigger',
+    prefix: null, // fields come directly from testPayload keys
+    fields: [], // populated dynamically from testPayload
+  },
+  find_lead: {
+    label: 'Find Lead',
+    prefix: 'found_lead',
+    fields: [
+      'id',
+      'first_name',
+      'last_name',
+      'email',
+      'phone',
+      'company',
+      'status',
+      'score',
+      'job_title',
+      'source',
+      'notes',
+    ],
+  },
+  create_lead: {
+    label: 'Create Lead',
+    prefix: 'found_lead',
+    fields: [
+      'id',
+      'first_name',
+      'last_name',
+      'email',
+      'phone',
+      'company',
+      'status',
+      'job_title',
+      'source',
+    ],
+  },
+  update_lead: {
+    label: 'Update Lead',
+    prefix: 'found_lead',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'status'],
+  },
+  find_contact: {
+    label: 'Find Contact',
+    prefix: 'found_contact',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'account_id'],
+  },
+  update_contact: {
+    label: 'Update Contact',
+    prefix: 'found_contact',
+    fields: ['id', 'first_name', 'last_name', 'email', 'phone'],
+  },
+  find_account: {
+    label: 'Find Account',
+    prefix: 'found_account',
+    fields: ['id', 'name', 'industry', 'website', 'email', 'phone'],
+  },
+  update_account: {
+    label: 'Update Account',
+    prefix: 'found_account',
+    fields: ['id', 'name', 'industry', 'website'],
+  },
+  find_opportunity: {
+    label: 'Find Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
+  },
+  create_opportunity: {
+    label: 'Create Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
+  },
+  update_opportunity: {
+    label: 'Update Opportunity',
+    prefix: 'found_opportunity',
+    fields: ['id', 'name', 'amount', 'stage'],
+  },
+  create_activity: {
+    label: 'Create Activity',
+    prefix: 'created_activity',
+    fields: [
+      'id',
+      'type',
+      'subject',
+      'body',
+      'status',
+      'due_date',
+      'assigned_to',
+      'related_id',
+      'related_to',
+    ],
+  },
+  http_request: {
+    label: 'HTTP Request',
+    prefix: null,
+    fields: ['last_http_status', 'last_http_response'],
+  },
+  ai_classify_opportunity_stage: {
+    label: 'AI: Classify Stage',
+    prefix: 'ai_stage',
+    fields: ['stage', 'confidence', 'reasoning'],
+  },
+  ai_generate_email: {
+    label: 'AI: Generate Email',
+    prefix: 'ai_email',
+    fields: ['subject', 'body', 'tone'],
+  },
+  ai_enrich_account: {
+    label: 'AI: Enrich Account',
+    prefix: 'ai_enrichment',
+    fields: ['industry', 'size', 'description', 'technologies'],
+  },
+  ai_route_activity: {
+    label: 'AI: Route Activity',
+    prefix: 'ai_route',
+    fields: ['assigned_to', 'priority', 'reasoning'],
+  },
+  ai_summarize: {
+    label: 'AI Summarize',
+    prefix: 'ai_summary',
+    fields: ['summary', 'key_points'],
+  },
+  pep_query: {
+    label: 'PEP Query',
+    prefix: 'pep_results',
+    fields: ['results', 'count'],
+  },
+};
+
+/**
+ * Topological walk: returns nodes in execution order up to (but not including)
+ * the targetNodeId. Handles linear and branching graphs.
+ */
+function getExecutionOrderBefore(targetNodeId, nodes, connections) {
+  // Build adjacency: from → [to]
+  const adj = {};
+  for (const c of connections) {
+    if (!adj[c.from]) adj[c.from] = [];
+    adj[c.from].push(c.to);
+  }
+
+  // Find start node (trigger – no incoming connections)
+  const hasIncoming = new Set(connections.map((c) => c.to));
+  const startNodes = nodes.filter((n) => !hasIncoming.has(n.id));
+  if (!startNodes.length) return [];
+
+  // BFS to collect all ancestors of targetNodeId
+  const ancestors = [];
+  const visited = new Set();
+  const queue = [...startNodes.map((n) => n.id)];
+
+  while (queue.length) {
+    const id = queue.shift();
+    if (id === targetNodeId) continue; // don't include target itself
+    if (visited.has(id)) continue;
+    visited.add(id);
+    const node = nodes.find((n) => n.id === id);
+    if (node) ancestors.push(node);
+    const nexts = adj[id] || [];
+    for (const next of nexts) {
+      if (!visited.has(next)) queue.push(next);
+    }
+  }
+
+  return ancestors;
+}
+
+/**
+ * Build a list of upstream tokens available to a given node.
+ *
+ * @param {string}  targetNodeId
+ * @param {Array}   nodes          – full workflow nodes array
+ * @param {Array}   connections    – full workflow connections array
+ * @param {object}  testPayload    – the captured webhook payload (or null)
+ * @returns {Array<Token>}
+ */
+export function getUpstreamTokens(targetNodeId, nodes, connections, testPayload) {
+  const ancestors = getExecutionOrderBefore(targetNodeId, nodes, connections);
+  const tokens = [];
+
+  ancestors.forEach((node, idx) => {
+    const stepIndex = idx + 1;
+    const def = NODE_OUTPUT_FIELDS[node.type];
+    if (!def) return;
+
+    const stepLabel = def.label;
+
+    if (node.type === 'webhook_trigger') {
+      // Dynamic: use testPayload keys if available, else show nothing
+      const payloadKeys = testPayload ? Object.keys(testPayload) : [];
+      for (const field of payloadKeys) {
+        tokens.push({
+          key: field,
+          label: field,
+          stepIndex,
+          stepLabel,
+          nodeType: node.type,
+          example: testPayload[field],
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'http_request') {
+      tokens.push({
+        key: 'last_http_status',
+        label: 'HTTP Status Code',
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: 200,
+      });
+      tokens.push({
+        key: 'last_http_response',
+        label: 'HTTP Response Body',
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: '{"success":true}',
+      });
+      return;
+    }
+
+    const prefix = def.prefix;
+    for (const field of def.fields) {
+      const key = prefix ? `${prefix}.${field}` : field;
+      tokens.push({
+        key,
+        label: prefix ? `${prefix} · ${field}` : field,
+        stepIndex,
+        stepLabel,
+        nodeType: node.type,
+        example: undefined,
+      });
+    }
+  });
+
+  return tokens;
+}
+
+/**
+ * Convert a token key to a {{variable}} template string.
+ * e.g. "found_lead.email" → "{{found_lead.email}}"
+ *      "email"            → "{{email}}"
+ */
+export function tokenToTemplate(key) {
+  if (!key) return '';
+  // If already a template string, return as-is
+  if (key.startsWith('{{') && key.endsWith('}}')) return key;
+  return `{{${key}}}`;
+}
+
+/**
+ * Schema definitions for each entity's writable fields.
+ * Used by FieldMappingPanel targetSchema prop.
+ */
+export const ENTITY_SCHEMAS = {
+  lead: [
+    { value: 'first_name', label: 'First Name' },
+    { value: 'last_name', label: 'Last Name' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'company', label: 'Company' },
+    { value: 'job_title', label: 'Job Title' },
+    { value: 'status', label: 'Status' },
+    { value: 'score', label: 'Score' },
+    { value: 'source', label: 'Source' },
+    { value: 'next_action', label: 'Next Action' },
+    { value: 'notes', label: 'Notes' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+  ],
+  contact: [
+    { value: 'first_name', label: 'First Name' },
+    { value: 'last_name', label: 'Last Name' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'mobile', label: 'Mobile' },
+    { value: 'job_title', label: 'Job Title' },
+    { value: 'company', label: 'Company' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'notes', label: 'Notes' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+  ],
+  account: [
+    { value: 'name', label: 'Name' },
+    { value: 'industry', label: 'Industry' },
+    { value: 'website', label: 'Website' },
+    { value: 'email', label: 'Email' },
+    { value: 'phone', label: 'Phone' },
+    { value: 'city', label: 'City' },
+    { value: 'state', label: 'State' },
+    { value: 'country', label: 'Country' },
+    { value: 'annual_revenue', label: 'Annual Revenue' },
+    { value: 'employee_count', label: 'Employee Count' },
+    { value: 'notes', label: 'Notes' },
+  ],
+  opportunity: [
+    { value: 'name', label: 'Name' },
+    { value: 'amount', label: 'Amount' },
+    { value: 'stage', label: 'Stage' },
+    { value: 'probability', label: 'Probability' },
+    { value: 'close_date', label: 'Close Date' },
+    { value: 'notes', label: 'Notes' },
+  ],
+  activity: [
+    { value: 'type', label: 'Type' },
+    { value: 'subject', label: 'Subject / Title' },
+    { value: 'body', label: 'Body / Details' },
+    { value: 'status', label: 'Status' },
+    { value: 'due_date', label: 'Due Date' },
+    { value: 'assigned_to', label: 'Assigned To (User ID)' },
+    { value: 'related_to', label: 'Related To (entity type)' },
+    { value: 'related_id', label: 'Related ID' },
+  ],
+};

--- a/src/components/workflows/upstreamTokens.js
+++ b/src/components/workflows/upstreamTokens.js
@@ -1,350 +1,291 @@
 /**
  * upstreamTokens.js
  *
- * Given a target node ID and the full nodes/connections array, walks the
- * execution graph backwards and returns a flat list of all variable tokens
- * that are available to that node.
+ * Resolves which data tokens are available to a given workflow node by
+ * walking the graph forward from the trigger (BFS), collecting every node
+ * that is an ancestor of the target, then emitting typed token descriptors
+ * for each such upstream node.
  *
  * Token shape:
- *  {
- *    key:       string  – the variable key to embed, e.g. "email" or "found_lead.first_name"
- *    label:     string  – human label, e.g. "email" or "found_lead · first_name"
- *    stepIndex: number  – 1-based position of the source node in execution order
- *    stepLabel: string  – human name of the source node
- *    nodeType:  string  – e.g. "webhook_trigger"
- *    example:   any     – optional example value from testPayload
- *  }
+ *   { key, label, nodeId, nodeType, stepIndex, example? }
  *
- * Variable resolution rules (mirrors backend replaceVariables):
- *  - webhook_trigger fields  → "{{fieldName}}"
- *  - find_lead / create_lead → "{{found_lead.fieldName}}"
- *  - find_contact            → "{{found_contact.fieldName}}"
- *  - find_account            → "{{found_account.fieldName}}"
- *  - find_opportunity        → "{{found_opportunity.fieldName}}"
- *  - create_activity         → "{{created_activity.fieldName}}"
- *  - http_request            → "{{last_http_response}}", "{{last_http_status}}"
- *  - ai_* nodes              → "{{ai_stage.stage}}", etc.
+ *   key        — the variable reference used in {{ }} templates
+ *   label      — human-readable display string shown in the UI
+ *   nodeId     — id of the node that produces this token
+ *   nodeType   — type of the node that produces this token
+ *   stepIndex  — 1-based execution order position of the producing node
+ *   example    — optional sample value (populated from testPayload for trigger tokens)
  */
 
-// Static field definitions per node type (mirrors generateNodeOutputPreview)
-const NODE_OUTPUT_FIELDS = {
-  webhook_trigger: {
-    label: 'Webhook Trigger',
-    prefix: null, // fields come directly from testPayload keys
-    fields: [], // populated dynamically from testPayload
-  },
-  find_lead: {
-    label: 'Find Lead',
-    prefix: 'found_lead',
-    fields: [
-      'id',
-      'first_name',
-      'last_name',
-      'email',
-      'phone',
-      'company',
-      'status',
-      'score',
-      'job_title',
-      'source',
-      'notes',
-    ],
-  },
-  create_lead: {
-    label: 'Create Lead',
-    prefix: 'found_lead',
-    fields: [
-      'id',
-      'first_name',
-      'last_name',
-      'email',
-      'phone',
-      'company',
-      'status',
-      'job_title',
-      'source',
-    ],
-  },
-  update_lead: {
-    label: 'Update Lead',
-    prefix: 'found_lead',
-    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'status'],
-  },
-  find_contact: {
-    label: 'Find Contact',
-    prefix: 'found_contact',
-    fields: ['id', 'first_name', 'last_name', 'email', 'phone', 'company', 'account_id'],
-  },
-  update_contact: {
-    label: 'Update Contact',
-    prefix: 'found_contact',
-    fields: ['id', 'first_name', 'last_name', 'email', 'phone'],
-  },
-  find_account: {
-    label: 'Find Account',
-    prefix: 'found_account',
-    fields: ['id', 'name', 'industry', 'website', 'email', 'phone'],
-  },
-  update_account: {
-    label: 'Update Account',
-    prefix: 'found_account',
-    fields: ['id', 'name', 'industry', 'website'],
-  },
-  find_opportunity: {
-    label: 'Find Opportunity',
-    prefix: 'found_opportunity',
-    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
-  },
-  create_opportunity: {
-    label: 'Create Opportunity',
-    prefix: 'found_opportunity',
-    fields: ['id', 'name', 'amount', 'stage', 'close_date'],
-  },
-  update_opportunity: {
-    label: 'Update Opportunity',
-    prefix: 'found_opportunity',
-    fields: ['id', 'name', 'amount', 'stage'],
-  },
-  create_activity: {
-    label: 'Create Activity',
-    prefix: 'created_activity',
-    fields: [
-      'id',
-      'type',
-      'subject',
-      'body',
-      'status',
-      'due_date',
-      'assigned_to',
-      'related_id',
-      'related_to',
-    ],
-  },
-  http_request: {
-    label: 'HTTP Request',
-    prefix: null,
-    fields: ['last_http_status', 'last_http_response'],
-  },
-  ai_classify_opportunity_stage: {
-    label: 'AI: Classify Stage',
-    prefix: 'ai_stage',
-    fields: ['stage', 'confidence', 'reasoning'],
-  },
-  ai_generate_email: {
-    label: 'AI: Generate Email',
-    prefix: 'ai_email',
-    fields: ['subject', 'body', 'tone'],
-  },
-  ai_enrich_account: {
-    label: 'AI: Enrich Account',
-    prefix: 'ai_enrichment',
-    fields: ['industry', 'size', 'description', 'technologies'],
-  },
-  ai_route_activity: {
-    label: 'AI: Route Activity',
-    prefix: 'ai_route',
-    fields: ['assigned_to', 'priority', 'reasoning'],
-  },
-  ai_summarize: {
-    label: 'AI Summarize',
-    prefix: 'ai_summary',
-    fields: ['summary', 'key_points'],
-  },
-  pep_query: {
-    label: 'PEP Query',
-    prefix: 'pep_results',
-    fields: ['results', 'count'],
-  },
+// ─── Entity field schemas ───────────────────────────────────────────────────
+// Used by FieldMappingPanel to populate the target-field dropdown.
+// Each entry: { value: db_column_name, label: display_label }
+
+export const ENTITY_SCHEMAS = {
+  lead: [
+    { value: 'first_name',  label: 'First Name' },
+    { value: 'last_name',   label: 'Last Name' },
+    { value: 'email',       label: 'Email' },
+    { value: 'phone',       label: 'Phone' },
+    { value: 'company',     label: 'Company' },
+    { value: 'status',      label: 'Status' },
+    { value: 'source',      label: 'Source' },
+    { value: 'address_1',   label: 'Address Line 1' },
+    { value: 'address_2',   label: 'Address Line 2' },
+    { value: 'city',        label: 'City' },
+    { value: 'state',       label: 'State' },
+    { value: 'zip',         label: 'Zip' },
+    { value: 'country',     label: 'Country' },
+    { value: 'notes',       label: 'Notes' },
+    { value: 'assigned_to', label: 'Assigned To' },
+  ],
+  contact: [
+    { value: 'first_name',  label: 'First Name' },
+    { value: 'last_name',   label: 'Last Name' },
+    { value: 'email',       label: 'Email' },
+    { value: 'phone',       label: 'Phone' },
+    { value: 'job_title',   label: 'Job Title' },
+    { value: 'department',  label: 'Department' },
+    { value: 'address_1',   label: 'Address Line 1' },
+    { value: 'city',        label: 'City' },
+    { value: 'state',       label: 'State' },
+    { value: 'country',     label: 'Country' },
+    { value: 'notes',       label: 'Notes' },
+    { value: 'assigned_to', label: 'Assigned To' },
+  ],
+  account: [
+    { value: 'name',        label: 'Company Name' },
+    { value: 'industry',    label: 'Industry' },
+    { value: 'website',     label: 'Website' },
+    { value: 'phone',       label: 'Phone' },
+    { value: 'email',       label: 'Email' },
+    { value: 'address_1',   label: 'Address Line 1' },
+    { value: 'city',        label: 'City' },
+    { value: 'state',       label: 'State' },
+    { value: 'country',     label: 'Country' },
+    { value: 'status',      label: 'Status' },
+    { value: 'assigned_to', label: 'Assigned To' },
+  ],
+  opportunity: [
+    { value: 'name',        label: 'Opportunity Name' },
+    { value: 'amount',      label: 'Amount' },
+    { value: 'stage',       label: 'Stage' },
+    { value: 'close_date',  label: 'Close Date' },
+    { value: 'probability', label: 'Probability' },
+    { value: 'description', label: 'Description' },
+    { value: 'assigned_to', label: 'Assigned To' },
+  ],
+  activity: [
+    { value: 'subject',     label: 'Subject' },
+    { value: 'body',        label: 'Body / Details' },
+    { value: 'status',      label: 'Status' },
+    { value: 'due_date',    label: 'Due Date' },
+    { value: 'assigned_to', label: 'Assigned To' },
+    { value: 'type',        label: 'Activity Type' },
+    { value: 'priority',    label: 'Priority' },
+  ],
 };
 
+// ─── Node → token emission map ─────────────────────────────────────────────
+// Maps node type → function(node, testPayload) → [{ key, label, example? }]
+// The context variable prefix (found_lead, etc.) must match workflowExecutionService.
+
+const NODE_TOKEN_EMITTERS = {
+  webhook_trigger: (_node, testPayload) => {
+    if (!testPayload || typeof testPayload !== 'object') return [];
+    return Object.keys(testPayload).map((k) => ({
+      key: k,
+      label: k.replace(/_/g, ' '),
+      example: testPayload[k],
+    }));
+  },
+
+  care_trigger: (_node, testPayload) => {
+    if (!testPayload || typeof testPayload !== 'object') return [];
+    return Object.keys(testPayload).map((k) => ({
+      key: k,
+      label: k.replace(/_/g, ' '),
+      example: testPayload[k],
+    }));
+  },
+
+  find_lead: () =>
+    ENTITY_SCHEMAS.lead.map(({ value, label }) => ({
+      key: `found_lead.${value}`,
+      label: `Lead → ${label}`,
+    })),
+
+  create_lead: () =>
+    ENTITY_SCHEMAS.lead.map(({ value, label }) => ({
+      key: `found_lead.${value}`,
+      label: `Created Lead → ${label}`,
+    })),
+
+  update_lead: () =>
+    ENTITY_SCHEMAS.lead.map(({ value, label }) => ({
+      key: `found_lead.${value}`,
+      label: `Updated Lead → ${label}`,
+    })),
+
+  find_contact: () =>
+    ENTITY_SCHEMAS.contact.map(({ value, label }) => ({
+      key: `found_contact.${value}`,
+      label: `Contact → ${label}`,
+    })),
+
+  update_contact: () =>
+    ENTITY_SCHEMAS.contact.map(({ value, label }) => ({
+      key: `found_contact.${value}`,
+      label: `Updated Contact → ${label}`,
+    })),
+
+  find_account: () =>
+    ENTITY_SCHEMAS.account.map(({ value, label }) => ({
+      key: `found_account.${value}`,
+      label: `Account → ${label}`,
+    })),
+
+  update_account: () =>
+    ENTITY_SCHEMAS.account.map(({ value, label }) => ({
+      key: `found_account.${value}`,
+      label: `Updated Account → ${label}`,
+    })),
+
+  create_opportunity: () =>
+    ENTITY_SCHEMAS.opportunity.map(({ value, label }) => ({
+      key: `found_opportunity.${value}`,
+      label: `Created Opp → ${label}`,
+    })),
+
+  update_opportunity: () =>
+    ENTITY_SCHEMAS.opportunity.map(({ value, label }) => ({
+      key: `found_opportunity.${value}`,
+      label: `Updated Opp → ${label}`,
+    })),
+
+  create_activity: () =>
+    ENTITY_SCHEMAS.activity.map(({ value, label }) => ({
+      key: `created_activity.${value}`,
+      label: `Activity → ${label}`,
+    })),
+
+  http_request: () => [
+    { key: 'last_http_status',   label: 'HTTP → Status Code' },
+    { key: 'last_http_response', label: 'HTTP → Response Body' },
+  ],
+
+  pep_query: () => [
+    { key: 'pep_results.rows',  label: 'PEP → Result Rows' },
+    { key: 'pep_results.count', label: 'PEP → Result Count' },
+  ],
+};
+
+// ─── BFS: forward-reachable ancestors ──────────────────────────────────────
+
 /**
- * Topological walk: returns nodes in execution order up to (but not including)
- * the targetNodeId. Handles linear and branching graphs.
+ * Returns an ordered list of node IDs that are ancestors of targetNodeId,
+ * in forward BFS execution order (trigger → target, exclusive of target).
+ *
+ * Strategy:
+ *   1. Backward BFS from target  → builds the ancestor set
+ *   2. Forward BFS from triggers → emits ancestors in execution order
+ *
+ * @param {string}   targetNodeId
+ * @param {object[]} nodes
+ * @param {object[]} connections  [{ from, to }]
+ * @returns {{ id: string, stepIndex: number }[]}
  */
-function getExecutionOrderBefore(targetNodeId, nodes, connections) {
-  // Build adjacency: from → [to]
-  const adj = {};
-  for (const c of connections) {
-    if (!adj[c.from]) adj[c.from] = [];
-    adj[c.from].push(c.to);
+function getUpstreamExecutionOrder(targetNodeId, nodes, connections) {
+  // Build adjacency lists
+  const fwdAdj = {};
+  const backAdj = {};
+  for (const { from, to } of connections) {
+    if (!fwdAdj[from]) fwdAdj[from] = [];
+    fwdAdj[from].push(to);
+    if (!backAdj[to]) backAdj[to] = [];
+    backAdj[to].push(from);
   }
 
-  // Find start node (trigger – no incoming connections)
-  const hasIncoming = new Set(connections.map((c) => c.to));
-  const startNodes = nodes.filter((n) => !hasIncoming.has(n.id));
-  if (!startNodes.length) return [];
-
-  // BFS to collect all ancestors of targetNodeId
-  const ancestors = [];
-  const visited = new Set();
-  const queue = [...startNodes.map((n) => n.id)];
-
-  while (queue.length) {
-    const id = queue.shift();
-    if (id === targetNodeId) continue; // don't include target itself
-    if (visited.has(id)) continue;
-    visited.add(id);
-    const node = nodes.find((n) => n.id === id);
-    if (node) ancestors.push(node);
-    const nexts = adj[id] || [];
-    for (const next of nexts) {
-      if (!visited.has(next)) queue.push(next);
+  // Step 1: ancestor set via backward BFS from target (target excluded)
+  const ancestors = new Set();
+  const backVisited = new Set([targetNodeId]);
+  const backQueue = [...(backAdj[targetNodeId] || [])];
+  for (const id of backQueue) backVisited.add(id);
+  while (backQueue.length) {
+    const cur = backQueue.shift();
+    ancestors.add(cur);
+    for (const pred of (backAdj[cur] || [])) {
+      if (!backVisited.has(pred)) {
+        backVisited.add(pred);
+        backQueue.push(pred);
+      }
     }
   }
 
-  return ancestors;
+  // Step 2: identify trigger roots (explicit trigger types, or nodes with no incoming edge)
+  const triggerTypes = new Set(['webhook_trigger', 'care_trigger']);
+  const hasIncoming = new Set(connections.map((c) => c.to));
+  const roots = nodes
+    .filter((n) => triggerTypes.has(n.type) || !hasIncoming.has(n.id))
+    .map((n) => n.id);
+
+  // Step 3: forward BFS from roots, emit only ancestor nodes in order
+  const result = [];
+  const fwdVisited = new Set();
+  const queue = [...roots];
+  while (queue.length) {
+    const cur = queue.shift();
+    if (fwdVisited.has(cur)) continue;
+    fwdVisited.add(cur);
+    if (ancestors.has(cur)) result.push(cur);
+    for (const next of (fwdAdj[cur] || [])) {
+      if (!fwdVisited.has(next)) queue.push(next);
+    }
+  }
+
+  return result.map((id, idx) => ({ id, stepIndex: idx + 1 }));
 }
 
+// ─── Public API ────────────────────────────────────────────────────────────
+
 /**
- * Build a list of upstream tokens available to a given node.
+ * Returns all tokens available to `targetNodeId` from its upstream nodes.
  *
- * @param {string}  targetNodeId
- * @param {Array}   nodes          – full workflow nodes array
- * @param {Array}   connections    – full workflow connections array
- * @param {object}  testPayload    – the captured webhook payload (or null)
- * @returns {Array<Token>}
+ * @param {string}       targetNodeId
+ * @param {object[]}     nodes        — full workflow node array
+ * @param {object[]}     connections  — full workflow connection array [{ from, to }]
+ * @param {object|null}  testPayload  — sample webhook payload (for trigger tokens)
+ * @returns {object[]}   array of token descriptors
  */
 export function getUpstreamTokens(targetNodeId, nodes, connections, testPayload) {
-  const ancestors = getExecutionOrderBefore(targetNodeId, nodes, connections);
+  const ordered = getUpstreamExecutionOrder(targetNodeId, nodes, connections);
+  const nodeById = Object.fromEntries(nodes.map((n) => [n.id, n]));
   const tokens = [];
 
-  ancestors.forEach((node, idx) => {
-    const stepIndex = idx + 1;
-    const def = NODE_OUTPUT_FIELDS[node.type];
-    if (!def) return;
+  for (const { id, stepIndex } of ordered) {
+    const node = nodeById[id];
+    if (!node) continue;
 
-    const stepLabel = def.label;
+    const emitter = NODE_TOKEN_EMITTERS[node.type];
+    if (!emitter) continue; // silently skip unknown node types
 
-    if (node.type === 'webhook_trigger') {
-      // Dynamic: use testPayload keys if available, else show nothing
-      const payloadKeys = testPayload ? Object.keys(testPayload) : [];
-      for (const field of payloadKeys) {
-        tokens.push({
-          key: field,
-          label: field,
-          stepIndex,
-          stepLabel,
-          nodeType: node.type,
-          example: testPayload[field],
-        });
-      }
-      return;
+    for (const descriptor of emitter(node, testPayload)) {
+      tokens.push({ ...descriptor, nodeId: node.id, nodeType: node.type, stepIndex });
     }
-
-    if (node.type === 'http_request') {
-      tokens.push({
-        key: 'last_http_status',
-        label: 'HTTP Status Code',
-        stepIndex,
-        stepLabel,
-        nodeType: node.type,
-        example: 200,
-      });
-      tokens.push({
-        key: 'last_http_response',
-        label: 'HTTP Response Body',
-        stepIndex,
-        stepLabel,
-        nodeType: node.type,
-        example: '{"success":true}',
-      });
-      return;
-    }
-
-    const prefix = def.prefix;
-    for (const field of def.fields) {
-      const key = prefix ? `${prefix}.${field}` : field;
-      tokens.push({
-        key,
-        label: prefix ? `${prefix} · ${field}` : field,
-        stepIndex,
-        stepLabel,
-        nodeType: node.type,
-        example: undefined,
-      });
-    }
-  });
+  }
 
   return tokens;
 }
 
 /**
- * Convert a token key to a {{variable}} template string.
- * e.g. "found_lead.email" → "{{found_lead.email}}"
- *      "email"            → "{{email}}"
+ * Wraps a bare token key in {{ }} for use in template strings.
+ * Already-wrapped keys are returned as-is. Falsy input returns ''.
+ *
+ * @param {string|null|undefined} key
+ * @returns {string}
  */
 export function tokenToTemplate(key) {
   if (!key) return '';
-  // If already a template string, return as-is
   if (key.startsWith('{{') && key.endsWith('}}')) return key;
   return `{{${key}}}`;
 }
-
-/**
- * Schema definitions for each entity's writable fields.
- * Used by FieldMappingPanel targetSchema prop.
- */
-export const ENTITY_SCHEMAS = {
-  lead: [
-    { value: 'first_name', label: 'First Name' },
-    { value: 'last_name', label: 'Last Name' },
-    { value: 'email', label: 'Email' },
-    { value: 'phone', label: 'Phone' },
-    { value: 'company', label: 'Company' },
-    { value: 'job_title', label: 'Job Title' },
-    { value: 'status', label: 'Status' },
-    { value: 'score', label: 'Score' },
-    { value: 'source', label: 'Source' },
-    { value: 'next_action', label: 'Next Action' },
-    { value: 'notes', label: 'Notes' },
-    { value: 'city', label: 'City' },
-    { value: 'state', label: 'State' },
-    { value: 'country', label: 'Country' },
-    { value: 'assigned_to', label: 'Assigned To (User ID)' },
-  ],
-  contact: [
-    { value: 'first_name', label: 'First Name' },
-    { value: 'last_name', label: 'Last Name' },
-    { value: 'email', label: 'Email' },
-    { value: 'phone', label: 'Phone' },
-    { value: 'mobile', label: 'Mobile' },
-    { value: 'job_title', label: 'Job Title' },
-    { value: 'company', label: 'Company' },
-    { value: 'city', label: 'City' },
-    { value: 'state', label: 'State' },
-    { value: 'country', label: 'Country' },
-    { value: 'notes', label: 'Notes' },
-    { value: 'assigned_to', label: 'Assigned To (User ID)' },
-  ],
-  account: [
-    { value: 'name', label: 'Name' },
-    { value: 'industry', label: 'Industry' },
-    { value: 'website', label: 'Website' },
-    { value: 'email', label: 'Email' },
-    { value: 'phone', label: 'Phone' },
-    { value: 'city', label: 'City' },
-    { value: 'state', label: 'State' },
-    { value: 'country', label: 'Country' },
-    { value: 'annual_revenue', label: 'Annual Revenue' },
-    { value: 'employee_count', label: 'Employee Count' },
-    { value: 'notes', label: 'Notes' },
-  ],
-  opportunity: [
-    { value: 'name', label: 'Name' },
-    { value: 'amount', label: 'Amount' },
-    { value: 'stage', label: 'Stage' },
-    { value: 'probability', label: 'Probability' },
-    { value: 'close_date', label: 'Close Date' },
-    { value: 'notes', label: 'Notes' },
-  ],
-  activity: [
-    { value: 'type', label: 'Type' },
-    { value: 'subject', label: 'Subject / Title' },
-    { value: 'body', label: 'Body / Details' },
-    { value: 'status', label: 'Status' },
-    { value: 'due_date', label: 'Due Date' },
-    { value: 'assigned_to', label: 'Assigned To (User ID)' },
-    { value: 'related_to', label: 'Related To (entity type)' },
-    { value: 'related_id', label: 'Related ID' },
-  ],
-};

--- a/src/pages/AICampaigns.jsx
+++ b/src/pages/AICampaigns.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { AICampaign } from '@/api/entities';
+import { AICampaign, BACKEND_URL, supabase } from '@/api/entities';
 import { useUser } from '@/components/shared/useUser.js';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -38,7 +38,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import AICampaignForm from '../components/campaigns/AICampaignForm';
 import AICampaignDetailPanel from '../components/campaigns/AICampaignDetailPanel';
 import CampaignMonitor from '../components/campaigns/CampaignMonitor';
@@ -231,7 +231,74 @@ export default function AICampaigns() {
 
   const handleStatusChange = async (campaign, newStatus) => {
     try {
-      await AICampaign.update(campaign.id, { status: newStatus });
+      const tenant_id = campaign?.tenant_id || selectedTenantId || currentUser?.tenant_id;
+      if (!tenant_id) {
+        throw new Error('tenant_id is required');
+      }
+
+      if (newStatus === 'running') {
+        const endpoint = campaign.status === 'paused' ? 'resume' : 'start';
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        const authHeaders = session?.access_token
+          ? { Authorization: `Bearer ${session.access_token}` }
+          : {};
+        const response = await fetch(`${BACKEND_URL}/api/aicampaigns/${campaign.id}/${endpoint}`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...authHeaders,
+          },
+          credentials: 'include',
+          body: JSON.stringify({ tenant_id }),
+        });
+
+        const contentType = response.headers.get('content-type') || '';
+        const raw = await response.text();
+        const result = contentType.includes('application/json')
+          ? JSON.parse(raw || '{}')
+          : { message: raw };
+        if (!response.ok) {
+          const message =
+            result?.message && !String(result.message).startsWith('<!doctype')
+              ? result.message
+              : `Failed to ${endpoint} campaign`;
+          throw new Error(message);
+        }
+      } else if (newStatus === 'paused') {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+        const authHeaders = session?.access_token
+          ? { Authorization: `Bearer ${session.access_token}` }
+          : {};
+        const response = await fetch(`${BACKEND_URL}/api/aicampaigns/${campaign.id}/pause`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...authHeaders,
+          },
+          credentials: 'include',
+          body: JSON.stringify({ tenant_id }),
+        });
+
+        const contentType = response.headers.get('content-type') || '';
+        const raw = await response.text();
+        const result = contentType.includes('application/json')
+          ? JSON.parse(raw || '{}')
+          : { message: raw };
+        if (!response.ok) {
+          const message =
+            result?.message && !String(result.message).startsWith('<!doctype')
+              ? result.message
+              : 'Failed to pause campaign';
+          throw new Error(message);
+        }
+      } else {
+        await AICampaign.update(campaign.id, { status: newStatus, tenant_id });
+      }
+
       loadCampaigns();
     } catch (error) {
       console.error('Error updating campaign status:', error);
@@ -622,6 +689,9 @@ export default function AICampaigns() {
         }}
       >
         <DialogContent className="bg-slate-900 border-slate-700 max-w-4xl w-full max-h-[90vh] overflow-y-auto p-0 gap-0">
+          <DialogTitle className="sr-only">
+            {editingCampaign ? 'Edit AI Campaign' : 'Create AI Campaign'}
+          </DialogTitle>
           <AICampaignForm
             campaign={editingCampaign}
             onSubmit={handleSubmit}

--- a/src/pages/Activities.jsx
+++ b/src/pages/Activities.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Activity, Account, Contact, Lead, Opportunity } from '@/api/entities';
+import { Activity, Account, Contact, Lead, Opportunity, BizDevSource } from '@/api/entities';
 import { useUser } from '@/components/shared/useUser.js';
 import { useApiManager } from '../components/shared/ApiManager';
 import { useProgress } from '../components/shared/ProgressOverlay';
@@ -10,6 +10,7 @@ import ContactDetailPanel from '../components/contacts/ContactDetailPanel';
 import AccountDetailPanel from '../components/accounts/AccountDetailPanel';
 import LeadDetailPanel from '../components/leads/LeadDetailPanel';
 import OpportunityDetailPanel from '../components/opportunities/OpportunityDetailPanel';
+import BizDevSourceDetailPanel from '../components/bizdev/BizDevSourceDetailPanel';
 import BulkActionsMenu from '../components/activities/BulkActionsMenu';
 import ActivityStatsCards from '../components/activities/ActivityStatsCards';
 import ActivityFilters from '../components/activities/ActivityFilters';
@@ -311,6 +312,7 @@ export default function ActivitiesPage() {
       account: { api: Account, label: 'Account' },
       lead: { api: Lead, label: 'Lead' },
       opportunity: { api: Opportunity, label: 'Opportunity' },
+      bizdev_source: { api: BizDevSource, label: 'Potential Lead' },
     };
 
     const entity = entityMap[activity.related_to];
@@ -820,6 +822,17 @@ export default function ActivitiesPage() {
       {relatedEntityType === 'opportunity' && isRelatedDetailOpen && viewingRelatedEntity && (
         <OpportunityDetailPanel
           opportunity={viewingRelatedEntity}
+          onClose={() => {
+            setIsRelatedDetailOpen(false);
+            setViewingRelatedEntity(null);
+            setRelatedEntityType(null);
+          }}
+          user={user}
+        />
+      )}
+      {relatedEntityType === 'bizdev_source' && isRelatedDetailOpen && viewingRelatedEntity && (
+        <BizDevSourceDetailPanel
+          bizDevSource={viewingRelatedEntity}
           onClose={() => {
             setIsRelatedDetailOpen(false);
             setViewingRelatedEntity(null);

--- a/src/pages/Workflows.jsx
+++ b/src/pages/Workflows.jsx
@@ -1,30 +1,21 @@
-import { useEffect, useState } from "react";
-import {
-  CheckCircle,
-  Clock,
-  Edit,
-  Pause,
-  Play,
-  Plus,
-  Trash2,
-  Zap,
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { useEffect, useState } from 'react';
+import { CheckCircle, Clock, Edit, Pause, Play, Plus, Trash2, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-} from "@/components/ui/dialog";
-import { Workflow } from "@/api/entities";
-import { useUser } from "../components/shared/useUser.js";
-import { useTenant } from "../components/shared/tenantContext";
-import WorkflowBuilder from "../components/workflows/WorkflowBuilder";
-import { format } from "date-fns";
-import { toast } from "sonner";
+} from '@/components/ui/dialog';
+import { Workflow } from '@/api/entities';
+import { useUser } from '../components/shared/useUser.js';
+import { useTenant } from '../components/shared/tenantContext';
+import WorkflowBuilder from '../components/workflows/WorkflowBuilder';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
 
 export default function WorkflowsPage() {
   const [workflows, setWorkflows] = useState([]);
@@ -46,14 +37,14 @@ export default function WorkflowsPage() {
       if (selectedTenantId) {
         params.tenant_id = selectedTenantId;
       }
-      
+
       const workflowsData = await Workflow.list(params);
       setWorkflows(workflowsData || []);
     } catch (error) {
       if (import.meta.env.DEV) {
-        console.error("Failed to load workflows:", error);
+        console.error('Failed to load workflows:', error);
       }
-      toast.error("Failed to load workflows");
+      toast.error('Failed to load workflows');
     } finally {
       setLoading(false);
     }
@@ -72,15 +63,13 @@ export default function WorkflowsPage() {
   const handleToggleActive = async (workflow) => {
     try {
       await Workflow.update(workflow.id, { is_active: !workflow.is_active });
-      toast.success(
-        `Workflow ${!workflow.is_active ? "activated" : "deactivated"}`,
-      );
+      toast.success(`Workflow ${!workflow.is_active ? 'activated' : 'deactivated'}`);
       loadData();
     } catch (error) {
       if (import.meta.env.DEV) {
-        console.error("Failed to toggle workflow:", error);
+        console.error('Failed to toggle workflow:', error);
       }
-      toast.error("Failed to update workflow");
+      toast.error('Failed to update workflow');
     }
   };
 
@@ -89,13 +78,13 @@ export default function WorkflowsPage() {
 
     try {
       await Workflow.delete(workflow.id);
-      toast.success("Workflow deleted");
+      toast.success('Workflow deleted');
       loadData();
     } catch (error) {
       if (import.meta.env.DEV) {
-        console.error("Failed to delete workflow:", error);
+        console.error('Failed to delete workflow:', error);
       }
-      toast.error("Failed to delete workflow");
+      toast.error('Failed to delete workflow');
     }
   };
 
@@ -126,153 +115,133 @@ export default function WorkflowsPage() {
               <Zap className="w-8 h-8 text-purple-400" />
               Workflows
             </h1>
-            <p className="text-slate-400 mt-1">
-              Automate your CRM with custom workflows
-            </p>
+            <p className="text-slate-400 mt-1">Automate your CRM with custom workflows</p>
           </div>
-          <Button
-            onClick={handleCreateNew}
-            className="bg-purple-600 hover:bg-purple-700"
-          >
+          <Button onClick={handleCreateNew} className="bg-purple-600 hover:bg-purple-700">
             <Plus className="w-4 h-4 mr-2" />
             Create Workflow
           </Button>
         </div>
 
         {/* Workflows List */}
-        {workflows.length === 0
-          ? (
-            <Card className="bg-slate-800 border-slate-700">
-              <CardContent className="py-12 text-center">
-                <Zap className="w-16 h-16 text-slate-600 mx-auto mb-4" />
-                <h3 className="text-lg font-semibold text-slate-300 mb-2">
-                  No workflows yet
-                </h3>
-                <p className="text-slate-500 mb-4">
-                  Create your first workflow to automate your CRM
-                </p>
-                <Button
-                  onClick={handleCreateNew}
-                  className="bg-purple-600 hover:bg-purple-700"
-                >
-                  <Plus className="w-4 h-4 mr-2" />
-                  Create Your First Workflow
-                </Button>
-              </CardContent>
-            </Card>
-          )
-          : (
-            <div className="grid gap-4">
-              {workflows.map((workflow) => (
-                <Card
-                  key={workflow.id}
-                  className="bg-slate-800 border-slate-700 hover:bg-slate-700/50 transition-colors"
-                >
-                  <CardContent className="p-6">
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-2">
-                          <h3 className="text-lg font-semibold text-slate-100">
-                            {workflow.name}
-                          </h3>
-                          <Badge
-                            variant={workflow.is_active
-                              ? "default"
-                              : "secondary"}
-                            className={workflow.is_active
-                              ? "bg-green-600"
-                              : "bg-slate-600"}
-                          >
-                            {workflow.is_active ? "Active" : "Inactive"}
-                          </Badge>
-                        </div>
-                        <p className="text-slate-400 text-sm mb-3">
-                          {workflow.description || "No description"}
-                        </p>
+        {workflows.length === 0 ? (
+          <Card className="bg-slate-800 border-slate-700">
+            <CardContent className="py-12 text-center">
+              <Zap className="w-16 h-16 text-slate-600 mx-auto mb-4" />
+              <h3 className="text-lg font-semibold text-slate-300 mb-2">No workflows yet</h3>
+              <p className="text-slate-500 mb-4">Create your first workflow to automate your CRM</p>
+              <Button onClick={handleCreateNew} className="bg-purple-600 hover:bg-purple-700">
+                <Plus className="w-4 h-4 mr-2" />
+                Create Your First Workflow
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4">
+            {workflows.map((workflow) => (
+              <Card
+                key={workflow.id}
+                className="bg-slate-800 border-slate-700 hover:bg-slate-700/50 transition-colors"
+              >
+                <CardContent className="p-6">
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-3 mb-2">
+                        <h3 className="text-lg font-semibold text-slate-100">{workflow.name}</h3>
+                        <Badge
+                          variant={workflow.is_active ? 'default' : 'secondary'}
+                          className={workflow.is_active ? 'bg-green-600' : 'bg-slate-600'}
+                        >
+                          {workflow.is_active ? 'Active' : 'Inactive'}
+                        </Badge>
+                      </div>
+                      <p className="text-slate-400 text-sm mb-3">
+                        {workflow.description || 'No description'}
+                      </p>
 
-                        <div className="flex items-center gap-4 text-xs text-slate-500">
+                      <div className="flex items-center gap-4 text-xs text-slate-500">
+                        <div className="flex items-center gap-1">
+                          <Zap className="w-3 h-3" />
+                          <span>{workflow.trigger?.type || 'webhook'}</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <CheckCircle className="w-3 h-3" />
+                          <span>{workflow.execution_count || 0} executions</span>
+                        </div>
+                        {workflow.last_executed && (
                           <div className="flex items-center gap-1">
-                            <Zap className="w-3 h-3" />
-                            <span>{workflow.trigger?.type || "webhook"}</span>
-                          </div>
-                          <div className="flex items-center gap-1">
-                            <CheckCircle className="w-3 h-3" />
+                            <Clock className="w-3 h-3" />
                             <span>
-                              {workflow.execution_count || 0} executions
+                              Last run: {format(new Date(workflow.last_executed), 'MMM d, h:mm a')}
                             </span>
-                          </div>
-                          {workflow.last_executed && (
-                            <div className="flex items-center gap-1">
-                              <Clock className="w-3 h-3" />
-                              <span>
-                                Last run:{" "}
-                                {format(
-                                  new Date(workflow.last_executed),
-                                  "MMM d, h:mm a",
-                                )}
-                              </span>
-                            </div>
-                          )}
-                        </div>
-
-                        {workflow.webhook_url && (
-                          <div className="mt-3 p-2 bg-slate-900 rounded border border-slate-700">
-                            <p className="text-xs text-slate-500 mb-1">
-                              Webhook URL:
-                            </p>
-                            <code className="text-xs text-blue-400 break-all">
-                              {workflow.webhook_url}
-                            </code>
                           </div>
                         )}
                       </div>
 
-                      <div className="flex items-center gap-2 ml-4">
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => handleToggleActive(workflow)}
-                          className="text-slate-400 hover:text-slate-200"
-                        >
-                          {workflow.is_active
-                            ? <Pause className="w-4 h-4" />
-                            : <Play className="w-4 h-4" />}
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => handleEdit(workflow)}
-                          className="text-slate-400 hover:text-slate-200"
-                        >
-                          <Edit className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="ghost"
-                          onClick={() => handleDelete(workflow)}
-                          className="text-red-400 hover:text-red-300"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
+                      <div className="mt-3 p-2 bg-slate-900 rounded border border-slate-700">
+                        <p className="text-xs text-slate-500 mb-1">Workflow ID:</p>
+                        <code className="text-xs text-purple-400 break-all select-all">
+                          {workflow.id}
+                        </code>
+                        {workflow.webhook_url && (
+                          <>
+                            <p className="text-xs text-slate-500 mt-2 mb-1">Webhook URL:</p>
+                            <code className="text-xs text-blue-400 break-all">
+                              {workflow.webhook_url}
+                            </code>
+                          </>
+                        )}
                       </div>
                     </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
+
+                    <div className="flex items-center gap-2 ml-4">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleToggleActive(workflow)}
+                        className="text-slate-400 hover:text-slate-200"
+                      >
+                        {workflow.is_active ? (
+                          <Pause className="w-4 h-4" />
+                        ) : (
+                          <Play className="w-4 h-4" />
+                        )}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleEdit(workflow)}
+                        className="text-slate-400 hover:text-slate-200"
+                      >
+                        <Edit className="w-4 h-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleDelete(workflow)}
+                        className="text-red-400 hover:text-red-300"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
 
         {/* Workflow Builder Dialog */}
         <Dialog open={showBuilder} onOpenChange={setShowBuilder}>
           <DialogContent className="max-w-[95vw] w-full max-h-[90vh] h-[90vh] bg-slate-900 border-slate-700 p-0">
             <DialogHeader className="px-6 pt-6 pb-0">
               <DialogTitle className="text-slate-100">
-                {editingWorkflow ? "Edit Workflow" : "Create New Workflow"}
+                {editingWorkflow ? 'Edit Workflow' : 'Create New Workflow'}
               </DialogTitle>
               <DialogDescription className="text-slate-400">
-                {editingWorkflow 
-                  ? "Configure your workflow triggers, conditions, and actions" 
-                  : "Create an automated workflow to streamline your CRM processes"}
+                {editingWorkflow
+                  ? 'Configure your workflow triggers, conditions, and actions'
+                  : 'Create an automated workflow to streamline your CRM processes'}
               </DialogDescription>
             </DialogHeader>
             <div className="h-[calc(90vh-4rem)] overflow-hidden">

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -167,6 +167,7 @@ export default defineConfig({
         plugins: [react()],
         test: {
           ...sharedConfig,
+          env: { NODE_ENV: 'test' },
           include: [
             'src/components/workflows/**/*.test.{js,jsx,ts,tsx}',
             'src/components/workflows/**/__tests__/**/*.{js,jsx,ts,tsx}',


### PR DESCRIPTION
## Summary

Integration branch merging `feature/workflow-field-mapping` and `feat/aicampaign-clean`. Ensures the AI campaign workflow dispatch integrates cleanly with the upgraded workflow node system.

## What's included

### From `feature/workflow-field-mapping` (PR #503)
- `FieldMappingPanel` + `upstreamTokens.js` — Zapier-style token pill picker for entity nodes
- Upgraded: `create_lead`, `update_lead`, `update_contact`, `update_account`, `create_opportunity`, `update_opportunity`
- Backend `resolveMapping()` normalises all legacy `{entity_field, webhook_field}` shapes + new `{target_field, source_value}` shape
- 54 passing tests (20 backend + 34 frontend)

### From `feat/aicampaign-clean`
- `create_activity` node — text input + `renderVariablePicker` for freeform `{{variable}}` injection (correct approach for campaign dispatch payloads like `{{contact.email}}`, `{{campaign.name}}`)
- Output preview refactored to Zapier-style clickable `rows` table; click any row to insert `{{varPath}}` at cursor
- `insertAtFocused` / `lastFocusedInputRef` cursor insertion mechanic
- `NODE_VARIABLE_SCHEMA` + `getUpstreamVariables` — upstream variable chip picker
- `workflowExecutionService.js`: `create_activity` now resolves `assigned_to` (UUID or email), normalises entity type aliases (`potential_lead`/`source` → `bizdev_source`), falls back to campaign payload `contact` object for association, defaults subject/body to campaign name, logs explicit errors on insert failure
- `aicampaigns.js`: `workflow_id` field on campaigns, `/audience-preview` endpoint, `/:id/targets` GET, hardened `/:id/start` with full audience resolution + `ai_campaign_targets` insertion + event logging + scheduled campaign support
- `resolveAudience.js` + `buildAudienceFromPrompt.js` — audience resolution pipeline
- Migrations: `091_ai_campaign_execution_hardening.sql`, `150_ai_campaign_workflow_id.sql`

### Conflict resolution
Only `WorkflowBuilder.jsx` conflicted. `create_activity` panel: took campaign branch's text inputs + `renderVariablePicker` over our `FieldMappingPanel` — campaign workers fire freeform `{{contact.email}}` template strings into `title`/`details`, not entity field mappings.

### vitest fix
Added `env: { NODE_ENV: 'test' }` to the `crm` vitest project (same fix already applied to `workflows` project in PR #503) — resolves pre-existing `act(...) is not supported in production builds` failures in `Activities.smoke.test.jsx`.

## Migrations to apply (both Supabase projects)
- `backend/migrations/091_ai_campaign_execution_hardening.sql`
- `backend/migrations/150_ai_campaign_workflow_id.sql`
