### PR TITLE
[codex] require explicit opt-in for campaign worker startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Campaign worker startup now requires explicit opt-in (`backend/lib/campaignWorker.js`, `backend/server.js`, `backend/__tests__/lib/campaignWorker.test.js`):** Standardized campaign worker enablement so both the server bootstrap and worker implementation only start when `CAMPAIGN_WORKER_ENABLED=true`, added explicit disabled-state logging, and locked the contract with focused unit coverage to avoid background worker drift across entrypoints.
+
 - **Workflow send_email output preview now shows resolved payload values (`src/components/workflows/WorkflowBuilder.jsx`):** Replaced placeholder preview rows (`sent/message_id`) with runtime-like resolved preview fields for `to`, `subject`, and `body`. Added a body preview mode toggle (`Text` / `HTML`) so operators can switch between plain resolved content and rendered structured template output before execution. When `template_id` is selected, preview resolves template variables and supports `text`, `image`, `button`, and `divider` blocks.
 
 - **Workflow Builder send_email node now exposes template controls (`src/components/workflows/WorkflowBuilder.jsx`):** Added UI controls for optional structured-template selection (`template_id`) in both the top template section and directly near Subject/Body for visibility, JSON-based `template_variables` editing/apply validation, and quick variable-token chips with an insert target selector (Body, Subject, or Focused Field) so operators can configure template-backed email nodes directly in the node editor instead of hand-editing workflow JSON.

--- a/backend/__tests__/lib/campaignWorker.test.js
+++ b/backend/__tests__/lib/campaignWorker.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isCampaignWorkerEnabled } from '../../lib/campaignWorker.js';
+
+test('isCampaignWorkerEnabled returns true only for explicit true', () => {
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'true' }), true);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'false' }), false);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'TRUE' }), false);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: '1' }), false);
+  assert.equal(isCampaignWorkerEnabled({}), false);
+  assert.equal(isCampaignWorkerEnabled(undefined), false);
+});
+
+test('campaign worker enablement helper ignores unrelated env values', () => {
+  assert.equal(
+    isCampaignWorkerEnabled({
+      CAMPAIGN_WORKER_INTERVAL_MS: '5000',
+      NODE_ENV: 'development',
+    }),
+    false,
+  );
+});

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -18,6 +18,10 @@ let supabase = null;
 const webhookDb = { query: supabaseSqlQuery };
 const TARGET_BATCH_SIZE = Number(process.env.CAMPAIGN_WORKER_TARGET_BATCH_SIZE || 25);
 
+export function isCampaignWorkerEnabled(env = process.env) {
+  return env?.CAMPAIGN_WORKER_ENABLED === 'true';
+}
+
 /**
  * Initialize and start the campaign worker
  */
@@ -26,10 +30,10 @@ export function startCampaignWorker(pool, intervalMs = 30000) {
     logger.debug('[CampaignWorker] Ignoring pgPool input; using Supabase client');
   }
   supabase = getSupabaseClient();
-  const enabled = process.env.CAMPAIGN_WORKER_ENABLED !== 'false';
+  const enabled = isCampaignWorkerEnabled(process.env);
 
   if (!enabled) {
-    logger.info('[CampaignWorker] Disabled (CAMPAIGN_WORKER_ENABLED=false)');
+    logger.info('[CampaignWorker] Disabled (set CAMPAIGN_WORKER_ENABLED=true to enable)');
     return;
   }
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -19,7 +19,7 @@ import workflowQueue from './services/workflowQueue.js';
 import { initPlaybookQueueProcessor } from './lib/care/carePlaybookExecutor.js';
 
 // Import background workers
-import { startCampaignWorker } from './lib/campaignWorker.js';
+import { isCampaignWorkerEnabled, startCampaignWorker } from './lib/campaignWorker.js';
 import { startAiTriggersWorker } from './lib/aiTriggersWorker.js';
 import { startEmailWorker } from './workers/emailWorker.js';
 import { startTaskWorkers } from './workers/taskWorkers.js';
@@ -931,10 +931,12 @@ server.listen(PORT, async () => {
   }, 1000); // Delay 1 second to ensure server is fully started
 
   // Start campaign worker if enabled
-  if (process.env.CAMPAIGN_WORKER_ENABLED === 'true' && pgPool) {
+  if (isCampaignWorkerEnabled(process.env) && pgPool) {
     const campaignInterval = parseInt(process.env.CAMPAIGN_WORKER_INTERVAL_MS || '5000', 10);
     startCampaignWorker(pgPool, campaignInterval);
-    logger.info('[CampaignWorker] Started');
+    logger.info({ intervalMs: campaignInterval }, '[CampaignWorker] Started');
+  } else {
+    logger.debug('[CampaignWorker] Disabled (set CAMPAIGN_WORKER_ENABLED=true to enable)');
   }
 
   // Start AI triggers worker if enabled (Phase 3 Autonomous Operations)


### PR DESCRIPTION
## Summary
- require explicit opt-in for campaign worker startup across both server bootstrap and the worker implementation
- centralize the env check in a shared helper so startup behavior cannot drift between entrypoints
- add focused unit coverage for the worker enablement contract and record the fix in the changelog

## Why
Recent review follow-up work identified that campaign worker startup behavior had drifted: `backend/server.js` only started the worker when `CAMPAIGN_WORKER_ENABLED === 'true'`, but `backend/lib/campaignWorker.js` still self-enabled for any value other than `'false'`. That made background processing semantics depend on which entrypoint invoked the worker.

## Impact
- campaign worker startup is now fail-closed and explicit
- disabled-state logging is clearer during backend boot
- the enablement rule is covered by unit tests so the contract is less likely to regress

## Validation
- `node --test backend/__tests__/lib/campaignWorker.test.js`
- pre-push hook ran and passed:
  - ESLint on changed files
  - frontend production build
  - backend test suite

## Notes
- pre-existing warnings from the push checks remained warnings only: unused helper warnings in `backend/lib/campaignWorker.js`, CSS syntax warnings during build, and existing chunk-size warnings
- PR opened as draft because this is a narrow hardening follow-up rather than a reviewed feature branch