### PR TITLE
feat: move CARE Workflows to secondary nav with per-user/tenant permission gating

### DIFF
--- a/src/components/settings/NavigationPermissions.jsx
+++ b/src/components/settings/NavigationPermissions.jsx
@@ -19,6 +19,7 @@ function toLabel(key) {
     ClientOnboarding: 'Client Onboarding',
     WorkflowGuide: 'Workflow Guide',
     ClientRequirements: 'Client Requirements',
+    CareWorkflows: 'CARE Workflows',
   };
   return map[key] || key.replace(/([a-z0-9])([A-Z])/g, '$1 $2');
 }
@@ -48,6 +49,7 @@ const ORDER = [
   'ClientOnboarding',
   'WorkflowGuide',
   'ClientRequirements',
+  'CareWorkflows',
 ];
 
 export default function NavigationPermissions({

--- a/src/components/settings/TenantNavigationDefaults.jsx
+++ b/src/components/settings/TenantNavigationDefaults.jsx
@@ -1,43 +1,177 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
-import { Switch } from "@/components/ui/switch";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Tenant, ModuleSettings } from "@/api/entities";
-import { useTenant } from "@/components/shared/tenantContext";
-import { Loader2, Save, RotateCcw, Info, Lock } from "lucide-react";
-import { toast } from "sonner";
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Tenant, ModuleSettings } from '@/api/entities';
+import { useTenant } from '@/components/shared/tenantContext';
+import { Loader2, Save, RotateCcw, Info, Lock } from 'lucide-react';
+import { toast } from 'sonner';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 // Navigation items that can be toggled
 // moduleName: matches modulesettings table module_name for disabling when module is off
 const NAV_ITEMS = [
-    { key: "Dashboard", label: "Dashboard", description: "Main overview page", default: true, moduleName: "Dashboard" },
-    { key: "Contacts", label: "Contacts", description: "Contact management", default: true, moduleName: "Contact Management" },
-    { key: "Accounts", label: "Accounts", description: "Company/organization records", default: true, moduleName: "Account Management" },
-    { key: "Leads", label: "Leads", description: "Potential customer tracking", default: true, moduleName: "Lead Management" },
-    { key: "Opportunities", label: "Opportunities", description: "Sales pipeline & deals", default: true, moduleName: "Opportunities" },
-    { key: "Activities", label: "Activities", description: "Tasks, calls, meetings", default: true, moduleName: "Activity Tracking" },
-    { key: "Calendar", label: "Calendar", description: "Schedule view", default: true, moduleName: "Calendar" },
-    { key: "BizDevSources", label: "BizDev Sources", description: "Lead source tracking", default: false, moduleName: "BizDev Sources" },
-    { key: "CashFlow", label: "Cash Flow", description: "Financial forecasting", default: false, moduleName: "Cash Flow Management" },
-    { key: "DocumentProcessing", label: "Document Processing", description: "AI document extraction", default: false, moduleName: "Document Processing & Management" },
-    { key: "DocumentManagement", label: "Document Management", description: "File storage", default: false, moduleName: "Document Processing & Management" },
-    { key: "AICampaigns", label: "AI Campaigns", description: "Outreach campaigns", default: false, moduleName: "AI Campaigns" },
-    { key: "Employees", label: "Employees", description: "Team member management", default: false, moduleName: "Employee Management" },
-    { key: "Reports", label: "Reports", description: "Analytics & reporting", default: false, moduleName: "Analytics & Reports" },
-    { key: "Integrations", label: "Integrations", description: "Third-party connections", default: false, moduleName: "Integrations" },
-    { key: "Workflows", label: "Workflows", description: "Automation rules", default: false, moduleName: "Workflows" },
-    { key: "PaymentPortal", label: "Payment Portal", description: "Payment processing", default: false, moduleName: "Payment Portal" },
-    { key: "ConstructionProjects", label: "Construction Projects", description: "Project management", default: false, moduleName: "Construction Projects" },
-    { key: "Workers", label: "Workers", description: "Contractor & labor management", default: false, moduleName: "Workers" },
-    { key: "Utilities", label: "Utilities", description: "Admin tools", default: false, moduleName: "Utilities" },
-    { key: "Agent", label: "AI Agent", description: "AI assistant", default: true, moduleName: "AI Agent" },
-    { key: "Documentation", label: "Documentation", description: "Help & guides", default: true, moduleName: null },
+  {
+    key: 'Dashboard',
+    label: 'Dashboard',
+    description: 'Main overview page',
+    default: true,
+    moduleName: 'Dashboard',
+  },
+  {
+    key: 'Contacts',
+    label: 'Contacts',
+    description: 'Contact management',
+    default: true,
+    moduleName: 'Contact Management',
+  },
+  {
+    key: 'Accounts',
+    label: 'Accounts',
+    description: 'Company/organization records',
+    default: true,
+    moduleName: 'Account Management',
+  },
+  {
+    key: 'Leads',
+    label: 'Leads',
+    description: 'Potential customer tracking',
+    default: true,
+    moduleName: 'Lead Management',
+  },
+  {
+    key: 'Opportunities',
+    label: 'Opportunities',
+    description: 'Sales pipeline & deals',
+    default: true,
+    moduleName: 'Opportunities',
+  },
+  {
+    key: 'Activities',
+    label: 'Activities',
+    description: 'Tasks, calls, meetings',
+    default: true,
+    moduleName: 'Activity Tracking',
+  },
+  {
+    key: 'Calendar',
+    label: 'Calendar',
+    description: 'Schedule view',
+    default: true,
+    moduleName: 'Calendar',
+  },
+  {
+    key: 'BizDevSources',
+    label: 'BizDev Sources',
+    description: 'Lead source tracking',
+    default: false,
+    moduleName: 'BizDev Sources',
+  },
+  {
+    key: 'CashFlow',
+    label: 'Cash Flow',
+    description: 'Financial forecasting',
+    default: false,
+    moduleName: 'Cash Flow Management',
+  },
+  {
+    key: 'DocumentProcessing',
+    label: 'Document Processing',
+    description: 'AI document extraction',
+    default: false,
+    moduleName: 'Document Processing & Management',
+  },
+  {
+    key: 'DocumentManagement',
+    label: 'Document Management',
+    description: 'File storage',
+    default: false,
+    moduleName: 'Document Processing & Management',
+  },
+  {
+    key: 'AICampaigns',
+    label: 'AI Campaigns',
+    description: 'Outreach campaigns',
+    default: false,
+    moduleName: 'AI Campaigns',
+  },
+  {
+    key: 'Employees',
+    label: 'Employees',
+    description: 'Team member management',
+    default: false,
+    moduleName: 'Employee Management',
+  },
+  {
+    key: 'Reports',
+    label: 'Reports',
+    description: 'Analytics & reporting',
+    default: false,
+    moduleName: 'Analytics & Reports',
+  },
+  {
+    key: 'Integrations',
+    label: 'Integrations',
+    description: 'Third-party connections',
+    default: false,
+    moduleName: 'Integrations',
+  },
+  {
+    key: 'Workflows',
+    label: 'Workflows',
+    description: 'Automation rules',
+    default: false,
+    moduleName: 'Workflows',
+  },
+  {
+    key: 'PaymentPortal',
+    label: 'Payment Portal',
+    description: 'Payment processing',
+    default: false,
+    moduleName: 'Payment Portal',
+  },
+  {
+    key: 'ConstructionProjects',
+    label: 'Construction Projects',
+    description: 'Project management',
+    default: false,
+    moduleName: 'Construction Projects',
+  },
+  {
+    key: 'Workers',
+    label: 'Workers',
+    description: 'Contractor & labor management',
+    default: false,
+    moduleName: 'Workers',
+  },
+  {
+    key: 'Utilities',
+    label: 'Utilities',
+    description: 'Admin tools',
+    default: false,
+    moduleName: 'Utilities',
+  },
+  {
+    key: 'Agent',
+    label: 'AI Agent',
+    description: 'AI assistant',
+    default: true,
+    moduleName: 'AI Agent',
+  },
+  {
+    key: 'Documentation',
+    label: 'Documentation',
+    description: 'Help & guides',
+    default: true,
+    moduleName: null,
+  },
+  {
+    key: 'CareWorkflows',
+    label: 'CARE Workflows',
+    description: 'AI-driven care triggers and playbooks',
+    default: false,
+    moduleName: 'CARE Workflows',
+  },
 ];
 
 // Build default permissions object
@@ -52,24 +186,24 @@ export default function TenantNavigationDefaults() {
 
   const [tenant, setTenant] = useState(null);
   const [permissions, setPermissions] = useState({ ...DEFAULT_PERMISSIONS });
-    const [moduleSettings, setModuleSettings] = useState([]);
+  const [moduleSettings, setModuleSettings] = useState([]);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
-    // Build a set of disabled module names from module settings
-    const disabledModules = useMemo(() => {
-        const disabled = new Set();
-        moduleSettings.forEach((ms) => {
-            if (ms.is_enabled === false) {
-                disabled.add(ms.module_name);
-            }
-        });
-        return disabled;
-    }, [moduleSettings]);
+  // Build a set of disabled module names from module settings
+  const disabledModules = useMemo(() => {
+    const disabled = new Set();
+    moduleSettings.forEach((ms) => {
+      if (ms.is_enabled === false) {
+        disabled.add(ms.module_name);
+      }
+    });
+    return disabled;
+  }, [moduleSettings]);
 
-    // Load tenant settings and module settings
+  // Load tenant settings and module settings
   useEffect(() => {
-      async function loadData() {
+    async function loadData() {
       if (!tenantId) {
         setLoading(false);
         return;
@@ -78,14 +212,14 @@ export default function TenantNavigationDefaults() {
       try {
         setLoading(true);
 
-          // Load tenant and module settings in parallel
-          const [tenantData, moduleData] = await Promise.all([
-              Tenant.get(tenantId),
-              ModuleSettings.filter({ tenant_id: tenantId }),
-          ]);
+        // Load tenant and module settings in parallel
+        const [tenantData, moduleData] = await Promise.all([
+          Tenant.get(tenantId),
+          ModuleSettings.filter({ tenant_id: tenantId }),
+        ]);
 
         setTenant(tenantData);
-          setModuleSettings(moduleData || []);
+        setModuleSettings(moduleData || []);
 
         // Get stored defaults from tenant settings
         const storedDefaults = tenantData?.settings?.default_navigation_permissions;
@@ -100,11 +234,11 @@ export default function TenantNavigationDefaults() {
       }
     }
 
-      loadData();
+    loadData();
   }, [tenantId]);
 
   const handleToggle = useCallback((key, checked) => {
-    setPermissions(prev => ({ ...prev, [key]: checked }));
+    setPermissions((prev) => ({ ...prev, [key]: checked }));
   }, []);
 
   const handleEnableAll = useCallback(() => {
@@ -161,11 +295,7 @@ export default function TenantNavigationDefaults() {
   }
 
   if (!tenantId) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        No tenant selected
-      </div>
-    );
+    return <div className="text-center py-8 text-muted-foreground">No tenant selected</div>;
   }
 
   return (
@@ -175,7 +305,8 @@ export default function TenantNavigationDefaults() {
         <Info className="w-5 h-5 text-blue-400 mt-0.5 flex-shrink-0" />
         <div>
           <p className="text-sm text-blue-300">
-            These settings control which navigation items are <strong>enabled by default</strong> when you invite new users.
+            These settings control which navigation items are <strong>enabled by default</strong>{' '}
+            when you invite new users.
           </p>
           <p className="text-xs text-blue-300/70 mt-1">
             You can still customize permissions for individual users during the invitation process.
@@ -189,29 +320,19 @@ export default function TenantNavigationDefaults() {
           <Badge variant="outline" className="text-sm">
             {enabledCount} of {NAV_ITEMS.length} enabled
           </Badge>
-                  {disabledModules.size > 0 && (
-                      <Badge variant="secondary" className="text-sm text-muted-foreground">
-                          <Lock className="w-3 h-3 mr-1" />
-                          {disabledModules.size} module{disabledModules.size > 1 ? 's' : ''} disabled
-                      </Badge>
-                  )}
+          {disabledModules.size > 0 && (
+            <Badge variant="secondary" className="text-sm text-muted-foreground">
+              <Lock className="w-3 h-3 mr-1" />
+              {disabledModules.size} module{disabledModules.size > 1 ? 's' : ''} disabled
+            </Badge>
+          )}
         </div>
         <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleReset}
-            disabled={saving}
-          >
+          <Button variant="outline" size="sm" onClick={handleReset} disabled={saving}>
             <RotateCcw className="w-4 h-4 mr-1" />
             Reset
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleEnableAll}
-            disabled={saving}
-          >
+          <Button variant="outline" size="sm" onClick={handleEnableAll} disabled={saving}>
             Enable All
           </Button>
         </div>
@@ -219,59 +340,59 @@ export default function TenantNavigationDefaults() {
 
       {/* Permissions Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {NAV_ITEMS.map((item) => {
-                  // Check if this nav item's module is disabled
-                  const isModuleDisabled = item.moduleName && disabledModules.has(item.moduleName);
+        {NAV_ITEMS.map((item) => {
+          // Check if this nav item's module is disabled
+          const isModuleDisabled = item.moduleName && disabledModules.has(item.moduleName);
 
-                  return (
-                      <TooltipProvider key={item.key}>
-                          <Tooltip>
-                              <TooltipTrigger asChild>
-                                  <div
-                              className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${isModuleDisabled
-                                      ? 'bg-muted/30 border-border/50 opacity-60 cursor-not-allowed'
-                                      : 'bg-secondary/50 border-border hover:bg-secondary/70'
-                                  }`}
-                          >
-                              <div className="flex-1 min-w-0">
-                                  <div className="flex items-center gap-2">
-                                      <span className={`font-medium text-sm ${isModuleDisabled ? 'text-muted-foreground' : ''}`}>
-                                          {item.label}
-                                      </span>
-                                      {isModuleDisabled && (
-                                          <Lock className="w-3 h-3 text-muted-foreground" />
-                                      )}
-                                  </div>
-                                  <div className="text-xs text-muted-foreground truncate">
-                                      {isModuleDisabled ? 'Module disabled' : item.description}
-                                  </div>
-                              </div>
-                              <Switch
-                                  checked={isModuleDisabled ? false : !!permissions[item.key]}
-                                  onCheckedChange={(checked) => handleToggle(item.key, checked)}
-                                  disabled={saving || isModuleDisabled}
-                                  className="ml-3 flex-shrink-0"
-                              />
-                          </div>
-                        </TooltipTrigger>
-                        {isModuleDisabled && (
-                            <TooltipContent>
-                                <p>This module is disabled in Module Settings. Enable the module first to allow user access.</p>
-                            </TooltipContent>
-                        )}
-                    </Tooltip>
-                </TooltipProvider>
-            );
+          return (
+            <TooltipProvider key={item.key}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={`flex items-center justify-between p-3 rounded-lg border transition-colors ${
+                      isModuleDisabled
+                        ? 'bg-muted/30 border-border/50 opacity-60 cursor-not-allowed'
+                        : 'bg-secondary/50 border-border hover:bg-secondary/70'
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`font-medium text-sm ${isModuleDisabled ? 'text-muted-foreground' : ''}`}
+                        >
+                          {item.label}
+                        </span>
+                        {isModuleDisabled && <Lock className="w-3 h-3 text-muted-foreground" />}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {isModuleDisabled ? 'Module disabled' : item.description}
+                      </div>
+                    </div>
+                    <Switch
+                      checked={isModuleDisabled ? false : !!permissions[item.key]}
+                      onCheckedChange={(checked) => handleToggle(item.key, checked)}
+                      disabled={saving || isModuleDisabled}
+                      className="ml-3 flex-shrink-0"
+                    />
+                  </div>
+                </TooltipTrigger>
+                {isModuleDisabled && (
+                  <TooltipContent>
+                    <p>
+                      This module is disabled in Module Settings. Enable the module first to allow
+                      user access.
+                    </p>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+          );
         })}
       </div>
 
       {/* Save Button */}
       <div className="flex justify-end pt-4 border-t">
-        <Button
-          onClick={handleSave}
-          disabled={saving}
-          className="bg-primary hover:bg-primary/90"
-        >
+        <Button onClick={handleSave} disabled={saving} className="bg-primary hover:bg-primary/90">
           {saving ? (
             <>
               <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/src/components/settings/TenantNavigationDefaults.jsx
+++ b/src/components/settings/TenantNavigationDefaults.jsx
@@ -65,7 +65,7 @@ const NAV_ITEMS = [
     label: 'BizDev Sources',
     description: 'Lead source tracking',
     default: false,
-    moduleName: 'BizDev Sources',
+    moduleName: 'Potential Leads',
   },
   {
     key: 'CashFlow',
@@ -135,7 +135,7 @@ const NAV_ITEMS = [
     label: 'Construction Projects',
     description: 'Project management',
     default: false,
-    moduleName: 'Construction Projects',
+    moduleName: 'Project Management',
   },
   {
     key: 'Workers',

--- a/src/components/settings/UserFormWizard.jsx
+++ b/src/components/settings/UserFormWizard.jsx
@@ -46,6 +46,7 @@ import {
   Menu,
   Copy,
   Trash2,
+  Zap,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { getBackendUrl } from '@/api/backendUrl';
@@ -232,6 +233,12 @@ const NAV_MODULES = [
     icon: Settings,
     description: 'System configuration and preferences',
   },
+  {
+    key: 'CareWorkflows',
+    label: 'CARE Workflows',
+    icon: Zap,
+    description: 'AI-driven customer care triggers and playbooks',
+  },
 ];
 
 // Default nav permissions - most things enabled by default
@@ -268,6 +275,7 @@ const DEFAULT_NAV_PERMISSIONS = {
   DeveloperAI: false, // Off by default - developer only
   ClientRequirements: false, // Off by default - admin only
   Settings: false, // Off by default - requires perm_settings
+  CareWorkflows: false, // Off by default - admin/superadmin only
 };
 
 /**

--- a/src/components/shared/ModuleManager.jsx
+++ b/src/components/shared/ModuleManager.jsx
@@ -304,6 +304,20 @@ const defaultModules = [
     ],
   },
   {
+    id: 'care_workflows',
+    name: 'CARE Workflows',
+    description:
+      'AI-driven care triggers, automations, and playbooks for proactive client engagement',
+    icon: Zap,
+    features: [
+      'C.A.R.E. Trigger Configuration',
+      'Automated Follow-ups',
+      'Playbook Management',
+      'Client Engagement Rules',
+      'Condition-Based Actions',
+    ],
+  },
+  {
     id: 'construction_projects',
     name: 'Project Management',
     description: 'Track projects, assignments, and team resources across your organization',

--- a/src/pages/CareWorkflows.jsx
+++ b/src/pages/CareWorkflows.jsx
@@ -1,0 +1,40 @@
+import { Suspense, lazy } from 'react';
+import { Loader2 } from 'lucide-react';
+import { useUser } from '@/components/shared/useUser.js';
+
+const CareSettings = lazy(() => import('@/components/settings/CareSettings'));
+
+export default function CareWorkflowsPage() {
+  const { user } = useUser();
+  const isSuperadmin = user?.role === 'superadmin';
+  const isAdmin = user?.role === 'admin' || isSuperadmin;
+
+  if (!isAdmin) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        You don&apos;t have permission to view this page.
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6 max-w-5xl mx-auto">
+      <div>
+        <h1 className="text-2xl font-bold">CARE Workflows</h1>
+        <p className="text-muted-foreground mt-1">
+          Configure AI-driven customer care triggers and playbooks
+        </p>
+      </div>
+      <Suspense
+        fallback={
+          <div className="flex items-center justify-center p-8">
+            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+            <span className="ml-2 text-muted-foreground">Loading CARE configuration...</span>
+          </div>
+        }
+      >
+        <CareSettings isSuperadmin={isSuperadmin} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -140,6 +140,7 @@ const secondaryNavIconMap = {
   Documentation: BookOpen,
   DeveloperAI: Bot,
   ClientRequirements: ClipboardCheck,
+  CareWorkflows: Zap,
 };
 
 const navItems = baseNavItems.map((item) => ({

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -53,6 +53,7 @@ const PAGES = {
   Workers: lazy(() => import('./Workers')),
   FunnelDemo: lazy(() => import('./FunnelDemo')),
   McpAdmin: lazy(() => import('./McpAdmin')),
+  CareWorkflows: lazy(() => import('./CareWorkflows')),
 };
 
 function _getCurrentPage(url) {
@@ -176,6 +177,7 @@ function PagesContent() {
                 <Route path="/ConstructionProjects" element={<PAGES.ConstructionProjects />} />
                 <Route path="/Workers" element={<PAGES.Workers />} />
                 <Route path="/McpAdmin" element={<PAGES.McpAdmin />} />
+                <Route path="/CareWorkflows" element={<PAGES.CareWorkflows />} />
               </Routes>
             </Layout>
           }

--- a/src/utils/navigationConfig.js
+++ b/src/utils/navigationConfig.js
@@ -43,6 +43,7 @@ export const secondaryNavItems = [
   { href: 'Documentation', label: 'Documentation' },
   { href: 'DeveloperAI', label: 'Developer AI' },
   { href: 'ClientRequirements', label: 'Client Requirements' },
+  { href: 'CareWorkflows', label: 'CARE Workflows' },
 ];
 
 /**
@@ -83,6 +84,7 @@ export const moduleMapping = {
   AuditLog: null,
   UnitTests: null,
   ClientRequirements: null,
+  CareWorkflows: 'CARE Workflows',
 };
 
 /**

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -332,6 +332,7 @@ export function hasPageAccess(user, pageName, selectedTenantId, moduleSettings =
     Workflows: 'Workflows',
     ConstructionProjects: 'Project Management',
     Workers: 'Workers',
+    CareWorkflows: 'CARE Workflows',
     DuplicateContacts: null,
     DuplicateAccounts: null,
     DuplicateLeads: null,

--- a/src/utils/permissions.js
+++ b/src/utils/permissions.js
@@ -440,6 +440,7 @@ export function getDefaultNavigationPermissions(role, navItems = [], secondaryNa
       UnitTests: true,
       ClientOnboarding: true,
       ClientRequirements: true, // NEW
+      CareWorkflows: true,
       ConstructionProjects: true, // Construction staffing module
       Workers: true, // Worker/contractor management
       DuplicateContacts: true,
@@ -474,6 +475,7 @@ export function getDefaultNavigationPermissions(role, navItems = [], secondaryNa
       UnitTests: true,
       ClientOnboarding: true,
       ClientRequirements: true, // NEW
+      CareWorkflows: true,
       ConstructionProjects: true, // Construction staffing module
       Workers: true, // Worker/contractor management
       DuplicateContacts: true,
@@ -508,6 +510,7 @@ export function getDefaultNavigationPermissions(role, navItems = [], secondaryNa
       UnitTests: false,
       ClientOnboarding: true,
       ClientRequirements: false,
+      CareWorkflows: false,
       ConstructionProjects: true, // Construction staffing module
       Workers: true, // Worker/contractor management
       DuplicateContacts: true,


### PR DESCRIPTION
## What

Moves **CARE Workflows** out of the Settings tab and into a dedicated secondary navigation item, wired into the same dual-gate permission system used by every other module.

## Changes

| File | Change |
|---|---|
| `src/pages/CareWorkflows.jsx` *(new)* | Page wrapper around `CareSettings` with admin role guard |
| `src/pages/index.jsx` | Lazy import + `/CareWorkflows` route |
| `src/utils/navigationConfig.js` | Added to `secondaryNavItems` + `moduleMapping` (`'CARE Workflows'`) |
| `src/pages/Layout.jsx` | Added `CareWorkflows: Zap` to `secondaryNavIconMap` |
| `src/components/settings/NavigationPermissions.jsx` | Added to `ORDER` array + label map |
| `src/components/settings/UserFormWizard.jsx` | Added to `NAV_MODULES` list, default `false` |
| `src/utils/permissions.js` | `true` for superadmin/admin, `false` for manager/employee |
| `src/components/settings/TenantNavigationDefaults.jsx` | Added to `NAV_ITEMS` with `default: false`, `moduleName: 'CARE Workflows'` |

## Permission behaviour

- **Tenant level**: toggled via Module Settings (`CARE Workflows` module name)
- **User level**: per-user toggle in UserFormWizard / NavigationPermissions, off by default for all roles except superadmin and admin
- **Page guard**: renders access-denied message if user is not admin/superadmin

## Notes

- The Settings tab entry for CARE Workflows is intentionally left in place for now — can be removed in a follow-up once the nav item is confirmed stable
- 460 backend tests passing ✅