### PR TITLE
[codex] align campaign worker startup with supabase config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Campaign worker startup now gates on Supabase config instead of `pgPool` (`backend/lib/campaignWorker.js`, `backend/server.js`, `backend/__tests__/lib/campaignWorker.test.js`):** Aligned backend startup with the worker’s real dependency path by requiring explicit opt-in plus `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`, distinguishing env opt-out from missing Supabase credentials in logs, and adding focused unit coverage for the startup helpers.
+
 - **Workflow send_email output preview now shows resolved payload values (`src/components/workflows/WorkflowBuilder.jsx`):** Replaced placeholder preview rows (`sent/message_id`) with runtime-like resolved preview fields for `to`, `subject`, and `body`. Added a body preview mode toggle (`Text` / `HTML`) so operators can switch between plain resolved content and rendered structured template output before execution. When `template_id` is selected, preview resolves template variables and supports `text`, `image`, `button`, and `divider` blocks.
 
 - **Workflow Builder send_email node now exposes template controls (`src/components/workflows/WorkflowBuilder.jsx`):** Added UI controls for optional structured-template selection (`template_id`) in both the top template section and directly near Subject/Body for visibility, JSON-based `template_variables` editing/apply validation, and quick variable-token chips with an insert target selector (Body, Subject, or Focused Field) so operators can configure template-backed email nodes directly in the node editor instead of hand-editing workflow JSON.

--- a/backend/__tests__/lib/campaignWorker.test.js
+++ b/backend/__tests__/lib/campaignWorker.test.js
@@ -1,9 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mock } from 'node:test';
 
 import {
+  __resetGetSupabaseClientForTest,
+  __setGetSupabaseClientForTest,
   hasCampaignWorkerSupabaseConfig,
   isCampaignWorkerEnabled,
+  startCampaignWorker,
+  stopCampaignWorker,
 } from '../../lib/campaignWorker.js';
 
 test('isCampaignWorkerEnabled returns true only for explicit true', () => {
@@ -46,4 +51,25 @@ test('campaign worker enablement helper ignores unrelated env values', () => {
     }),
     false,
   );
+});
+
+test('startCampaignWorker does not initialize Supabase when config is missing', () => {
+  const originalEnv = { ...process.env };
+  const getClientSpy = mock.fn(() => {
+    throw new Error('getSupabaseClient should not be called without config');
+  });
+
+  __setGetSupabaseClientForTest(getClientSpy);
+  process.env.CAMPAIGN_WORKER_ENABLED = 'true';
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  try {
+    assert.doesNotThrow(() => startCampaignWorker(null, 5));
+    assert.equal(getClientSpy.mock.calls.length, 0);
+  } finally {
+    stopCampaignWorker();
+    __resetGetSupabaseClientForTest();
+    process.env = originalEnv;
+  }
 });

--- a/backend/__tests__/lib/campaignWorker.test.js
+++ b/backend/__tests__/lib/campaignWorker.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hasCampaignWorkerSupabaseConfig,
+  isCampaignWorkerEnabled,
+} from '../../lib/campaignWorker.js';
+
+test('isCampaignWorkerEnabled returns true only for explicit true', () => {
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'true' }), true);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'false' }), false);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: 'TRUE' }), false);
+  assert.equal(isCampaignWorkerEnabled({ CAMPAIGN_WORKER_ENABLED: '1' }), false);
+  assert.equal(isCampaignWorkerEnabled({}), false);
+  assert.equal(isCampaignWorkerEnabled(undefined), false);
+});
+
+test('hasCampaignWorkerSupabaseConfig requires both Supabase env vars', () => {
+  assert.equal(
+    hasCampaignWorkerSupabaseConfig({
+      SUPABASE_URL: 'https://example.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    }),
+    true,
+  );
+  assert.equal(
+    hasCampaignWorkerSupabaseConfig({
+      SUPABASE_URL: 'https://example.supabase.co',
+    }),
+    false,
+  );
+  assert.equal(
+    hasCampaignWorkerSupabaseConfig({
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    }),
+    false,
+  );
+  assert.equal(hasCampaignWorkerSupabaseConfig({}), false);
+});

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -15,6 +15,7 @@ import { getSupabaseClient, query as supabaseSqlQuery } from './supabase-db.js';
 
 let workerInterval = null;
 let supabase = null;
+let getSupabaseClientImpl = getSupabaseClient;
 const webhookDb = { query: supabaseSqlQuery };
 const TARGET_BATCH_SIZE = Number(process.env.CAMPAIGN_WORKER_TARGET_BATCH_SIZE || 25);
 
@@ -25,6 +26,7 @@ export function isCampaignWorkerEnabled(env = process.env) {
 export function hasCampaignWorkerSupabaseConfig(env = process.env) {
   return Boolean(env?.SUPABASE_URL && env?.SUPABASE_SERVICE_ROLE_KEY);
 }
+
 /**
  * Initialize and start the campaign worker
  */
@@ -46,7 +48,7 @@ export function startCampaignWorker(pool, intervalMs = 30000) {
     return;
   }
 
-  supabase = getSupabaseClient();
+  supabase = getSupabaseClientImpl();
   logger.info({ intervalMs }, '[CampaignWorker] Starting');
 
   // Run immediately on start
@@ -71,6 +73,15 @@ export function stopCampaignWorker() {
     workerInterval = null;
     logger.info('[CampaignWorker] Stopped');
   }
+  supabase = null;
+}
+
+export function __setGetSupabaseClientForTest(fn) {
+  getSupabaseClientImpl = fn;
+}
+
+export function __resetGetSupabaseClientForTest() {
+  getSupabaseClientImpl = getSupabaseClient;
 }
 
 /**

--- a/backend/lib/campaignWorker.js
+++ b/backend/lib/campaignWorker.js
@@ -18,6 +18,14 @@ let supabase = null;
 const webhookDb = { query: supabaseSqlQuery };
 const TARGET_BATCH_SIZE = Number(process.env.CAMPAIGN_WORKER_TARGET_BATCH_SIZE || 25);
 
+export function isCampaignWorkerEnabled(env = process.env) {
+  return env?.CAMPAIGN_WORKER_ENABLED === 'true';
+}
+
+export function hasCampaignWorkerSupabaseConfig(env = process.env) {
+  return Boolean(env?.SUPABASE_URL && env?.SUPABASE_SERVICE_ROLE_KEY);
+}
+
 /**
  * Initialize and start the campaign worker
  */
@@ -25,14 +33,21 @@ export function startCampaignWorker(pool, intervalMs = 30000) {
   if (pool) {
     logger.debug('[CampaignWorker] Ignoring pgPool input; using Supabase client');
   }
-  supabase = getSupabaseClient();
-  const enabled = process.env.CAMPAIGN_WORKER_ENABLED !== 'false';
+  const enabled = isCampaignWorkerEnabled(process.env);
 
   if (!enabled) {
-    logger.info('[CampaignWorker] Disabled (CAMPAIGN_WORKER_ENABLED=false)');
+    logger.info('[CampaignWorker] Disabled (set CAMPAIGN_WORKER_ENABLED=true to enable)');
     return;
   }
 
+  if (!hasCampaignWorkerSupabaseConfig(process.env)) {
+    logger.warn(
+      '[CampaignWorker] Not started (missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)',
+    );
+    return;
+  }
+
+  supabase = getSupabaseClient();
   logger.info({ intervalMs }, '[CampaignWorker] Starting');
 
   // Run immediately on start

--- a/backend/server.js
+++ b/backend/server.js
@@ -942,7 +942,7 @@ server.listen(PORT, async () => {
   } else {
     const campaignInterval = parseInt(process.env.CAMPAIGN_WORKER_INTERVAL_MS || '5000', 10);
     startCampaignWorker(pgPool, campaignInterval);
-    logger.info({ intervalMs: campaignInterval }, '[CampaignWorker] Started');
+    logger.info({ intervalMs: campaignInterval }, '[CampaignWorker] Start requested');
   }
 
   // Start AI triggers worker if enabled (Phase 3 Autonomous Operations)

--- a/backend/server.js
+++ b/backend/server.js
@@ -19,7 +19,11 @@ import workflowQueue from './services/workflowQueue.js';
 import { initPlaybookQueueProcessor } from './lib/care/carePlaybookExecutor.js';
 
 // Import background workers
-import { startCampaignWorker } from './lib/campaignWorker.js';
+import {
+  hasCampaignWorkerSupabaseConfig,
+  isCampaignWorkerEnabled,
+  startCampaignWorker,
+} from './lib/campaignWorker.js';
 import { startAiTriggersWorker } from './lib/aiTriggersWorker.js';
 import { startEmailWorker } from './workers/emailWorker.js';
 import { startTaskWorkers } from './workers/taskWorkers.js';
@@ -931,10 +935,14 @@ server.listen(PORT, async () => {
   }, 1000); // Delay 1 second to ensure server is fully started
 
   // Start campaign worker if enabled
-  if (process.env.CAMPAIGN_WORKER_ENABLED === 'true' && pgPool) {
+  if (!isCampaignWorkerEnabled(process.env)) {
+    logger.debug('[CampaignWorker] Disabled (set CAMPAIGN_WORKER_ENABLED=true to enable)');
+  } else if (!hasCampaignWorkerSupabaseConfig(process.env)) {
+    logger.warn('[CampaignWorker] Not started (missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY)');
+  } else {
     const campaignInterval = parseInt(process.env.CAMPAIGN_WORKER_INTERVAL_MS || '5000', 10);
     startCampaignWorker(pgPool, campaignInterval);
-    logger.info('[CampaignWorker] Started');
+    logger.info({ intervalMs: campaignInterval }, '[CampaignWorker] Started');
   }
 
   // Start AI triggers worker if enabled (Phase 3 Autonomous Operations)


### PR DESCRIPTION
## Summary
- align campaign worker startup gating with the worker's actual Supabase dependency path
- distinguish env opt-out from missing Supabase credentials in backend startup logs
- add focused unit coverage for campaign worker startup helpers and update the changelog

## Why
A follow-up review on PR #513 correctly pointed out that the startup log path in `backend/server.js` was misleading. The branch treated `pgPool` as part of the worker-start decision, even though `backend/lib/campaignWorker.js` already uses `getSupabaseClient()` and only logs that it ignores the passed pool. This patch makes the startup contract consistent with the implementation.

## Impact
- campaign worker startup now depends on explicit opt-in plus `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`
- startup logs now distinguish:
  - env opt-out
  - missing Supabase configuration
  - successful worker start
- worker startup semantics are now covered by focused unit tests

## Validation
- `node --test backend/__tests__/lib/campaignWorker.test.js`
- pre-push hook ran and passed:
  - ESLint on changed files
  - frontend production build
  - backend test suite

## Notes
- push checks surfaced existing warning-level output only: unused helper warnings in `backend/lib/campaignWorker.js`, CSS syntax warnings during build, and existing chunk-size warnings
- PR opened as draft because this is a small post-merge correctness follow-up