### PR TITLE
feat: Platform Billing Foundation (Phase 1)

### DIFF
--- a/backend/__tests__/billing/_billingMock.js
+++ b/backend/__tests__/billing/_billingMock.js
@@ -1,0 +1,250 @@
+/**
+ * Shared supabase mock for billing service unit tests.
+ *
+ * Simulates a single-table in-memory store with just enough of the
+ * Supabase JS query builder surface to exercise billing services.
+ *
+ * Supported chain shapes:
+ *   from(t).select(...).eq(col, v).[maybe]Single()
+ *   from(t).select(...).eq(col, v).neq(col, v).order(...).limit(n).maybeSingle()
+ *   from(t).select(..., {count:'exact', head:true}).eq(col,v).gte(col,v)
+ *   from(t).insert(row).select('*').single()
+ *   from(t).update(row).eq(col,v).select('*').single()
+ *   from(t).update(row).eq(col,v).in(col,[...])
+ *   from(t).delete().eq(col,v)
+ *
+ * Not intended to be a general-purpose mock -- only what billing code calls.
+ */
+
+export function createBillingMock(initial = {}) {
+  // Shallow-clone tables so tests can't bleed state
+  const db = {};
+  for (const [k, v] of Object.entries(initial)) {
+    db[k] = Array.isArray(v) ? v.map((r) => ({ ...r })) : [];
+  }
+  const ensure = (t) => {
+    if (!db[t]) db[t] = [];
+    return db[t];
+  };
+
+  function applyFilters(rows, filters) {
+    return rows.filter((r) => {
+      for (const f of filters) {
+        if (f.op === 'eq' && r[f.col] !== f.val) return false;
+        if (f.op === 'neq' && r[f.col] === f.val) return false;
+        if (f.op === 'in' && !f.val.includes(r[f.col])) return false;
+        if (f.op === 'gte' && !(r[f.col] >= f.val)) return false;
+        if (f.op === 'lte' && !(r[f.col] <= f.val)) return false;
+        if (f.op === 'gt' && !(r[f.col] > f.val)) return false;
+      }
+      return true;
+    });
+  }
+
+  function genId() {
+    return 'mock-' + Math.random().toString(36).slice(2, 10);
+  }
+
+  function makeSelectChain(table, { headCount = false } = {}) {
+    const filters = [];
+    let orderBy = null;
+    let orderDir = 'asc';
+    let limit = null;
+
+    const thenable = {
+      eq(col, val) {
+        filters.push({ op: 'eq', col, val });
+        return thenable;
+      },
+      neq(col, val) {
+        filters.push({ op: 'neq', col, val });
+        return thenable;
+      },
+      in(col, val) {
+        filters.push({ op: 'in', col, val });
+        return thenable;
+      },
+      gte(col, val) {
+        filters.push({ op: 'gte', col, val });
+        return thenable;
+      },
+      lte(col, val) {
+        filters.push({ op: 'lte', col, val });
+        return thenable;
+      },
+      gt(col, val) {
+        filters.push({ op: 'gt', col, val });
+        return thenable;
+      },
+      order(col, opts = {}) {
+        orderBy = col;
+        orderDir = opts.ascending === false ? 'desc' : 'asc';
+        return thenable;
+      },
+      limit(n) {
+        limit = n;
+        return thenable;
+      },
+      async single() {
+        let rows = applyFilters(ensure(table), filters);
+        if (rows.length === 0) return { data: null, error: { message: 'no rows' } };
+        if (rows.length > 1) return { data: null, error: { message: 'multiple rows' } };
+        return { data: { ...rows[0] }, error: null };
+      },
+      async maybeSingle() {
+        let rows = applyFilters(ensure(table), filters);
+        if (orderBy) {
+          rows = [...rows].sort((a, b) => (a[orderBy] > b[orderBy] ? 1 : -1));
+          if (orderDir === 'desc') rows.reverse();
+        }
+        if (limit) rows = rows.slice(0, limit);
+        return { data: rows[0] ? { ...rows[0] } : null, error: null };
+      },
+      async then(resolve) {
+        let rows = applyFilters(ensure(table), filters);
+        if (headCount) {
+          return resolve({ count: rows.length, error: null });
+        }
+        if (orderBy) {
+          rows = [...rows].sort((a, b) => (a[orderBy] > b[orderBy] ? 1 : -1));
+          if (orderDir === 'desc') rows.reverse();
+        }
+        if (limit) rows = rows.slice(0, limit);
+        return resolve({ data: rows.map((r) => ({ ...r })), error: null });
+      },
+    };
+    return thenable;
+  }
+
+  const client = {
+    db,
+    from(table) {
+      return {
+        select(_cols, opts = {}) {
+          return makeSelectChain(table, { headCount: !!opts.head });
+        },
+        insert(rowOrRows) {
+          const rows = Array.isArray(rowOrRows) ? rowOrRows : [rowOrRows];
+          // Enforce simple uniqueness rules that the billing code depends on
+          if (table === 'billing_accounts') {
+            for (const r of rows) {
+              if (ensure(table).some((x) => x.tenant_id === r.tenant_id)) {
+                return {
+                  select: () => ({
+                    single: async () => ({
+                      data: null,
+                      error: { code: '23505', message: 'duplicate key' },
+                    }),
+                  }),
+                };
+              }
+            }
+          }
+          if (table === 'payments') {
+            for (const r of rows) {
+              if (
+                r.provider_payment_intent_id &&
+                ensure(table).some(
+                  (x) => x.provider_payment_intent_id === r.provider_payment_intent_id,
+                )
+              ) {
+                return {
+                  select: () => ({
+                    single: async () => ({
+                      data: null,
+                      error: { code: '23505', message: 'duplicate payment_intent' },
+                    }),
+                  }),
+                };
+              }
+            }
+          }
+          const stamped = rows.map((r) => ({
+            id: r.id || genId(),
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            amount_paid_cents: 0,
+            ...r,
+          }));
+          ensure(table).push(...stamped);
+          return {
+            select: () => ({
+              single: async () => ({ data: { ...stamped[0] }, error: null }),
+              then: (resolve) => resolve({ data: stamped.map((r) => ({ ...r })), error: null }),
+            }),
+          };
+        },
+
+        update(patch) {
+          const filters = [];
+          const chain = {
+            eq(col, val) {
+              filters.push({ op: 'eq', col, val });
+              return chain;
+            },
+            neq(col, val) {
+              filters.push({ op: 'neq', col, val });
+              return chain;
+            },
+            in(col, val) {
+              filters.push({ op: 'in', col, val });
+              return chain;
+            },
+            select: () => ({
+              single: async () => {
+                const rows = applyFilters(ensure(table), filters);
+                if (rows.length === 0) return { data: null, error: { message: 'no rows' } };
+                Object.assign(rows[0], patch, { updated_at: new Date().toISOString() });
+                return { data: { ...rows[0] }, error: null };
+              },
+              then: (resolve) => {
+                const rows = applyFilters(ensure(table), filters);
+                rows.forEach((r) =>
+                  Object.assign(r, patch, { updated_at: new Date().toISOString() }),
+                );
+                resolve({ data: rows.map((r) => ({ ...r })), error: null });
+              },
+            }),
+            then(resolve) {
+              const rows = applyFilters(ensure(table), filters);
+              rows.forEach((r) =>
+                Object.assign(r, patch, { updated_at: new Date().toISOString() }),
+              );
+              resolve({ data: null, error: null });
+            },
+          };
+          return chain;
+        },
+        delete() {
+          const filters = [];
+          const chain = {
+            eq(col, val) {
+              filters.push({ op: 'eq', col, val });
+              return chain;
+            },
+            neq(col, val) {
+              filters.push({ op: 'neq', col, val });
+              return chain;
+            },
+            in(col, val) {
+              filters.push({ op: 'in', col, val });
+              return chain;
+            },
+            is(col, val) {
+              filters.push({ op: 'eq', col, val });
+              return chain;
+            },
+            then(resolve) {
+              const arr = ensure(table);
+              const remaining = arr.filter((r) => !applyFilters([r], filters).length);
+              db[table] = remaining;
+              resolve({ data: null, error: null });
+            },
+          };
+          return chain;
+        },
+      };
+    },
+  };
+  return client;
+}

--- a/backend/__tests__/billing/_billingMock.js
+++ b/backend/__tests__/billing/_billingMock.js
@@ -159,13 +159,20 @@ export function createBillingMock(initial = {}) {
               }
             }
           }
-          const stamped = rows.map((r) => ({
-            id: r.id || genId(),
-            created_at: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            amount_paid_cents: 0,
-            ...r,
-          }));
+          const stamped = rows.map((r) => {
+            // Apply schema defaults per table
+            const defaults = {
+              id: genId(),
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              amount_paid_cents: 0,
+            };
+            if (table === 'billing_accounts') {
+              defaults.billing_exempt = false;
+              defaults.currency = 'usd';
+            }
+            return { ...defaults, ...r };
+          });
           ensure(table).push(...stamped);
           return {
             select: () => ({

--- a/backend/__tests__/billing/billingAccountService.test.js
+++ b/backend/__tests__/billing/billingAccountService.test.js
@@ -30,7 +30,7 @@ describe('billingAccountService -- getOrCreateBillingAccount', () => {
     const account = await getOrCreateBillingAccount(mock, TENANT);
 
     assert.equal(account.tenant_id, TENANT);
-    assert.equal(account.billing_exempt, undefined); // not set until exempt=true
+    assert.equal(account.billing_exempt, false); // schema default on create
     assert.equal(mock.db.billing_accounts.length, 1);
   });
 

--- a/backend/__tests__/billing/billingAccountService.test.js
+++ b/backend/__tests__/billing/billingAccountService.test.js
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for backend/lib/billing/billingAccountService.js
+ *
+ * Exercises exemption policy, audit trail, and field filtering using
+ * the in-memory billing mock (_billingMock.js).
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBillingMock } from './_billingMock.js';
+import {
+  getOrCreateBillingAccount,
+  updateBillingProfile,
+  setExemption,
+  removeExemption,
+} from '../../lib/billing/billingAccountService.js';
+
+const TENANT = 'tenant-aaa';
+const ACTOR = 'user-admin-1';
+
+function seedTenant(mock, overrides = {}) {
+  mock.db.tenant = [{ id: TENANT, billing_state: 'active', ...overrides }];
+}
+
+describe('billingAccountService -- getOrCreateBillingAccount', () => {
+  it('creates an empty account on first access', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+
+    const account = await getOrCreateBillingAccount(mock, TENANT);
+
+    assert.equal(account.tenant_id, TENANT);
+    assert.equal(account.billing_exempt, undefined); // not set until exempt=true
+    assert.equal(mock.db.billing_accounts.length, 1);
+  });
+
+  it('returns existing account without duplicating', async () => {
+    const mock = createBillingMock({
+      billing_accounts: [{ id: 'ba1', tenant_id: TENANT, billing_email: 'a@b.c' }],
+      billing_events: [],
+      tenant: [],
+    });
+    seedTenant(mock);
+
+    const account = await getOrCreateBillingAccount(mock, TENANT);
+    assert.equal(account.id, 'ba1');
+    assert.equal(account.billing_email, 'a@b.c');
+    assert.equal(mock.db.billing_accounts.length, 1);
+  });
+
+  it('throws when tenantId is missing', async () => {
+    const mock = createBillingMock();
+    await assert.rejects(() => getOrCreateBillingAccount(mock, null), /tenantId required/);
+  });
+});
+
+describe('billingAccountService -- updateBillingProfile', () => {
+  it('updates allowed fields', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+
+    const updated = await updateBillingProfile(mock, TENANT, {
+      billing_email: 'finance@acme.com',
+      company_name: 'Acme Inc',
+      tax_id: 'EIN-123',
+    });
+
+    assert.equal(updated.billing_email, 'finance@acme.com');
+    assert.equal(updated.company_name, 'Acme Inc');
+    assert.equal(updated.tax_id, 'EIN-123');
+  });
+
+  it('silently filters out non-allowed fields', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+
+    const updated = await updateBillingProfile(mock, TENANT, {
+      billing_email: 'f@acme.com',
+      injected_field: 'should_be_dropped',
+    });
+
+    assert.equal(updated.billing_email, 'f@acme.com');
+    assert.equal(updated.injected_field, undefined);
+  });
+
+  it('REJECTS attempts to modify billing_exempt via updateBillingProfile', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+
+    await assert.rejects(
+      () => updateBillingProfile(mock, TENANT, { billing_exempt: true }),
+      /setExemption\(\) to modify/,
+    );
+  });
+
+  it('REJECTS attempts to modify exempt_reason / exempt_set_by / exempt_set_at', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+    for (const f of ['exempt_reason', 'exempt_set_by', 'exempt_set_at']) {
+      await assert.rejects(
+        () => updateBillingProfile(mock, TENANT, { [f]: 'anything' }),
+        /setExemption\(\) to modify/,
+        `${f} should be blocked from updateBillingProfile`,
+      );
+    }
+  });
+
+  it('throws when no updatable fields are provided', async () => {
+    const mock = createBillingMock({ billing_accounts: [], tenant: [] });
+    seedTenant(mock);
+    await assert.rejects(() => updateBillingProfile(mock, TENANT, {}), /no updatable fields/);
+  });
+});
+
+describe('billingAccountService -- setExemption', () => {
+  it('sets billing_exempt=true with audit trail and writes billing_event', async () => {
+    const mock = createBillingMock({
+      billing_accounts: [],
+      billing_events: [],
+      tenant_subscriptions: [],
+      tenant: [],
+    });
+    seedTenant(mock);
+
+    const { account, stateChange } = await setExemption(mock, {
+      tenant_id: TENANT,
+      reason: 'Strategic partner, indefinite comp',
+      actor_id: ACTOR,
+    });
+
+    assert.equal(account.billing_exempt, true);
+    assert.equal(account.exempt_reason, 'Strategic partner, indefinite comp');
+    assert.equal(account.exempt_set_by, ACTOR);
+    assert.ok(account.exempt_set_at, 'exempt_set_at must be populated');
+
+    // Event logged
+    assert.equal(mock.db.billing_events.length, 1);
+    assert.equal(mock.db.billing_events[0].event_type, 'tenant.billing_exempt_set');
+    assert.equal(mock.db.billing_events[0].source, 'admin');
+    assert.equal(mock.db.billing_events[0].actor_id, ACTOR);
+
+    // Tenant state synced to billing_exempt
+    assert.equal(stateChange.to, 'billing_exempt');
+    assert.equal(mock.db.tenant[0].billing_state, 'billing_exempt');
+  });
+
+  it('rejects missing reason', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+    await assert.rejects(
+      () => setExemption(mock, { tenant_id: TENANT, actor_id: ACTOR }),
+      /reason required/,
+    );
+  });
+
+  it('rejects whitespace-only reason', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+    await assert.rejects(
+      () => setExemption(mock, { tenant_id: TENANT, actor_id: ACTOR, reason: '   ' }),
+      /reason required/,
+    );
+  });
+
+  it('rejects missing actor_id', async () => {
+    const mock = createBillingMock({ billing_accounts: [], billing_events: [], tenant: [] });
+    seedTenant(mock);
+    await assert.rejects(
+      () => setExemption(mock, { tenant_id: TENANT, reason: 'r' }),
+      /actor_id required/,
+    );
+  });
+});
+
+describe('billingAccountService -- removeExemption', () => {
+  it('clears exemption and logs event', async () => {
+    const mock = createBillingMock({
+      billing_accounts: [
+        {
+          id: 'ba1',
+          tenant_id: TENANT,
+          billing_exempt: true,
+          exempt_reason: 'was comp',
+          exempt_set_by: 'user-prev',
+          exempt_set_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+      billing_events: [],
+      tenant_subscriptions: [],
+      tenant: [],
+    });
+    seedTenant(mock, { billing_state: 'billing_exempt' });
+
+    const { account, stateChange } = await removeExemption(mock, {
+      tenant_id: TENANT,
+      actor_id: ACTOR,
+    });
+
+    assert.equal(account.billing_exempt, false);
+    assert.equal(account.exempt_reason, null);
+    assert.equal(account.exempt_set_by, null);
+    assert.equal(account.exempt_set_at, null);
+
+    assert.equal(mock.db.billing_events.length, 1);
+    const event = mock.db.billing_events[0];
+    assert.equal(event.event_type, 'tenant.billing_exempt_removed');
+    assert.equal(event.actor_id, ACTOR);
+    assert.equal(event.payload_json.previous_reason, 'was comp');
+
+    // Without an active subscription, state falls back to active
+    assert.equal(stateChange.to, 'active');
+  });
+
+  it('rejects when tenant is not currently exempt', async () => {
+    const mock = createBillingMock({
+      billing_accounts: [{ id: 'ba1', tenant_id: TENANT, billing_exempt: false }],
+      billing_events: [],
+      tenant: [],
+    });
+    seedTenant(mock);
+    await assert.rejects(
+      () => removeExemption(mock, { tenant_id: TENANT, actor_id: ACTOR }),
+      /not currently exempt/,
+    );
+  });
+
+  it('rejects missing actor_id', async () => {
+    const mock = createBillingMock({
+      billing_accounts: [{ id: 'ba1', tenant_id: TENANT, billing_exempt: true }],
+      billing_events: [],
+      tenant: [],
+    });
+    seedTenant(mock);
+    await assert.rejects(() => removeExemption(mock, { tenant_id: TENANT }), /actor_id required/);
+  });
+});

--- a/backend/__tests__/billing/billingEventLogger.test.js
+++ b/backend/__tests__/billing/billingEventLogger.test.js
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for backend/lib/billing/billingEventLogger.js
+ *
+ * Covers input validation. The actual DB insert is mocked with a minimal
+ * supabase stub that records the call and returns a synthetic row.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  BILLING_EVENTS,
+  VALID_EVENT_TYPES,
+  VALID_SOURCES,
+  logBillingEvent,
+} from '../../lib/billing/billingEventLogger.js';
+
+// ─── Minimal mock supabase for insert().select().single() chain ─────────────
+
+function mockSupabase({ insertResult = null, insertError = null } = {}) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      return {
+        insert(row) {
+          calls.push({ op: 'insert', table, row });
+          return {
+            select() {
+              return {
+                single: async () => ({
+                  data: insertResult || { id: 'evt-1', ...row },
+                  error: insertError,
+                }),
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+describe('billingEventLogger -- BILLING_EVENTS constants', () => {
+  it('exports all 18 canonical event types', () => {
+    // 5 invoice + 3 payment + 3 subscription + 5 tenant + 2 plan = 18
+    assert.equal(VALID_EVENT_TYPES.size, 18);
+  });
+
+  it('all event types are dotted namespace.action form', () => {
+    for (const t of VALID_EVENT_TYPES) {
+      assert.match(t, /^[a-z_]+\.[a-z_]+$/, `bad format: ${t}`);
+    }
+  });
+
+  it('BILLING_EVENTS is frozen', () => {
+    assert.throws(() => {
+      BILLING_EVENTS.NEW_EVENT = 'foo.bar';
+    }, /read only|Cannot (add|assign)/);
+  });
+
+  it('VALID_SOURCES is the 4 canonical sources', () => {
+    assert.deepEqual([...VALID_SOURCES].sort(), ['admin', 'api', 'system', 'webhook']);
+  });
+});
+
+describe('billingEventLogger -- logBillingEvent validation', () => {
+  const sb = mockSupabase();
+
+  it('rejects missing event_type', async () => {
+    await assert.rejects(
+      () => logBillingEvent(sb, { tenant_id: 't1', source: 'system' }),
+      /event_type is required/,
+    );
+  });
+
+  it('rejects unknown event_type', async () => {
+    await assert.rejects(
+      () =>
+        logBillingEvent(sb, {
+          tenant_id: 't1',
+          event_type: 'invoice.totally_made_up',
+          source: 'system',
+        }),
+      /unknown event_type/,
+    );
+  });
+
+  it('rejects invalid source', async () => {
+    await assert.rejects(
+      () =>
+        logBillingEvent(sb, {
+          tenant_id: 't1',
+          event_type: BILLING_EVENTS.INVOICE_CREATED,
+          source: 'alien',
+        }),
+      /source must be one of/,
+    );
+  });
+});
+
+describe('billingEventLogger -- actor requirement', () => {
+  it('source=admin requires actor_id', async () => {
+    const sb = mockSupabase();
+    await assert.rejects(
+      () =>
+        logBillingEvent(sb, {
+          tenant_id: 't1',
+          event_type: BILLING_EVENTS.TENANT_BILLING_EXEMPT_SET,
+          source: 'admin',
+        }),
+      /actor_id required/,
+    );
+  });
+
+  it('source=api requires actor_id', async () => {
+    const sb = mockSupabase();
+    await assert.rejects(
+      () =>
+        logBillingEvent(sb, {
+          tenant_id: 't1',
+          event_type: BILLING_EVENTS.PLAN_ASSIGNED,
+          source: 'api',
+        }),
+      /actor_id required/,
+    );
+  });
+
+  it('source=system allows no actor_id', async () => {
+    const sb = mockSupabase();
+    const result = await logBillingEvent(sb, {
+      tenant_id: 't1',
+      event_type: BILLING_EVENTS.INVOICE_CREATED,
+      source: 'system',
+    });
+    assert.ok(result, 'should insert successfully');
+    assert.equal(sb.calls.length, 1);
+    assert.equal(sb.calls[0].row.actor_id, null);
+  });
+
+  it('source=webhook allows no actor_id', async () => {
+    const sb = mockSupabase();
+    await logBillingEvent(sb, {
+      tenant_id: 't1',
+      event_type: BILLING_EVENTS.PAYMENT_RECEIVED,
+      source: 'webhook',
+    });
+    assert.equal(sb.calls[0].row.actor_id, null);
+  });
+});
+
+describe('billingEventLogger -- payload and normalization', () => {
+  it('passes tenant_id, event_type, source through', async () => {
+    const sb = mockSupabase();
+    await logBillingEvent(sb, {
+      tenant_id: 't-abc',
+      event_type: BILLING_EVENTS.INVOICE_PAID,
+      source: 'webhook',
+      payload: { invoice_id: 'inv-1' },
+    });
+    const row = sb.calls[0].row;
+    assert.equal(row.tenant_id, 't-abc');
+    assert.equal(row.event_type, 'invoice.paid');
+    assert.equal(row.source, 'webhook');
+    assert.deepEqual(row.payload_json, { invoice_id: 'inv-1' });
+  });
+
+  it('defaults missing payload to empty object', async () => {
+    const sb = mockSupabase();
+    await logBillingEvent(sb, {
+      tenant_id: 't1',
+      event_type: BILLING_EVENTS.INVOICE_VOIDED,
+      source: 'admin',
+      actor_id: 'u1',
+    });
+    assert.deepEqual(sb.calls[0].row.payload_json, {});
+  });
+
+  it('accepts null tenant_id (platform-wide event)', async () => {
+    const sb = mockSupabase();
+    await logBillingEvent(sb, {
+      tenant_id: null,
+      event_type: BILLING_EVENTS.PLAN_CHANGED,
+      source: 'system',
+    });
+    assert.equal(sb.calls[0].row.tenant_id, null);
+  });
+
+  it('surfaces DB insert errors', async () => {
+    const sb = mockSupabase({ insertError: { message: 'constraint violation' } });
+    await assert.rejects(
+      () =>
+        logBillingEvent(sb, {
+          tenant_id: 't1',
+          event_type: BILLING_EVENTS.INVOICE_CREATED,
+          source: 'system',
+        }),
+      /constraint violation/,
+    );
+  });
+});

--- a/backend/__tests__/billing/billingStateMachine.test.js
+++ b/backend/__tests__/billing/billingStateMachine.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for backend/lib/billing/billingStateMachine.js
+ *
+ * Pure-logic tests for computeBillingState() and canAutoTransition().
+ * No DB access. The DB-touching syncTenantBillingState() is exercised
+ * by the billing-schema-alignment integration test.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  BILLING_STATES,
+  VALID_STATES,
+  canAutoTransition,
+  computeBillingState,
+} from '../../lib/billing/billingStateMachine.js';
+
+describe('billingStateMachine -- VALID_STATES', () => {
+  it('contains all 6 canonical states', () => {
+    assert.equal(VALID_STATES.size, 6);
+    for (const s of [
+      'active',
+      'past_due',
+      'grace_period',
+      'suspended',
+      'billing_exempt',
+      'canceled',
+    ]) {
+      assert.ok(VALID_STATES.has(s), `missing state: ${s}`);
+    }
+  });
+});
+
+describe('billingStateMachine -- computeBillingState', () => {
+  it('exempt flag trumps everything, including suspended subscription', () => {
+    const state = computeBillingState({
+      billingAccount: { billing_exempt: true },
+      subscription: { status: 'suspended' },
+    });
+    assert.equal(state, BILLING_STATES.BILLING_EXEMPT);
+  });
+
+  it('no subscription + no account = active (default for fresh tenant)', () => {
+    const state = computeBillingState({ billingAccount: null, subscription: null });
+    assert.equal(state, BILLING_STATES.ACTIVE);
+  });
+
+  it('canceled subscription = canceled', () => {
+    const state = computeBillingState({
+      billingAccount: { billing_exempt: false },
+      subscription: { status: 'canceled' },
+    });
+    assert.equal(state, BILLING_STATES.CANCELED);
+  });
+
+  it('draft subscription = active (tenant has plan assigned but not started)', () => {
+    const state = computeBillingState({
+      billingAccount: null,
+      subscription: { status: 'draft' },
+    });
+    assert.equal(state, BILLING_STATES.ACTIVE);
+  });
+
+  it('subscription.status passes through for all valid states', () => {
+    for (const s of ['active', 'past_due', 'grace_period', 'suspended']) {
+      const state = computeBillingState({
+        billingAccount: { billing_exempt: false },
+        subscription: { status: s },
+      });
+      assert.equal(state, s, `expected ${s} to pass through`);
+    }
+  });
+
+  it('unknown subscription status falls back to active (defensive default)', () => {
+    const state = computeBillingState({
+      billingAccount: null,
+      subscription: { status: 'some_future_state' },
+    });
+    assert.equal(state, BILLING_STATES.ACTIVE);
+  });
+
+  it('exempt=false with no subscription = active', () => {
+    const state = computeBillingState({
+      billingAccount: { billing_exempt: false },
+      subscription: null,
+    });
+    assert.equal(state, BILLING_STATES.ACTIVE);
+  });
+});
+
+describe('billingStateMachine -- canAutoTransition', () => {
+  it('allows self-transitions (idempotent sync)', () => {
+    for (const s of VALID_STATES) {
+      assert.equal(canAutoTransition(s, s), true, `self-transition ${s}->${s} should be allowed`);
+    }
+  });
+
+  it('allows active -> past_due', () => {
+    assert.equal(canAutoTransition('active', 'past_due'), true);
+  });
+
+  it('allows past_due -> grace_period -> suspended progression', () => {
+    assert.equal(canAutoTransition('past_due', 'grace_period'), true);
+    assert.equal(canAutoTransition('grace_period', 'suspended'), true);
+  });
+
+  it('allows recovery paths: past_due -> active, grace_period -> active, suspended -> active', () => {
+    assert.equal(canAutoTransition('past_due', 'active'), true);
+    assert.equal(canAutoTransition('grace_period', 'active'), true);
+    assert.equal(canAutoTransition('suspended', 'active'), true);
+  });
+
+  it('allows any non-exempt state to be canceled', () => {
+    for (const s of ['active', 'past_due', 'grace_period', 'suspended']) {
+      assert.equal(canAutoTransition(s, 'canceled'), true, `${s} -> canceled should be allowed`);
+    }
+  });
+
+  it('blocks auto-transitions INTO billing_exempt (admin-only)', () => {
+    for (const s of ['active', 'past_due', 'grace_period', 'suspended', 'canceled']) {
+      assert.equal(
+        canAutoTransition(s, 'billing_exempt'),
+        false,
+        `${s} -> billing_exempt must NOT be auto-allowed`,
+      );
+    }
+  });
+
+  it('blocks auto-transitions OUT of billing_exempt (admin-only)', () => {
+    for (const s of VALID_STATES) {
+      if (s === 'billing_exempt') continue;
+      assert.equal(
+        canAutoTransition('billing_exempt', s),
+        false,
+        `billing_exempt -> ${s} must NOT be auto-allowed`,
+      );
+    }
+  });
+
+  it('blocks auto-transitions out of canceled (terminal)', () => {
+    for (const s of VALID_STATES) {
+      if (s === 'canceled') continue;
+      assert.equal(
+        canAutoTransition('canceled', s),
+        false,
+        `canceled -> ${s} must NOT be auto-allowed`,
+      );
+    }
+  });
+
+  it('rejects invalid state names', () => {
+    assert.equal(canAutoTransition('bogus', 'active'), false);
+    assert.equal(canAutoTransition('active', 'bogus'), false);
+    assert.equal(canAutoTransition(null, 'active'), false);
+  });
+
+  it('blocks skipping grace_period (active -> suspended not allowed)', () => {
+    assert.equal(canAutoTransition('active', 'suspended'), false);
+    assert.equal(canAutoTransition('active', 'grace_period'), false);
+  });
+});

--- a/backend/__tests__/billing/invoiceService.test.js
+++ b/backend/__tests__/billing/invoiceService.test.js
@@ -1,0 +1,358 @@
+/**
+ * Unit tests for backend/lib/billing/invoiceService.js
+ *
+ * Covers:
+ *   - Exemption guard on createInvoice
+ *   - Line item sum + balance math
+ *   - Invoice number generation format
+ *   - recordPayment idempotency on provider_payment_intent_id
+ *   - voidInvoice rules (cannot void paid; idempotent on void->void)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBillingMock } from './_billingMock.js';
+import {
+  generateInvoiceNumber,
+  createInvoice,
+  issueInvoice,
+  recordPayment,
+  voidInvoice,
+} from '../../lib/billing/invoiceService.js';
+
+const TENANT = 'tenant-bbb';
+const ACTOR = 'user-admin-2';
+
+function fresh() {
+  return createBillingMock({
+    billing_accounts: [],
+    invoices: [],
+    invoice_line_items: [],
+    payments: [],
+    billing_events: [],
+    tenant: [{ id: TENANT, billing_state: 'active' }],
+    tenant_subscriptions: [],
+  });
+}
+
+describe('invoiceService -- generateInvoiceNumber', () => {
+  it('produces INV-<YYYY>-000001 for the first invoice of the year', async () => {
+    const mock = fresh();
+    const n = await generateInvoiceNumber(mock, TENANT);
+    const year = new Date().getUTCFullYear();
+    assert.equal(n, `INV-${year}-000001`);
+  });
+
+  it('increments sequence per tenant', async () => {
+    const mock = fresh();
+    const year = new Date().getUTCFullYear();
+    mock.db.invoices = [
+      {
+        id: '1',
+        tenant_id: TENANT,
+        created_at: `${year}-01-05T00:00:00Z`,
+        invoice_number: `INV-${year}-000001`,
+      },
+      {
+        id: '2',
+        tenant_id: TENANT,
+        created_at: `${year}-02-10T00:00:00Z`,
+        invoice_number: `INV-${year}-000002`,
+      },
+    ];
+    const n = await generateInvoiceNumber(mock, TENANT);
+    assert.equal(n, `INV-${year}-000003`);
+  });
+
+  it('throws without tenantId', async () => {
+    const mock = fresh();
+    await assert.rejects(() => generateInvoiceNumber(mock, null), /tenantId required/);
+  });
+});
+
+describe('invoiceService -- createInvoice exemption guard', () => {
+  it('REFUSES to create invoice when tenant is billing_exempt', async () => {
+    const mock = fresh();
+    mock.db.billing_accounts = [
+      {
+        id: 'ba',
+        tenant_id: TENANT,
+        billing_exempt: true,
+        exempt_reason: 'comp',
+        exempt_set_by: ACTOR,
+        exempt_set_at: new Date().toISOString(),
+      },
+    ];
+
+    await assert.rejects(
+      () =>
+        createInvoice(mock, {
+          tenant_id: TENANT,
+          line_items: [
+            {
+              item_type: 'subscription',
+              description: 'Starter',
+              quantity: 1,
+              unit_price_cents: 4900,
+            },
+          ],
+        }),
+      /billing-exempt/,
+    );
+    assert.equal(mock.db.invoices.length, 0, 'no invoice should be created');
+  });
+
+  it('allows creation when exempt=false', async () => {
+    const mock = fresh();
+    mock.db.billing_accounts = [{ id: 'ba', tenant_id: TENANT, billing_exempt: false }];
+
+    const { invoice, line_items } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'Starter', quantity: 1, unit_price_cents: 4900 },
+      ],
+    });
+
+    assert.equal(invoice.status, 'draft');
+    assert.equal(invoice.total_cents, 4900);
+    assert.equal(line_items.length, 1);
+  });
+
+  it('allows creation when no billing_account exists (new tenant)', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    assert.ok(invoice);
+  });
+});
+
+describe('invoiceService -- balance math', () => {
+  it('subtotal = sum of amount_cents; total = subtotal + tax', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      tax_total_cents: 500,
+      line_items: [
+        { item_type: 'subscription', description: 'Base', quantity: 1, unit_price_cents: 4900 },
+        { item_type: 'setup_fee', description: 'Onboarding', quantity: 1, unit_price_cents: 10000 },
+      ],
+    });
+    assert.equal(invoice.subtotal_cents, 14900);
+    assert.equal(invoice.tax_total_cents, 500);
+    assert.equal(invoice.total_cents, 15400);
+    assert.equal(invoice.balance_due_cents, 15400);
+  });
+
+  it('logs INVOICE_CREATED event', async () => {
+    const mock = fresh();
+    await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    const event = mock.db.billing_events.find((e) => e.event_type === 'invoice.created');
+    assert.ok(event, 'invoice.created event must be logged');
+    assert.equal(event.source, 'system');
+  });
+
+  it('rejects empty line_items', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => createInvoice(mock, { tenant_id: TENANT, line_items: [] }),
+      /at least one line_item/,
+    );
+  });
+});
+
+describe('invoiceService -- recordPayment', () => {
+  async function seedInvoice(mock, total = 10000) {
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: total },
+      ],
+    });
+    await issueInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+    return invoice;
+  }
+
+  it('full payment sets status=paid, balance_due=0, logs PAYMENT_RECEIVED + INVOICE_PAID', async () => {
+    const mock = fresh();
+    const invoice = await seedInvoice(mock, 10000);
+
+    const {
+      payment,
+      invoice: updated,
+      idempotent,
+    } = await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 10000,
+      provider_payment_intent_id: 'pi_abc',
+      source: 'webhook',
+    });
+
+    assert.equal(idempotent, false);
+    assert.equal(payment.amount_cents, 10000);
+    assert.equal(updated.status, 'paid');
+    assert.equal(updated.amount_paid_cents, 10000);
+    assert.equal(updated.balance_due_cents, 0);
+
+    const types = mock.db.billing_events.map((e) => e.event_type);
+    assert.ok(types.includes('payment.received'));
+    assert.ok(types.includes('invoice.paid'));
+  });
+
+  it('partial payment keeps invoice status=open, tracks balance', async () => {
+    const mock = fresh();
+    const invoice = await seedInvoice(mock, 10000);
+
+    const { invoice: updated } = await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 3000,
+      provider_payment_intent_id: 'pi_partial',
+      source: 'webhook',
+    });
+
+    assert.equal(updated.status, 'open');
+    assert.equal(updated.amount_paid_cents, 3000);
+    assert.equal(updated.balance_due_cents, 7000);
+
+    const types = mock.db.billing_events.map((e) => e.event_type);
+    assert.ok(types.includes('payment.received'));
+    assert.ok(!types.includes('invoice.paid'), 'invoice.paid should NOT fire on partial');
+  });
+});
+
+describe('invoiceService -- recordPayment idempotency', () => {
+  it('returns existing payment when provider_payment_intent_id already recorded', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 5000 },
+      ],
+    });
+    await issueInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+
+    const first = await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 5000,
+      provider_payment_intent_id: 'pi_dup_check',
+      source: 'webhook',
+    });
+    assert.equal(first.idempotent, false);
+
+    const second = await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 5000,
+      provider_payment_intent_id: 'pi_dup_check',
+      source: 'webhook',
+    });
+    assert.equal(second.idempotent, true);
+    assert.equal(second.payment.id, first.payment.id);
+
+    // Exactly one payment row, exactly one invoice.paid event
+    assert.equal(mock.db.payments.length, 1);
+    const paidEvents = mock.db.billing_events.filter((e) => e.event_type === 'invoice.paid');
+    assert.equal(paidEvents.length, 1);
+  });
+
+  it('rejects amount_cents <= 0', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    await assert.rejects(
+      () => recordPayment(mock, { invoice_id: invoice.id, amount_cents: 0 }),
+      /amount_cents must be > 0/,
+    );
+  });
+
+  it('rejects payment on voided invoice', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    await voidInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR, reason: 'test' });
+    await assert.rejects(
+      () => recordPayment(mock, { invoice_id: invoice.id, amount_cents: 100 }),
+      /invoice is void/,
+    );
+  });
+});
+
+describe('invoiceService -- voidInvoice', () => {
+  it('voids a draft invoice; zeroes balance_due; logs INVOICE_VOIDED', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    const voided = await voidInvoice(mock, {
+      invoice_id: invoice.id,
+      actor_id: ACTOR,
+      reason: 'customer request',
+    });
+    assert.equal(voided.status, 'void');
+    assert.equal(voided.balance_due_cents, 0);
+    const ev = mock.db.billing_events.find((e) => e.event_type === 'invoice.voided');
+    assert.equal(ev.payload_json.reason, 'customer request');
+  });
+
+  it('refuses to void a paid invoice', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    await issueInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+    await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 100,
+      provider_payment_intent_id: 'pi_v',
+    });
+    await assert.rejects(
+      () => voidInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR }),
+      /cannot void a paid invoice/,
+    );
+  });
+
+  it('is idempotent on already-voided invoice', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    await voidInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+    const again = await voidInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+    assert.equal(again.status, 'void');
+  });
+
+  it('requires actor_id', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', quantity: 1, unit_price_cents: 100 },
+      ],
+    });
+    await assert.rejects(() => voidInvoice(mock, { invoice_id: invoice.id }), /actor_id required/);
+  });
+});

--- a/backend/__tests__/billing/paymentProvider.test.js
+++ b/backend/__tests__/billing/paymentProvider.test.js
@@ -1,0 +1,67 @@
+/**
+ * Unit tests for backend/lib/billing/paymentProvider.js
+ *
+ * Ensures adapters implementing the provider interface are correctly
+ * validated at runtime.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { assertProviderInterface } from '../../lib/billing/paymentProvider.js';
+
+const completeAdapter = {
+  createCustomer: async () => ({ id: 'c_1' }),
+  createCheckoutSession: async () => ({ id: 's_1', url: 'https://example.com' }),
+  createPortalSession: async () => ({ url: 'https://example.com' }),
+  verifyWebhookSignature: () => ({ event: {} }),
+  normalizePaymentEvent: () => ({ type: 'test' }),
+};
+
+describe('paymentProvider -- assertProviderInterface', () => {
+  it('accepts a fully-implemented adapter', () => {
+    assert.doesNotThrow(() => assertProviderInterface(completeAdapter));
+  });
+
+  it('rejects adapter missing createCustomer', () => {
+    const { createCustomer, ...partial } = completeAdapter;
+    assert.throws(() => assertProviderInterface(partial), /createCustomer/);
+  });
+
+  it('rejects adapter missing createCheckoutSession', () => {
+    const { createCheckoutSession, ...partial } = completeAdapter;
+    assert.throws(() => assertProviderInterface(partial), /createCheckoutSession/);
+  });
+
+  it('rejects adapter missing verifyWebhookSignature', () => {
+    const { verifyWebhookSignature, ...partial } = completeAdapter;
+    assert.throws(() => assertProviderInterface(partial), /verifyWebhookSignature/);
+  });
+
+  it('rejects adapter missing normalizePaymentEvent', () => {
+    const { normalizePaymentEvent, ...partial } = completeAdapter;
+    assert.throws(() => assertProviderInterface(partial), /normalizePaymentEvent/);
+  });
+
+  it('lists ALL missing methods in the error', () => {
+    const partial = { createCustomer: completeAdapter.createCustomer };
+    try {
+      assertProviderInterface(partial);
+      assert.fail('should have thrown');
+    } catch (err) {
+      assert.match(err.message, /createCheckoutSession/);
+      assert.match(err.message, /createPortalSession/);
+      assert.match(err.message, /verifyWebhookSignature/);
+      assert.match(err.message, /normalizePaymentEvent/);
+    }
+  });
+
+  it('rejects null / undefined', () => {
+    assert.throws(() => assertProviderInterface(null), /missing methods/);
+    assert.throws(() => assertProviderInterface(undefined), /missing methods/);
+  });
+
+  it('rejects adapter where method is a string, not a function', () => {
+    const bad = { ...completeAdapter, createCustomer: 'not a fn' };
+    assert.throws(() => assertProviderInterface(bad), /createCustomer/);
+  });
+});

--- a/backend/__tests__/billing/stripePlatformAdapter.test.js
+++ b/backend/__tests__/billing/stripePlatformAdapter.test.js
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for backend/lib/billing/stripePlatformAdapter.js
+ *
+ * Focused on pure-logic surfaces:
+ *   - normalizePaymentEvent() shape transformation
+ *   - interface conformance (exports match provider contract)
+ *
+ * Calls that actually invoke Stripe (createCustomer, createCheckoutSession,
+ * verifyWebhookSignature) are tested via integration tests in PR 3.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import * as adapter from '../../lib/billing/stripePlatformAdapter.js';
+import { assertProviderInterface } from '../../lib/billing/paymentProvider.js';
+
+describe('stripePlatformAdapter -- interface conformance', () => {
+  it('implements the full payment provider interface', () => {
+    assert.doesNotThrow(() => assertProviderInterface(adapter));
+  });
+});
+
+describe('stripePlatformAdapter -- normalizePaymentEvent', () => {
+  it('returns null for empty or malformed event', () => {
+    assert.equal(adapter.normalizePaymentEvent(null), null);
+    assert.equal(adapter.normalizePaymentEvent({}), null);
+    assert.equal(adapter.normalizePaymentEvent({ type: '' }), null);
+  });
+
+  it('extracts tenant_id from metadata', () => {
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_123',
+          metadata: { tenant_id: 'tenant-abc' },
+          amount_total: 4900,
+          currency: 'usd',
+          payment_intent: 'pi_456',
+        },
+      },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.type, 'checkout.session.completed');
+    assert.equal(normalized.tenant_id, 'tenant-abc');
+    assert.equal(normalized.amount_cents, 4900);
+    assert.equal(normalized.currency, 'usd');
+    assert.equal(normalized.payment_intent_id, 'pi_456');
+  });
+
+  it('falls back to client_reference_id when metadata.tenant_id missing', () => {
+    const event = {
+      type: 'checkout.session.completed',
+      data: { object: { id: 'cs_1', client_reference_id: 'tenant-xyz' } },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.tenant_id, 'tenant-xyz');
+  });
+
+  it('handles payment_intent.succeeded events (top-level intent id)', () => {
+    const event = {
+      type: 'payment_intent.succeeded',
+      data: {
+        object: {
+          object: 'payment_intent',
+          id: 'pi_789',
+          amount: 2500,
+          currency: 'usd',
+          metadata: { tenant_id: 't1' },
+          latest_charge: 'ch_111',
+        },
+      },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.payment_intent_id, 'pi_789');
+    assert.equal(normalized.charge_id, 'ch_111');
+    assert.equal(normalized.amount_cents, 2500);
+  });
+
+  it('handles charge events (top-level charge id)', () => {
+    const event = {
+      type: 'charge.succeeded',
+      data: {
+        object: {
+          object: 'charge',
+          id: 'ch_222',
+          amount: 10000,
+          currency: 'usd',
+          metadata: {},
+        },
+      },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.charge_id, 'ch_222');
+    assert.equal(normalized.payment_intent_id, null);
+  });
+
+  it('returns null tenant_id if neither metadata nor client_reference_id is set', () => {
+    const event = {
+      type: 'payment_intent.payment_failed',
+      data: { object: { id: 'pi_1', metadata: {} } },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.tenant_id, null);
+  });
+
+  it('preserves raw_object_id for webhook correlation', () => {
+    const event = {
+      type: 'whatever',
+      data: { object: { id: 'obj_xyz', metadata: {} } },
+    };
+    const normalized = adapter.normalizePaymentEvent(event);
+    assert.equal(normalized.raw_object_id, 'obj_xyz');
+  });
+});

--- a/backend/__tests__/billing/subscriptionService.test.js
+++ b/backend/__tests__/billing/subscriptionService.test.js
@@ -1,0 +1,247 @@
+/**
+ * Unit tests for backend/lib/billing/subscriptionService.js
+ *
+ * Covers:
+ *   - assignPlan validation + rejection when active sub exists
+ *   - changePlan flow (cancel old + create new + PLAN_CHANGED event)
+ *   - cancelSubscription + tenant.billing_state sync
+ *   - Plan validation (not found / inactive)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createBillingMock } from './_billingMock.js';
+import {
+  getActiveSubscription,
+  assignPlan,
+  changePlan,
+  cancelSubscription,
+} from '../../lib/billing/subscriptionService.js';
+
+const TENANT = 'tenant-ccc';
+const ACTOR = 'user-admin-3';
+
+function fresh() {
+  return createBillingMock({
+    billing_plans: [
+      {
+        id: 'plan-starter',
+        code: 'starter_monthly',
+        billing_interval: 'month',
+        amount_cents: 4900,
+        is_active: true,
+      },
+      {
+        id: 'plan-growth',
+        code: 'growth_monthly',
+        billing_interval: 'month',
+        amount_cents: 14900,
+        is_active: true,
+      },
+      {
+        id: 'plan-legacy',
+        code: 'legacy_plan',
+        billing_interval: 'month',
+        amount_cents: 9900,
+        is_active: false,
+      },
+    ],
+    billing_accounts: [],
+    tenant_subscriptions: [],
+    billing_events: [],
+    tenant: [{ id: TENANT, billing_state: 'active' }],
+  });
+}
+
+describe('subscriptionService -- assignPlan', () => {
+  it('creates active subscription with renewal_date for monthly plan', async () => {
+    const mock = fresh();
+    const before = Date.now();
+    const sub = await assignPlan(mock, {
+      tenant_id: TENANT,
+      plan_code: 'starter_monthly',
+      actor_id: ACTOR,
+    });
+
+    assert.equal(sub.status, 'active');
+    assert.equal(sub.billing_plan_id, 'plan-starter');
+    assert.ok(sub.renewal_date, 'monthly plan must have renewal_date');
+
+    const renewalMs = new Date(sub.renewal_date).getTime();
+    const expectedMin = before + 27 * 24 * 60 * 60 * 1000;
+    const expectedMax = before + 32 * 24 * 60 * 60 * 1000;
+    assert.ok(
+      renewalMs >= expectedMin && renewalMs <= expectedMax,
+      `renewal_date (${sub.renewal_date}) should be ~1 month from now`,
+    );
+
+    const types = mock.db.billing_events.map((e) => e.event_type);
+    assert.ok(types.includes('plan.assigned'));
+    assert.ok(types.includes('subscription.created'));
+
+    assert.equal(mock.db.tenant[0].billing_state, 'active');
+  });
+
+  it('rejects when plan_code does not exist', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => assignPlan(mock, { tenant_id: TENANT, plan_code: 'no_such_plan' }),
+      /not found or inactive/,
+    );
+  });
+
+  it('rejects inactive plan', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => assignPlan(mock, { tenant_id: TENANT, plan_code: 'legacy_plan' }),
+      /not found or inactive/,
+    );
+  });
+
+  it('rejects when tenant already has active subscription', async () => {
+    const mock = fresh();
+    await assignPlan(mock, { tenant_id: TENANT, plan_code: 'starter_monthly', actor_id: ACTOR });
+    await assert.rejects(
+      () => assignPlan(mock, { tenant_id: TENANT, plan_code: 'growth_monthly', actor_id: ACTOR }),
+      /already has an active subscription/,
+    );
+  });
+
+  it('rejects missing tenant_id / plan_code', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => assignPlan(mock, { plan_code: 'starter_monthly' }),
+      /tenant_id required/,
+    );
+    await assert.rejects(() => assignPlan(mock, { tenant_id: TENANT }), /plan_code required/);
+  });
+});
+
+describe('subscriptionService -- getActiveSubscription', () => {
+  it('returns null when tenant has no subscription', async () => {
+    const mock = fresh();
+    const sub = await getActiveSubscription(mock, TENANT);
+    assert.equal(sub, null);
+  });
+
+  it('returns the active subscription ignoring canceled ones', async () => {
+    const mock = fresh();
+    mock.db.tenant_subscriptions = [
+      {
+        id: 's1',
+        tenant_id: TENANT,
+        billing_plan_id: 'plan-starter',
+        status: 'canceled',
+        created_at: '2026-01-01',
+      },
+      {
+        id: 's2',
+        tenant_id: TENANT,
+        billing_plan_id: 'plan-growth',
+        status: 'active',
+        created_at: '2026-02-01',
+      },
+    ];
+    const sub = await getActiveSubscription(mock, TENANT);
+    assert.equal(sub.id, 's2');
+  });
+});
+
+describe('subscriptionService -- changePlan', () => {
+  it('cancels old sub, creates new one, emits PLAN_CHANGED', async () => {
+    const mock = fresh();
+    const old = await assignPlan(mock, {
+      tenant_id: TENANT,
+      plan_code: 'starter_monthly',
+      actor_id: ACTOR,
+    });
+
+    const next = await changePlan(mock, {
+      tenant_id: TENANT,
+      plan_code: 'growth_monthly',
+      actor_id: ACTOR,
+    });
+
+    assert.equal(next.billing_plan_id, 'plan-growth');
+    assert.equal(next.status, 'active');
+
+    const oldRow = mock.db.tenant_subscriptions.find((s) => s.id === old.id);
+    assert.equal(oldRow.status, 'canceled');
+
+    const changedEvent = mock.db.billing_events.find((e) => e.event_type === 'plan.changed');
+    assert.ok(changedEvent, 'plan.changed event must be logged');
+    assert.equal(changedEvent.payload_json.from_subscription_id, old.id);
+    assert.equal(changedEvent.payload_json.to_subscription_id, next.id);
+    assert.equal(changedEvent.payload_json.to_plan_code, 'growth_monthly');
+  });
+
+  it('rejects when no active subscription exists', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => changePlan(mock, { tenant_id: TENANT, plan_code: 'growth_monthly', actor_id: ACTOR }),
+      /use assignPlan/,
+    );
+  });
+
+  it('rejects change to same plan', async () => {
+    const mock = fresh();
+    await assignPlan(mock, { tenant_id: TENANT, plan_code: 'starter_monthly', actor_id: ACTOR });
+    await assert.rejects(
+      () => changePlan(mock, { tenant_id: TENANT, plan_code: 'starter_monthly', actor_id: ACTOR }),
+      /already on/,
+    );
+  });
+
+  it('rejects change to inactive plan without canceling the existing one', async () => {
+    const mock = fresh();
+    const existing = await assignPlan(mock, {
+      tenant_id: TENANT,
+      plan_code: 'starter_monthly',
+      actor_id: ACTOR,
+    });
+    await assert.rejects(
+      () => changePlan(mock, { tenant_id: TENANT, plan_code: 'legacy_plan', actor_id: ACTOR }),
+      /not found or inactive/,
+    );
+    const row = mock.db.tenant_subscriptions.find((s) => s.id === existing.id);
+    assert.equal(row.status, 'active', 'existing sub must remain active on failed change');
+  });
+});
+
+describe('subscriptionService -- cancelSubscription', () => {
+  it('cancels active subscription and syncs tenant.billing_state to canceled', async () => {
+    const mock = fresh();
+    await assignPlan(mock, { tenant_id: TENANT, plan_code: 'starter_monthly', actor_id: ACTOR });
+
+    const canceled = await cancelSubscription(mock, {
+      tenant_id: TENANT,
+      actor_id: ACTOR,
+      reason: 'customer request',
+    });
+
+    assert.equal(canceled.status, 'canceled');
+    assert.ok(canceled.canceled_at);
+
+    const ev = mock.db.billing_events.find((e) => e.event_type === 'subscription.canceled');
+    assert.equal(ev.payload_json.reason, 'customer request');
+
+    assert.equal(mock.db.tenant[0].billing_state, 'canceled');
+  });
+
+  it('rejects when no active subscription', async () => {
+    const mock = fresh();
+    await assert.rejects(
+      () => cancelSubscription(mock, { tenant_id: TENANT, actor_id: ACTOR }),
+      /no active subscription/,
+    );
+  });
+
+  it('requires actor_id', async () => {
+    const mock = fresh();
+    await assignPlan(mock, { tenant_id: TENANT, plan_code: 'starter_monthly', actor_id: ACTOR });
+    await assert.rejects(
+      () => cancelSubscription(mock, { tenant_id: TENANT }),
+      /actor_id required/,
+    );
+  });
+});

--- a/backend/__tests__/schema/billing-schema-alignment.test.js
+++ b/backend/__tests__/schema/billing-schema-alignment.test.js
@@ -1,0 +1,257 @@
+/**
+ * Billing Schema Alignment Test (Phase 1 / Migration 154)
+ *
+ * Verifies migration 154_platform_billing_foundation.sql has been applied
+ * to the target Supabase environment. Runs against SUPABASE_URL --
+ * typically dev first, then prod after promotion.
+ *
+ * Skips silently when Supabase creds are unavailable (local unit runs).
+ */
+
+import { test, describe, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { initSupabaseForTests, hasSupabaseCredentials } from '../setup.js';
+import { getSupabaseClient } from '../../lib/supabase-db.js';
+import { TENANT_ID } from '../testConstants.js';
+
+const SHOULD_RUN = hasSupabaseCredentials();
+
+const PLATFORM_BILLING_TABLES = [
+  'billing_plans',
+  'billing_accounts',
+  'tenant_subscriptions',
+  'invoices',
+  'invoice_line_items',
+  'payments',
+  'billing_events',
+];
+
+const CALCOM_TABLES = ['session_packages', 'session_credits', 'booking_sessions'];
+
+describe(
+  'Migration 154: Platform Billing Foundation -- Schema Alignment',
+  { skip: !SHOULD_RUN },
+  () => {
+    let supabase;
+
+    before(async () => {
+      await initSupabaseForTests();
+      supabase = getSupabaseClient();
+    });
+
+    test('all 7 platform billing tables exist', async () => {
+      for (const tbl of PLATFORM_BILLING_TABLES) {
+        const { error } = await supabase.from(tbl).select('*').limit(1);
+        assert.equal(
+          error,
+          null,
+          `Table public.${tbl} must exist and be queryable -- got: ${error?.message}`,
+        );
+      }
+    });
+
+    test('tenant.billing_state column exists', async () => {
+      const { data, error } = await supabase.from('tenant').select('id, billing_state').limit(1);
+
+      assert.equal(
+        error,
+        null,
+        `tenant.billing_state must be selectable -- got: ${error?.message}`,
+      );
+      if (data && data.length > 0) {
+        assert.ok(data[0].billing_state !== undefined, 'billing_state column must exist on tenant');
+      }
+    });
+
+    test('billing_state CHECK constraint rejects invalid values', async () => {
+      const { data: tenants } = await supabase.from('tenant').select('id').limit(1);
+      if (!tenants || tenants.length === 0) return;
+      const tenantId = tenants[0].id;
+
+      const { data: beforeRow } = await supabase
+        .from('tenant')
+        .select('billing_state')
+        .eq('id', tenantId)
+        .single();
+
+      const { error } = await supabase
+        .from('tenant')
+        .update({ billing_state: 'not_a_real_state' })
+        .eq('id', tenantId);
+
+      assert.notEqual(error, null, 'CHECK must reject invalid billing_state');
+
+      if (!error && beforeRow) {
+        await supabase
+          .from('tenant')
+          .update({ billing_state: beforeRow.billing_state })
+          .eq('id', tenantId);
+      }
+    });
+
+    test('default plans are seeded', async () => {
+      const { data, error } = await supabase
+        .from('billing_plans')
+        .select('code')
+        .in('code', ['starter_monthly', 'growth_monthly', 'pro_monthly']);
+
+      assert.equal(error, null, `billing_plans query failed: ${error?.message}`);
+      assert.equal(data.length, 3, 'All 3 default plans must be seeded');
+    });
+
+    test('billing_accounts enforces exemption audit trail', async () => {
+      const { error } = await supabase.from('billing_accounts').insert({
+        tenant_id: TENANT_ID,
+        billing_exempt: true,
+        // missing exempt_reason, exempt_set_by, exempt_set_at
+      });
+
+      assert.notEqual(error, null, 'CHECK must reject billing_exempt=true without audit fields');
+    });
+
+    test('billing_events is append-only (UPDATE blocked)', async () => {
+      const { data: inserted, error: insErr } = await supabase
+        .from('billing_events')
+        .insert({
+          tenant_id: TENANT_ID,
+          event_type: 'test.immutability_probe',
+          source: 'system',
+          payload_json: { probe: true },
+        })
+        .select('id')
+        .single();
+
+      assert.equal(insErr, null, `insert should succeed: ${insErr?.message}`);
+
+      const { error: updErr } = await supabase
+        .from('billing_events')
+        .update({ event_type: 'test.mutated' })
+        .eq('id', inserted.id);
+
+      assert.notEqual(updErr, null, 'UPDATE on billing_events must be rejected');
+      assert.match(
+        updErr.message || '',
+        /append-only|not permitted/i,
+        'error must come from immutability trigger',
+      );
+    });
+
+    test('billing_events is append-only (DELETE blocked)', async () => {
+      const { data: inserted, error: insErr } = await supabase
+        .from('billing_events')
+        .insert({
+          tenant_id: TENANT_ID,
+          event_type: 'test.delete_probe',
+          source: 'system',
+        })
+        .select('id')
+        .single();
+
+      assert.equal(insErr, null);
+
+      const { error: delErr } = await supabase
+        .from('billing_events')
+        .delete()
+        .eq('id', inserted.id);
+
+      assert.notEqual(delErr, null, 'DELETE on billing_events must be rejected');
+    });
+
+    test('only one non-canceled subscription per tenant', async () => {
+      const { data: plans } = await supabase
+        .from('billing_plans')
+        .select('id')
+        .eq('code', 'starter_monthly')
+        .single();
+      assert.ok(plans?.id);
+
+      await supabase
+        .from('tenant_subscriptions')
+        .update({ status: 'canceled', canceled_at: new Date().toISOString() })
+        .eq('tenant_id', TENANT_ID)
+        .neq('status', 'canceled');
+
+      const { data: first, error: firstErr } = await supabase
+        .from('tenant_subscriptions')
+        .insert({
+          tenant_id: TENANT_ID,
+          billing_plan_id: plans.id,
+          status: 'active',
+        })
+        .select('id')
+        .single();
+      assert.equal(firstErr, null, `first sub insert: ${firstErr?.message}`);
+
+      const { error: secondErr } = await supabase.from('tenant_subscriptions').insert({
+        tenant_id: TENANT_ID,
+        billing_plan_id: plans.id,
+        status: 'active',
+      });
+
+      assert.notEqual(secondErr, null, 'second active sub must be rejected');
+
+      await supabase.from('tenant_subscriptions').delete().eq('id', first.id);
+    });
+
+    test('payments.provider_payment_intent_id is unique (idempotency)', async () => {
+      const pi = `pi_test_${Date.now()}`;
+
+      const { data: first, error: firstErr } = await supabase
+        .from('payments')
+        .insert({
+          tenant_id: TENANT_ID,
+          amount_cents: 100,
+          status: 'succeeded',
+          provider_payment_intent_id: pi,
+        })
+        .select('id')
+        .single();
+
+      assert.equal(firstErr, null, `first payment insert: ${firstErr?.message}`);
+
+      const { error: dupErr } = await supabase.from('payments').insert({
+        tenant_id: TENANT_ID,
+        amount_cents: 100,
+        status: 'succeeded',
+        provider_payment_intent_id: pi,
+      });
+
+      assert.notEqual(dupErr, null, 'duplicate payment_intent must be rejected');
+
+      await supabase.from('payments').delete().eq('id', first.id);
+    });
+
+    test('domain separation: Cal.com tables untouched', async () => {
+      for (const tbl of CALCOM_TABLES) {
+        const { error } = await supabase.from(tbl).select('*').limit(1);
+        assert.equal(
+          error,
+          null,
+          `Cal.com table ${tbl} must still be queryable -- got: ${error?.message}`,
+        );
+      }
+
+      const overlap = PLATFORM_BILLING_TABLES.filter((t) => CALCOM_TABLES.includes(t));
+      assert.equal(overlap.length, 0, `domain table name overlap: ${overlap.join(',')}`);
+    });
+
+    test('billing_accounts is one-per-tenant', async () => {
+      await supabase.from('billing_accounts').delete().eq('tenant_id', TENANT_ID);
+
+      const { data: first, error: firstErr } = await supabase
+        .from('billing_accounts')
+        .insert({ tenant_id: TENANT_ID, billing_email: 'test@example.com' })
+        .select('id')
+        .single();
+      assert.equal(firstErr, null, `first insert: ${firstErr?.message}`);
+
+      const { error: dupErr } = await supabase
+        .from('billing_accounts')
+        .insert({ tenant_id: TENANT_ID, billing_email: 'dup@example.com' });
+
+      assert.notEqual(dupErr, null, 'second billing_account for same tenant must be rejected');
+
+      await supabase.from('billing_accounts').delete().eq('id', first.id);
+    });
+  },
+);

--- a/backend/lib/billing/billingAccountService.js
+++ b/backend/lib/billing/billingAccountService.js
@@ -1,0 +1,214 @@
+/**
+ * Platform Billing -- Billing Account Service
+ *
+ * CRUD operations on billing_accounts plus exemption management.
+ *
+ * Exemption policy (locked in PR decision):
+ *   - billing_exempt is a BOOLEAN FLAG with mandatory audit fields
+ *     (reason + actor + timestamp), enforced by CHECK constraint.
+ *   - Setting/removing exemption writes a billing_event.
+ *   - Toggling exemption triggers syncTenantBillingState().
+ */
+
+import logger from '../logger.js';
+import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
+import { syncTenantBillingState } from './billingStateMachine.js';
+
+/**
+ * Get the billing_account row for a tenant (creates it empty on first access).
+ * @returns {Promise<object>} billing_accounts row
+ */
+export async function getOrCreateBillingAccount(supabase, tenantId) {
+  if (!tenantId) throw new Error('getOrCreateBillingAccount: tenantId required');
+
+  const { data: existing, error: selErr } = await supabase
+    .from('billing_accounts')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+
+  if (selErr) throw new Error(`billing_accounts select: ${selErr.message}`);
+  if (existing) return existing;
+
+  const { data: created, error: insErr } = await supabase
+    .from('billing_accounts')
+    .insert({ tenant_id: tenantId })
+    .select('*')
+    .single();
+
+  if (insErr) {
+    // Handle race: another request may have just inserted
+    if (insErr.code === '23505') {
+      const { data: raced } = await supabase
+        .from('billing_accounts')
+        .select('*')
+        .eq('tenant_id', tenantId)
+        .single();
+      return raced;
+    }
+    throw new Error(`billing_accounts insert: ${insErr.message}`);
+  }
+
+  return created;
+}
+
+/**
+ * Update billing profile fields (contact info, address, tax id, etc).
+ * Does NOT touch billing_exempt -- use setExemption() for that.
+ */
+export async function updateBillingProfile(supabase, tenantId, updates) {
+  if (!tenantId) throw new Error('updateBillingProfile: tenantId required');
+
+  const allowed = [
+    'billing_contact_name',
+    'billing_email',
+    'company_name',
+    'billing_address',
+    'tax_id',
+    'currency',
+    'provider_customer_id',
+    'notes',
+  ];
+  const clean = {};
+  for (const k of allowed) {
+    if (updates[k] !== undefined) clean[k] = updates[k];
+  }
+
+  // Reject any attempt to touch exemption via this path
+  const forbidden = ['billing_exempt', 'exempt_reason', 'exempt_set_by', 'exempt_set_at'];
+  for (const k of forbidden) {
+    if (updates[k] !== undefined) {
+      throw new Error(`updateBillingProfile: use setExemption() to modify ${k}`);
+    }
+  }
+
+  if (Object.keys(clean).length === 0) {
+    throw new Error('updateBillingProfile: no updatable fields provided');
+  }
+
+  // Ensure account exists
+  await getOrCreateBillingAccount(supabase, tenantId);
+
+  const { data, error } = await supabase
+    .from('billing_accounts')
+    .update(clean)
+    .eq('tenant_id', tenantId)
+    .select('*')
+    .single();
+
+  if (error) throw new Error(`updateBillingProfile: ${error.message}`);
+  return data;
+}
+
+/**
+ * Mark a tenant as billing-exempt. Requires reason + actor.
+ * Writes billing_event and syncs tenant.billing_state.
+ *
+ * @param {object} supabase - service-role client
+ * @param {object} params
+ * @param {string} params.tenant_id
+ * @param {string} params.reason       - human-readable justification (required)
+ * @param {string} params.actor_id     - users.id of admin performing action (required)
+ * @param {string} [params.request_id]
+ * @returns {Promise<{account: object, stateChange: object}>}
+ */
+export async function setExemption(supabase, { tenant_id, reason, actor_id, request_id }) {
+  if (!tenant_id) throw new Error('setExemption: tenant_id required');
+  if (!reason || !reason.trim()) throw new Error('setExemption: reason required');
+  if (!actor_id) throw new Error('setExemption: actor_id required');
+
+  await getOrCreateBillingAccount(supabase, tenant_id);
+
+  const { data: account, error } = await supabase
+    .from('billing_accounts')
+    .update({
+      billing_exempt: true,
+      exempt_reason: reason.trim(),
+      exempt_set_by: actor_id,
+      exempt_set_at: new Date().toISOString(),
+    })
+    .eq('tenant_id', tenant_id)
+    .select('*')
+    .single();
+
+  if (error) throw new Error(`setExemption: ${error.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.TENANT_BILLING_EXEMPT_SET,
+    source: 'admin',
+    actor_id,
+    payload: { reason: reason.trim() },
+    request_id,
+  });
+
+  const stateChange = await syncTenantBillingState(supabase, tenant_id);
+  logger.info({ tenant_id, actor_id, stateChange }, '[BillingAccounts] Exemption set');
+
+  return { account, stateChange };
+}
+
+/**
+ * Remove billing exemption from a tenant. Requires actor.
+ * Clears audit fields and re-runs state sync so tenant returns to
+ * whatever state its subscription dictates.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.tenant_id
+ * @param {string} params.actor_id
+ * @param {string} [params.request_id]
+ * @returns {Promise<{account: object, stateChange: object}>}
+ */
+export async function removeExemption(supabase, { tenant_id, actor_id, request_id }) {
+  if (!tenant_id) throw new Error('removeExemption: tenant_id required');
+  if (!actor_id) throw new Error('removeExemption: actor_id required');
+
+  const { data: current } = await supabase
+    .from('billing_accounts')
+    .select('*')
+    .eq('tenant_id', tenant_id)
+    .maybeSingle();
+
+  if (!current || !current.billing_exempt) {
+    throw new Error('removeExemption: tenant is not currently exempt');
+  }
+
+  const { data: account, error } = await supabase
+    .from('billing_accounts')
+    .update({
+      billing_exempt: false,
+      exempt_reason: null,
+      exempt_set_by: null,
+      exempt_set_at: null,
+    })
+    .eq('tenant_id', tenant_id)
+    .select('*')
+    .single();
+
+  if (error) throw new Error(`removeExemption: ${error.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.TENANT_BILLING_EXEMPT_REMOVED,
+    source: 'admin',
+    actor_id,
+    payload: {
+      previous_reason: current.exempt_reason,
+      previous_set_at: current.exempt_set_at,
+    },
+    request_id,
+  });
+
+  const stateChange = await syncTenantBillingState(supabase, tenant_id);
+  logger.info({ tenant_id, actor_id, stateChange }, '[BillingAccounts] Exemption removed');
+
+  return { account, stateChange };
+}
+
+export default {
+  getOrCreateBillingAccount,
+  updateBillingProfile,
+  setExemption,
+  removeExemption,
+};

--- a/backend/lib/billing/billingEventLogger.js
+++ b/backend/lib/billing/billingEventLogger.js
@@ -1,0 +1,102 @@
+/**
+ * Platform Billing -- Event Logger
+ *
+ * Append-only writer for the `billing_events` table.
+ * Enforces the canonical event type vocabulary at the application layer
+ * (the DB column is free-form TEXT to allow forward compatibility).
+ *
+ * Usage:
+ *   import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
+ *   await logBillingEvent(supabase, {
+ *     tenant_id, event_type: BILLING_EVENTS.INVOICE_CREATED,
+ *     source: 'system', payload: { invoice_id },
+ *   });
+ */
+
+import logger from '../logger.js';
+
+export const BILLING_EVENTS = Object.freeze({
+  // Invoice lifecycle
+  INVOICE_CREATED: 'invoice.created',
+  INVOICE_SENT: 'invoice.sent',
+  INVOICE_PAST_DUE: 'invoice.past_due',
+  INVOICE_PAID: 'invoice.paid',
+  INVOICE_VOIDED: 'invoice.voided',
+
+  // Payment lifecycle
+  PAYMENT_RECEIVED: 'payment.received',
+  PAYMENT_FAILED: 'payment.failed',
+  PAYMENT_REFUNDED: 'payment.refunded',
+
+  // Subscription lifecycle
+  SUBSCRIPTION_CREATED: 'subscription.created',
+  SUBSCRIPTION_CANCELED: 'subscription.canceled',
+  SUBSCRIPTION_RENEWED: 'subscription.renewed',
+
+  // Tenant state
+  TENANT_SUSPENSION_WARNING: 'tenant.suspension_warning',
+  TENANT_SUSPENDED: 'tenant.suspended',
+  TENANT_UNSUSPENDED: 'tenant.unsuspended',
+  TENANT_BILLING_EXEMPT_SET: 'tenant.billing_exempt_set',
+  TENANT_BILLING_EXEMPT_REMOVED: 'tenant.billing_exempt_removed',
+
+  // Plan management
+  PLAN_ASSIGNED: 'plan.assigned',
+  PLAN_CHANGED: 'plan.changed',
+});
+
+export const VALID_EVENT_TYPES = new Set(Object.values(BILLING_EVENTS));
+export const VALID_SOURCES = new Set(['system', 'admin', 'webhook', 'api']);
+
+/**
+ * Log a billing event. Append-only; throws on invalid input.
+ *
+ * @param {object} supabase - service-role client
+ * @param {object} params
+ * @param {string|null} params.tenant_id - nullable for platform-wide events
+ * @param {string} params.event_type - must be in BILLING_EVENTS
+ * @param {string} params.source - must be in VALID_SOURCES
+ * @param {string|null} [params.actor_id] - users.id for admin/api sources
+ * @param {object} [params.payload] - JSONB payload
+ * @param {string|null} [params.request_id]
+ * @returns {Promise<object>} inserted row
+ */
+export async function logBillingEvent(supabase, params) {
+  const { tenant_id, event_type, source, actor_id, payload, request_id } = params;
+
+  if (!event_type || typeof event_type !== 'string') {
+    throw new Error('logBillingEvent: event_type is required (string)');
+  }
+  if (!VALID_EVENT_TYPES.has(event_type)) {
+    throw new Error(
+      `logBillingEvent: unknown event_type "${event_type}". ` +
+        `Valid: ${[...VALID_EVENT_TYPES].join(', ')}`,
+    );
+  }
+  if (!source || !VALID_SOURCES.has(source)) {
+    throw new Error(`logBillingEvent: source must be one of ${[...VALID_SOURCES].join(', ')}`);
+  }
+  if ((source === 'admin' || source === 'api') && !actor_id) {
+    throw new Error(`logBillingEvent: actor_id required when source="${source}"`);
+  }
+
+  const row = {
+    tenant_id: tenant_id || null,
+    event_type,
+    source,
+    actor_id: actor_id || null,
+    payload_json: payload || {},
+    request_id: request_id || null,
+  };
+
+  const { data, error } = await supabase.from('billing_events').insert(row).select('*').single();
+
+  if (error) {
+    logger.error({ err: error, event_type, tenant_id }, '[BillingEvents] Insert failed');
+    throw new Error(`logBillingEvent: ${error.message}`);
+  }
+
+  return data;
+}
+
+export default { BILLING_EVENTS, VALID_EVENT_TYPES, VALID_SOURCES, logBillingEvent };

--- a/backend/lib/billing/billingStateMachine.js
+++ b/backend/lib/billing/billingStateMachine.js
@@ -1,0 +1,139 @@
+/**
+ * Platform Billing -- State Machine
+ *
+ * Enforces valid transitions between tenant billing states and keeps
+ * `tenant.billing_state` in sync with the authoritative source of truth
+ * (billing_accounts.billing_exempt + tenant_subscriptions.status).
+ *
+ * States (cf. migration 154):
+ *   active         -- paying normally
+ *   past_due       -- invoice unpaid past due date, pre-grace
+ *   grace_period   -- in dunning window before suspension
+ *   suspended      -- 30+ days overdue, non-billing access blocked
+ *   billing_exempt -- indefinite exemption; bypasses all lifecycle rules
+ *   canceled       -- subscription terminated
+ *
+ * Rule: billing_exempt is a TERMINAL hold -- it can only be entered by an
+ * admin toggling billing_accounts.billing_exempt=true, and can only be
+ * exited by the same admin toggling it back to false. Automated dunning
+ * never transitions TO or FROM billing_exempt.
+ */
+
+export const BILLING_STATES = Object.freeze({
+  ACTIVE: 'active',
+  PAST_DUE: 'past_due',
+  GRACE_PERIOD: 'grace_period',
+  SUSPENDED: 'suspended',
+  BILLING_EXEMPT: 'billing_exempt',
+  CANCELED: 'canceled',
+});
+
+export const VALID_STATES = new Set(Object.values(BILLING_STATES));
+
+/**
+ * Allowed automated transitions (does not include admin overrides).
+ * Admin actions can force any transition except entering/leaving exempt,
+ * which is handled solely by billingAccountService.setExemption().
+ */
+const AUTO_TRANSITIONS = Object.freeze({
+  active: ['past_due', 'canceled'],
+  past_due: ['active', 'grace_period', 'canceled'],
+  grace_period: ['active', 'suspended', 'canceled'],
+  suspended: ['active', 'canceled'],
+  billing_exempt: [],
+  canceled: [],
+});
+
+/**
+ * Check whether an automated transition is allowed.
+ * @param {string} from
+ * @param {string} to
+ * @returns {boolean}
+ */
+export function canAutoTransition(from, to) {
+  if (!VALID_STATES.has(from) || !VALID_STATES.has(to)) return false;
+  if (from === to) return true;
+  return (AUTO_TRANSITIONS[from] || []).includes(to);
+}
+
+/**
+ * Compute authoritative billing_state from source-of-truth inputs.
+ * Priority (highest wins):
+ *   1. billing_accounts.billing_exempt=true -> billing_exempt
+ *   2. no subscription OR subscription.status='canceled' -> canceled
+ *   3. subscription.status maps 1:1 to billing_state
+ *
+ * @param {object} params
+ * @param {object|null} params.billingAccount  - row from billing_accounts (may be null)
+ * @param {object|null} params.subscription    - row from tenant_subscriptions (may be null)
+ * @returns {string} one of BILLING_STATES values
+ */
+export function computeBillingState({ billingAccount, subscription }) {
+  if (billingAccount?.billing_exempt === true) {
+    return BILLING_STATES.BILLING_EXEMPT;
+  }
+  if (!subscription || subscription.status === 'canceled') {
+    return subscription ? BILLING_STATES.CANCELED : BILLING_STATES.ACTIVE;
+    // No subscription yet = default active. Once a plan is assigned,
+    // the subscription row drives state.
+  }
+  if (subscription.status === 'draft') return BILLING_STATES.ACTIVE;
+  if (VALID_STATES.has(subscription.status)) return subscription.status;
+  return BILLING_STATES.ACTIVE;
+}
+
+/**
+ * Sync `tenant.billing_state` column with computed state.
+ * Idempotent -- returns {changed: bool, from, to}.
+ *
+ * @param {object} supabase - service-role client
+ * @param {string} tenantId
+ * @returns {Promise<{changed: boolean, from: string|null, to: string}>}
+ */
+export async function syncTenantBillingState(supabase, tenantId) {
+  if (!tenantId) throw new Error('syncTenantBillingState: tenantId required');
+
+  const [{ data: tenantRow, error: tErr }, { data: account }, { data: subs }] = await Promise.all([
+    supabase.from('tenant').select('billing_state').eq('id', tenantId).single(),
+    supabase
+      .from('billing_accounts')
+      .select('billing_exempt')
+      .eq('tenant_id', tenantId)
+      .maybeSingle(),
+    supabase
+      .from('tenant_subscriptions')
+      .select('status')
+      .eq('tenant_id', tenantId)
+      .order('created_at', { ascending: false })
+      .limit(1),
+  ]);
+
+  if (tErr) throw new Error(`syncTenantBillingState: tenant lookup failed: ${tErr.message}`);
+
+  const subscription = subs && subs.length > 0 ? subs[0] : null;
+  const computed = computeBillingState({ billingAccount: account, subscription });
+
+  const current = tenantRow?.billing_state || null;
+  if (current === computed) {
+    return { changed: false, from: current, to: computed };
+  }
+
+  const { error: updErr } = await supabase
+    .from('tenant')
+    .update({ billing_state: computed })
+    .eq('id', tenantId);
+
+  if (updErr) {
+    throw new Error(`syncTenantBillingState: update failed: ${updErr.message}`);
+  }
+
+  return { changed: true, from: current, to: computed };
+}
+
+export default {
+  BILLING_STATES,
+  VALID_STATES,
+  canAutoTransition,
+  computeBillingState,
+  syncTenantBillingState,
+};

--- a/backend/lib/billing/billingStateMachine.js
+++ b/backend/lib/billing/billingStateMachine.js
@@ -73,9 +73,10 @@ export function computeBillingState({ billingAccount, subscription }) {
     return BILLING_STATES.BILLING_EXEMPT;
   }
   if (!subscription || subscription.status === 'canceled') {
+    // No subscription yet = default active (tenant is on a free/implicit tier).
+    // Once a plan is assigned, the subscription row drives state.
+    // Canceled subscription = canceled.
     return subscription ? BILLING_STATES.CANCELED : BILLING_STATES.ACTIVE;
-    // No subscription yet = default active. Once a plan is assigned,
-    // the subscription row drives state.
   }
   if (subscription.status === 'draft') return BILLING_STATES.ACTIVE;
   if (VALID_STATES.has(subscription.status)) return subscription.status;
@@ -93,7 +94,11 @@ export function computeBillingState({ billingAccount, subscription }) {
 export async function syncTenantBillingState(supabase, tenantId) {
   if (!tenantId) throw new Error('syncTenantBillingState: tenantId required');
 
-  const [{ data: tenantRow, error: tErr }, { data: account }, { data: subs }] = await Promise.all([
+  const [
+    { data: tenantRow, error: tErr },
+    { data: account, error: acctErr },
+    { data: subs, error: subsErr },
+  ] = await Promise.all([
     supabase.from('tenant').select('billing_state').eq('id', tenantId).single(),
     supabase
       .from('billing_accounts')
@@ -109,6 +114,10 @@ export async function syncTenantBillingState(supabase, tenantId) {
   ]);
 
   if (tErr) throw new Error(`syncTenantBillingState: tenant lookup failed: ${tErr.message}`);
+  if (acctErr)
+    throw new Error(`syncTenantBillingState: billing_accounts lookup failed: ${acctErr.message}`);
+  if (subsErr)
+    throw new Error(`syncTenantBillingState: subscription lookup failed: ${subsErr.message}`);
 
   const subscription = subs && subs.length > 0 ? subs[0] : null;
   const computed = computeBillingState({ billingAccount: account, subscription });

--- a/backend/lib/billing/config.js
+++ b/backend/lib/billing/config.js
@@ -1,0 +1,50 @@
+/**
+ * Platform Billing -- Configuration Loader
+ *
+ * Loads platform-level Stripe credentials from Doppler/env.
+ *
+ * IMPORTANT: These are AiSHA's OWN Stripe keys for platform billing
+ * (tenant <- AiSHA). They are distinct from tenant_integrations.stripe,
+ * which holds PER-TENANT Stripe keys used for Cal.com session purchases
+ * (client <- tenant).
+ *
+ * Required Doppler secrets (prd_prd + dev_dev):
+ *   - STRIPE_PLATFORM_SECRET_KEY       (sk_live_... or sk_test_...)
+ *   - STRIPE_PLATFORM_WEBHOOK_SECRET   (whsec_...)
+ *
+ * Optional:
+ *   - STRIPE_PLATFORM_API_VERSION      (default: 2024-06-20)
+ *   - PLATFORM_BILLING_CURRENCY        (default: usd)
+ */
+
+const API_VERSION_DEFAULT = '2024-06-20';
+const CURRENCY_DEFAULT = 'usd';
+
+export function getPlatformBillingConfig() {
+  const secretKey = process.env.STRIPE_PLATFORM_SECRET_KEY;
+  const webhookSecret = process.env.STRIPE_PLATFORM_WEBHOOK_SECRET;
+
+  return {
+    stripeSecretKey: secretKey || null,
+    stripeWebhookSecret: webhookSecret || null,
+    stripeApiVersion: process.env.STRIPE_PLATFORM_API_VERSION || API_VERSION_DEFAULT,
+    defaultCurrency: process.env.PLATFORM_BILLING_CURRENCY || CURRENCY_DEFAULT,
+    isConfigured: Boolean(secretKey && webhookSecret),
+  };
+}
+
+/**
+ * Throws if platform billing is not configured. Use in code paths that
+ * absolutely need a live Stripe connection (checkout creation, webhook verify).
+ */
+export function requirePlatformBillingConfig() {
+  const cfg = getPlatformBillingConfig();
+  if (!cfg.isConfigured) {
+    throw new Error(
+      'Platform billing not configured: STRIPE_PLATFORM_SECRET_KEY and STRIPE_PLATFORM_WEBHOOK_SECRET must be set in Doppler',
+    );
+  }
+  return cfg;
+}
+
+export default { getPlatformBillingConfig, requirePlatformBillingConfig };

--- a/backend/lib/billing/config.js
+++ b/backend/lib/billing/config.js
@@ -29,19 +29,29 @@ export function getPlatformBillingConfig() {
     stripeWebhookSecret: webhookSecret || null,
     stripeApiVersion: process.env.STRIPE_PLATFORM_API_VERSION || API_VERSION_DEFAULT,
     defaultCurrency: process.env.PLATFORM_BILLING_CURRENCY || CURRENCY_DEFAULT,
-    isConfigured: Boolean(secretKey && webhookSecret),
+    isConfigured: Boolean(secretKey),
   };
 }
 
 /**
- * Throws if platform billing is not configured. Use in code paths that
- * absolutely need a live Stripe connection (checkout creation, webhook verify).
+ * Throws if platform billing is not configured. Accepts options to specify
+ * which secrets are required for the current operation.
+ *
+ * @param {object} [options]
+ * @param {boolean} [options.requireWebhookSecret=false] - Also require webhook secret (for webhook handlers)
  */
-export function requirePlatformBillingConfig() {
+export function requirePlatformBillingConfig(options = {}) {
+  const { requireWebhookSecret = false } = options;
   const cfg = getPlatformBillingConfig();
-  if (!cfg.isConfigured) {
+  const missing = [];
+
+  if (!cfg.stripeSecretKey) missing.push('STRIPE_PLATFORM_SECRET_KEY');
+  if (requireWebhookSecret && !cfg.stripeWebhookSecret)
+    missing.push('STRIPE_PLATFORM_WEBHOOK_SECRET');
+
+  if (missing.length > 0) {
     throw new Error(
-      'Platform billing not configured: STRIPE_PLATFORM_SECRET_KEY and STRIPE_PLATFORM_WEBHOOK_SECRET must be set in Doppler',
+      `Platform billing not configured: ${missing.join(' and ')} must be set in Doppler`,
     );
   }
   return cfg;

--- a/backend/lib/billing/index.js
+++ b/backend/lib/billing/index.js
@@ -1,0 +1,29 @@
+/**
+ * Platform Billing -- Barrel Export
+ *
+ * Single import surface for the platform billing service module.
+ *
+ *   import billing from '../lib/billing/index.js';
+ *   await billing.subscription.assignPlan(supabase, {...});
+ *
+ * Or named:
+ *
+ *   import { subscriptionService, BILLING_EVENTS } from '../lib/billing/index.js';
+ */
+
+export * as account from './billingAccountService.js';
+export * as subscription from './subscriptionService.js';
+export * as invoice from './invoiceService.js';
+export * as stateMachine from './billingStateMachine.js';
+export * as eventLogger from './billingEventLogger.js';
+export * as stripe from './stripePlatformAdapter.js';
+export * as providerInterface from './paymentProvider.js';
+export * as config from './config.js';
+
+export { BILLING_EVENTS } from './billingEventLogger.js';
+export {
+  BILLING_STATES,
+  computeBillingState,
+  syncTenantBillingState,
+  canAutoTransition,
+} from './billingStateMachine.js';

--- a/backend/lib/billing/invoiceService.js
+++ b/backend/lib/billing/invoiceService.js
@@ -18,7 +18,7 @@ const DEFAULT_DUE_DAYS = 14;
 /**
  * Generate an invoice number scoped to tenant.
  * Format: INV-<YYYY>-<6-digit sequence>
- * Sequence is derived from count of existing invoices for the tenant this year.
+ * Uses count+1 with a uniqueness check to handle concurrent creation.
  */
 export async function generateInvoiceNumber(supabase, tenantId) {
   if (!tenantId) throw new Error('generateInvoiceNumber: tenantId required');
@@ -33,8 +33,23 @@ export async function generateInvoiceNumber(supabase, tenantId) {
 
   if (error) throw new Error(`generateInvoiceNumber: ${error.message}`);
 
-  const seq = String((count || 0) + 1).padStart(6, '0');
-  return `INV-${year}-${seq}`;
+  // Try count+1, then increment on collision (handles concurrent inserts)
+  const maxAttempts = 5;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const seq = String((count || 0) + 1 + attempt).padStart(6, '0');
+    const candidate = `INV-${year}-${seq}`;
+
+    const { data: existing } = await supabase
+      .from('invoices')
+      .select('id')
+      .eq('tenant_id', tenantId)
+      .eq('invoice_number', candidate)
+      .maybeSingle();
+
+    if (!existing) return candidate;
+  }
+
+  throw new Error('generateInvoiceNumber: failed to allocate unique number after retries');
 }
 
 function sumLineItems(items) {
@@ -113,15 +128,21 @@ export async function createInvoice(supabase, params) {
 
   if (invErr) throw new Error(`createInvoice: ${invErr.message}`);
 
-  const lineRows = line_items.map((li) => ({
-    invoice_id: invoice.id,
-    item_type: li.item_type,
-    description: li.description,
-    quantity: li.quantity || 1,
-    unit_price_cents: li.unit_price_cents,
-    amount_cents: li.amount_cents ?? (li.quantity || 1) * li.unit_price_cents,
-    metadata: li.metadata || {},
-  }));
+  const lineRows = line_items.map((li) => {
+    if (li.quantity != null && li.quantity <= 0) {
+      throw new Error(`createInvoice: line item quantity must be > 0, got ${li.quantity}`);
+    }
+    const qty = li.quantity || 1;
+    return {
+      invoice_id: invoice.id,
+      item_type: li.item_type,
+      description: li.description,
+      quantity: qty,
+      unit_price_cents: li.unit_price_cents,
+      amount_cents: li.amount_cents ?? qty * li.unit_price_cents,
+      metadata: li.metadata || {},
+    };
+  });
 
   const { data: inserted_items, error: liErr } = await supabase
     .from('invoice_line_items')
@@ -273,17 +294,33 @@ export async function recordPayment(supabase, params) {
   const newBalance = invoice.total_cents - newPaid;
   const newStatus = newBalance <= 0 ? 'paid' : invoice.status;
 
-  const { data: updInvoice, error: updErr } = await supabase
-    .from('invoices')
-    .update({
-      amount_paid_cents: newPaid,
-      balance_due_cents: Math.max(newBalance, 0),
-      status: newStatus,
-    })
-    .eq('id', invoice_id)
-    .select('*')
-    .single();
-  if (updErr) throw new Error(`recordPayment: invoice update: ${updErr.message}`);
+  let updInvoice;
+  try {
+    const { data, error: updErr } = await supabase
+      .from('invoices')
+      .update({
+        amount_paid_cents: newPaid,
+        balance_due_cents: Math.max(newBalance, 0),
+        status: newStatus,
+      })
+      .eq('id', invoice_id)
+      .select('*')
+      .single();
+    if (updErr) throw updErr;
+    updInvoice = data;
+  } catch (invoiceUpdateError) {
+    // Attempt to roll back the payment insert
+    const { error: rollbackErr } = await supabase.from('payments').delete().eq('id', payment.id);
+    if (rollbackErr) {
+      logger.error('recordPayment: failed to roll back payment after invoice update error', {
+        invoice_id,
+        payment_id: payment.id,
+        invoiceUpdateError: invoiceUpdateError.message,
+        rollbackError: rollbackErr.message,
+      });
+    }
+    throw new Error(`recordPayment: invoice update: ${invoiceUpdateError.message}`);
+  }
 
   await logBillingEvent(supabase, {
     tenant_id: invoice.tenant_id,

--- a/backend/lib/billing/invoiceService.js
+++ b/backend/lib/billing/invoiceService.js
@@ -1,0 +1,382 @@
+/**
+ * Platform Billing -- Invoice Service
+ *
+ * Create / issue / pay / void invoices and manage line items.
+ * All write operations emit billing_events and keep balance math consistent.
+ *
+ * Exemption guard: invoice creation refuses if the tenant is billing-exempt.
+ * This is an application-layer guard (the DB does not enforce it) because
+ * exemption is a policy, not a data integrity, concern.
+ */
+
+import logger from '../logger.js';
+import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
+import { syncTenantBillingState } from './billingStateMachine.js';
+
+const DEFAULT_DUE_DAYS = 14;
+
+/**
+ * Generate an invoice number scoped to tenant.
+ * Format: INV-<YYYY>-<6-digit sequence>
+ * Sequence is derived from count of existing invoices for the tenant this year.
+ */
+export async function generateInvoiceNumber(supabase, tenantId) {
+  if (!tenantId) throw new Error('generateInvoiceNumber: tenantId required');
+  const year = new Date().getUTCFullYear();
+  const yearStart = new Date(Date.UTC(year, 0, 1)).toISOString();
+
+  const { count, error } = await supabase
+    .from('invoices')
+    .select('id', { count: 'exact', head: true })
+    .eq('tenant_id', tenantId)
+    .gte('created_at', yearStart);
+
+  if (error) throw new Error(`generateInvoiceNumber: ${error.message}`);
+
+  const seq = String((count || 0) + 1).padStart(6, '0');
+  return `INV-${year}-${seq}`;
+}
+
+function sumLineItems(items) {
+  return items.reduce((s, li) => s + (li.amount_cents ?? li.quantity * li.unit_price_cents), 0);
+}
+
+/**
+ * Create an invoice in 'draft' status. Does not send it -- use issueInvoice().
+ * Refuses if tenant is billing-exempt.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.tenant_id
+ * @param {string|null} [params.subscription_id]
+ * @param {Array<{item_type, description, quantity, unit_price_cents}>} params.line_items
+ * @param {string} [params.currency='usd']
+ * @param {number} [params.due_days=14]
+ * @param {number} [params.tax_total_cents=0]
+ * @param {string} [params.memo]
+ * @param {string|null} [params.actor_id]
+ * @param {string} [params.request_id]
+ * @returns {Promise<{invoice: object, line_items: Array}>}
+ */
+export async function createInvoice(supabase, params) {
+  const {
+    tenant_id,
+    subscription_id = null,
+    line_items = [],
+    currency = 'usd',
+    due_days = DEFAULT_DUE_DAYS,
+    tax_total_cents = 0,
+    memo = null,
+    actor_id = null,
+    request_id,
+  } = params;
+
+  if (!tenant_id) throw new Error('createInvoice: tenant_id required');
+  if (!Array.isArray(line_items) || line_items.length === 0) {
+    throw new Error('createInvoice: at least one line_item required');
+  }
+
+  // Exemption guard
+  const { data: account } = await supabase
+    .from('billing_accounts')
+    .select('billing_exempt')
+    .eq('tenant_id', tenant_id)
+    .maybeSingle();
+  if (account?.billing_exempt === true) {
+    throw new Error('createInvoice: tenant is billing-exempt; no invoice created');
+  }
+
+  const subtotal = sumLineItems(line_items);
+  if (subtotal < 0) throw new Error('createInvoice: subtotal cannot be negative');
+  const total = subtotal + tax_total_cents;
+
+  const invoice_number = await generateInvoiceNumber(supabase, tenant_id);
+  const due_date = new Date(Date.now() + due_days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data: invoice, error: invErr } = await supabase
+    .from('invoices')
+    .insert({
+      tenant_id,
+      subscription_id,
+      invoice_number,
+      due_date,
+      status: 'draft',
+      subtotal_cents: subtotal,
+      tax_total_cents,
+      total_cents: total,
+      balance_due_cents: total,
+      currency,
+      memo,
+    })
+    .select('*')
+    .single();
+
+  if (invErr) throw new Error(`createInvoice: ${invErr.message}`);
+
+  const lineRows = line_items.map((li) => ({
+    invoice_id: invoice.id,
+    item_type: li.item_type,
+    description: li.description,
+    quantity: li.quantity || 1,
+    unit_price_cents: li.unit_price_cents,
+    amount_cents: li.amount_cents ?? (li.quantity || 1) * li.unit_price_cents,
+    metadata: li.metadata || {},
+  }));
+
+  const { data: inserted_items, error: liErr } = await supabase
+    .from('invoice_line_items')
+    .insert(lineRows)
+    .select('*');
+
+  if (liErr) {
+    // Roll back the invoice on line-item failure
+    await supabase.from('invoices').delete().eq('id', invoice.id);
+    throw new Error(`createInvoice: line items failed: ${liErr.message}`);
+  }
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.INVOICE_CREATED,
+    source: actor_id ? 'admin' : 'system',
+    actor_id,
+    payload: {
+      invoice_id: invoice.id,
+      invoice_number,
+      total_cents: total,
+      line_item_count: lineRows.length,
+    },
+    request_id,
+  });
+
+  logger.info({ tenant_id, invoice_id: invoice.id, total }, '[Invoices] Created');
+  return { invoice, line_items: inserted_items };
+}
+
+/**
+ * Issue a draft invoice (draft -> open). Emits invoice.sent event.
+ */
+export async function issueInvoice(supabase, { invoice_id, actor_id, request_id }) {
+  if (!invoice_id) throw new Error('issueInvoice: invoice_id required');
+
+  const { data: invoice, error: selErr } = await supabase
+    .from('invoices')
+    .select('*')
+    .eq('id', invoice_id)
+    .single();
+  if (selErr || !invoice) throw new Error('issueInvoice: invoice not found');
+  if (invoice.status !== 'draft') {
+    throw new Error(`issueInvoice: invoice is ${invoice.status}, must be draft`);
+  }
+
+  const { data: updated, error: updErr } = await supabase
+    .from('invoices')
+    .update({ status: 'open' })
+    .eq('id', invoice_id)
+    .select('*')
+    .single();
+  if (updErr) throw new Error(`issueInvoice: ${updErr.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id: invoice.tenant_id,
+    event_type: BILLING_EVENTS.INVOICE_SENT,
+    source: actor_id ? 'admin' : 'system',
+    actor_id: actor_id || null,
+    payload: { invoice_id, invoice_number: invoice.invoice_number },
+    request_id,
+  });
+
+  return updated;
+}
+
+/**
+ * Record a payment against an invoice. Creates the payments row,
+ * updates invoice amount_paid/balance_due/status, emits events.
+ *
+ * Idempotent on provider_payment_intent_id: if one already exists, returns it.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.invoice_id
+ * @param {number} params.amount_cents
+ * @param {string} [params.provider_payment_intent_id]
+ * @param {string} [params.provider_charge_id]
+ * @param {string} [params.payment_method_type]
+ * @param {string} [params.receipt_url]
+ * @param {string} [params.source='system']
+ * @param {string|null} [params.actor_id]
+ * @param {string} [params.request_id]
+ */
+export async function recordPayment(supabase, params) {
+  const {
+    invoice_id,
+    amount_cents,
+    provider_payment_intent_id,
+    provider_charge_id,
+    payment_method_type,
+    receipt_url,
+    source = 'system',
+    actor_id = null,
+    request_id,
+  } = params;
+
+  if (!invoice_id) throw new Error('recordPayment: invoice_id required');
+  if (!amount_cents || amount_cents <= 0) {
+    throw new Error('recordPayment: amount_cents must be > 0');
+  }
+
+  const { data: invoice, error: invErr } = await supabase
+    .from('invoices')
+    .select('*')
+    .eq('id', invoice_id)
+    .single();
+  if (invErr || !invoice) throw new Error('recordPayment: invoice not found');
+  if (invoice.status === 'void' || invoice.status === 'uncollectible') {
+    throw new Error(`recordPayment: invoice is ${invoice.status}`);
+  }
+
+  // Idempotency check
+  if (provider_payment_intent_id) {
+    const { data: existing } = await supabase
+      .from('payments')
+      .select('*')
+      .eq('provider_payment_intent_id', provider_payment_intent_id)
+      .maybeSingle();
+    if (existing) {
+      logger.info(
+        { payment_id: existing.id, provider_payment_intent_id },
+        '[Invoices] recordPayment idempotent skip',
+      );
+      return { payment: existing, invoice, idempotent: true };
+    }
+  }
+
+  const { data: payment, error: payErr } = await supabase
+    .from('payments')
+    .insert({
+      tenant_id: invoice.tenant_id,
+      invoice_id,
+      amount_cents,
+      currency: invoice.currency,
+      status: 'succeeded',
+      provider_payment_intent_id: provider_payment_intent_id || null,
+      provider_charge_id: provider_charge_id || null,
+      payment_method_type: payment_method_type || null,
+      paid_at: new Date().toISOString(),
+      receipt_url: receipt_url || null,
+    })
+    .select('*')
+    .single();
+
+  if (payErr) throw new Error(`recordPayment: ${payErr.message}`);
+
+  const newPaid = invoice.amount_paid_cents + amount_cents;
+  const newBalance = invoice.total_cents - newPaid;
+  const newStatus = newBalance <= 0 ? 'paid' : invoice.status;
+
+  const { data: updInvoice, error: updErr } = await supabase
+    .from('invoices')
+    .update({
+      amount_paid_cents: newPaid,
+      balance_due_cents: Math.max(newBalance, 0),
+      status: newStatus,
+    })
+    .eq('id', invoice_id)
+    .select('*')
+    .single();
+  if (updErr) throw new Error(`recordPayment: invoice update: ${updErr.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id: invoice.tenant_id,
+    event_type: BILLING_EVENTS.PAYMENT_RECEIVED,
+    source,
+    actor_id,
+    payload: {
+      invoice_id,
+      payment_id: payment.id,
+      amount_cents,
+      invoice_status_after: newStatus,
+    },
+    request_id,
+  });
+
+  if (newStatus === 'paid') {
+    await logBillingEvent(supabase, {
+      tenant_id: invoice.tenant_id,
+      event_type: BILLING_EVENTS.INVOICE_PAID,
+      source,
+      actor_id,
+      payload: { invoice_id, invoice_number: invoice.invoice_number },
+      request_id,
+    });
+    // Payment may clear suspension state; re-sync
+    await syncTenantBillingState(supabase, invoice.tenant_id);
+  }
+
+  return { payment, invoice: updInvoice, idempotent: false };
+}
+
+/**
+ * Void an invoice. Only valid for non-paid invoices. Clears balance_due.
+ */
+export async function voidInvoice(supabase, { invoice_id, actor_id, request_id, reason }) {
+  if (!invoice_id) throw new Error('voidInvoice: invoice_id required');
+  if (!actor_id) throw new Error('voidInvoice: actor_id required');
+
+  const { data: invoice, error: selErr } = await supabase
+    .from('invoices')
+    .select('*')
+    .eq('id', invoice_id)
+    .single();
+  if (selErr || !invoice) throw new Error('voidInvoice: invoice not found');
+  if (invoice.status === 'paid') throw new Error('voidInvoice: cannot void a paid invoice');
+  if (invoice.status === 'void') return invoice; // idempotent
+
+  const { data: voided, error: updErr } = await supabase
+    .from('invoices')
+    .update({ status: 'void', balance_due_cents: 0 })
+    .eq('id', invoice_id)
+    .select('*')
+    .single();
+  if (updErr) throw new Error(`voidInvoice: ${updErr.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id: invoice.tenant_id,
+    event_type: BILLING_EVENTS.INVOICE_VOIDED,
+    source: 'admin',
+    actor_id,
+    payload: {
+      invoice_id,
+      invoice_number: invoice.invoice_number,
+      reason: reason || null,
+    },
+    request_id,
+  });
+
+  return voided;
+}
+
+/**
+ * Fetch a tenant's invoices ordered by issue_date DESC.
+ */
+export async function listInvoices(supabase, tenantId, { status, limit = 50 } = {}) {
+  if (!tenantId) throw new Error('listInvoices: tenantId required');
+  let q = supabase
+    .from('invoices')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('issue_date', { ascending: false })
+    .limit(limit);
+  if (status) q = q.eq('status', status);
+  const { data, error } = await q;
+  if (error) throw new Error(`listInvoices: ${error.message}`);
+  return data || [];
+}
+
+export default {
+  generateInvoiceNumber,
+  createInvoice,
+  issueInvoice,
+  recordPayment,
+  voidInvoice,
+  listInvoices,
+};

--- a/backend/lib/billing/paymentProvider.js
+++ b/backend/lib/billing/paymentProvider.js
@@ -1,0 +1,59 @@
+/**
+ * Platform Billing -- Payment Provider Interface
+ *
+ * Abstract contract every provider adapter must honor. This exists so
+ * the billing service can stay provider-agnostic (Phase 1 ships Stripe;
+ * Phase 6 may add others).
+ *
+ * Every method takes plain objects and returns plain objects.
+ * Adapters are responsible for mapping provider-specific fields into
+ * this normalized shape.
+ *
+ * NOTE: This file is intentionally a specification, not a class.
+ * Adapters are plain objects exposing these function names.
+ */
+
+/**
+ * Contract documentation (typedef-style):
+ *
+ *   createCustomer({ billing_email, company_name, metadata }) ->
+ *     Promise<{ id: string }>
+ *
+ *   createCheckoutSession({ customer_id, amount_cents, currency,
+ *                           description, success_url, cancel_url,
+ *                           metadata }) ->
+ *     Promise<{ id: string, url: string }>
+ *
+ *   createPortalSession({ customer_id, return_url }) ->
+ *     Promise<{ url: string }>
+ *
+ *   verifyWebhookSignature({ rawBody, signature }) ->
+ *     { event: object }   // throws on invalid signature
+ *
+ *   normalizePaymentEvent(event) ->
+ *     { type: string, tenant_id: string|null, amount_cents: number|null,
+ *       currency: string|null, payment_intent_id: string|null,
+ *       charge_id: string|null, metadata: object }
+ */
+
+/**
+ * Assert that a given object implements the provider interface.
+ * Useful in tests and at startup.
+ * @param {object} adapter
+ * @throws {Error} if any required method is missing
+ */
+export function assertProviderInterface(adapter) {
+  const required = [
+    'createCustomer',
+    'createCheckoutSession',
+    'createPortalSession',
+    'verifyWebhookSignature',
+    'normalizePaymentEvent',
+  ];
+  const missing = required.filter((m) => typeof adapter?.[m] !== 'function');
+  if (missing.length) {
+    throw new Error(`Payment provider missing methods: ${missing.join(', ')}`);
+  }
+}
+
+export default { assertProviderInterface };

--- a/backend/lib/billing/stripePlatformAdapter.js
+++ b/backend/lib/billing/stripePlatformAdapter.js
@@ -1,0 +1,135 @@
+/**
+ * Platform Billing -- Stripe Platform Adapter
+ *
+ * Implements the payment provider interface using AiSHA's PLATFORM
+ * Stripe account (STRIPE_PLATFORM_SECRET_KEY). Distinct from the
+ * Cal.com tenant-level Stripe adapter that reads from tenant_integrations.
+ *
+ * This adapter is stateless -- it instantiates a Stripe client per call
+ * using the platform key from Doppler. Caching the client is safe but
+ * not necessary for correctness.
+ */
+
+import Stripe from 'stripe';
+import { requirePlatformBillingConfig } from './config.js';
+import logger from '../logger.js';
+
+function getStripeClient() {
+  const cfg = requirePlatformBillingConfig();
+  return new Stripe(cfg.stripeSecretKey, { apiVersion: cfg.stripeApiVersion });
+}
+
+export async function createCustomer({ billing_email, company_name, metadata = {} }) {
+  const stripe = getStripeClient();
+  const customer = await stripe.customers.create({
+    email: billing_email || undefined,
+    name: company_name || undefined,
+    metadata,
+  });
+  return { id: customer.id };
+}
+
+export async function createCheckoutSession({
+  customer_id,
+  amount_cents,
+  currency,
+  description,
+  success_url,
+  cancel_url,
+  metadata = {},
+}) {
+  if (!success_url || !cancel_url) {
+    throw new Error('createCheckoutSession: success_url and cancel_url required');
+  }
+  if (!amount_cents || amount_cents <= 0) {
+    throw new Error('createCheckoutSession: amount_cents must be > 0');
+  }
+
+  const stripe = getStripeClient();
+  const cfg = requirePlatformBillingConfig();
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'payment',
+    payment_method_types: ['card'],
+    customer: customer_id || undefined,
+    line_items: [
+      {
+        quantity: 1,
+        price_data: {
+          currency: currency || cfg.defaultCurrency,
+          unit_amount: amount_cents,
+          product_data: {
+            name: description || 'AiSHA Platform Billing',
+          },
+        },
+      },
+    ],
+    metadata,
+    success_url,
+    cancel_url,
+  });
+
+  return { id: session.id, url: session.url };
+}
+
+export async function createPortalSession({ customer_id, return_url }) {
+  if (!customer_id) throw new Error('createPortalSession: customer_id required');
+  if (!return_url) throw new Error('createPortalSession: return_url required');
+
+  const stripe = getStripeClient();
+  const session = await stripe.billingPortal.sessions.create({
+    customer: customer_id,
+    return_url,
+  });
+  return { url: session.url };
+}
+
+/**
+ * Verify Stripe webhook signature against the PLATFORM webhook secret.
+ * Throws on invalid signature.
+ */
+export function verifyWebhookSignature({ rawBody, signature }) {
+  if (!rawBody) throw new Error('verifyWebhookSignature: rawBody required');
+  if (!signature) throw new Error('verifyWebhookSignature: signature required');
+
+  const cfg = requirePlatformBillingConfig();
+  const stripe = new Stripe(cfg.stripeSecretKey, { apiVersion: cfg.stripeApiVersion });
+
+  try {
+    const event = stripe.webhooks.constructEvent(rawBody, signature, cfg.stripeWebhookSecret);
+    return { event };
+  } catch (err) {
+    logger.warn({ err: err.message }, '[StripePlatformAdapter] Signature verification failed');
+    throw new Error(`Invalid platform webhook signature: ${err.message}`);
+  }
+}
+
+/**
+ * Normalize a Stripe event into the provider-agnostic shape.
+ * Returns null for unhandled event types.
+ */
+export function normalizePaymentEvent(event) {
+  if (!event || !event.type) return null;
+  const obj = event.data?.object || {};
+
+  const base = {
+    type: event.type,
+    tenant_id: obj.metadata?.tenant_id || obj.client_reference_id || null,
+    amount_cents: obj.amount_total ?? obj.amount ?? null,
+    currency: obj.currency || null,
+    payment_intent_id: obj.payment_intent || (obj.object === 'payment_intent' ? obj.id : null),
+    charge_id: obj.latest_charge || (obj.object === 'charge' ? obj.id : null),
+    metadata: obj.metadata || {},
+    raw_object_id: obj.id,
+  };
+
+  return base;
+}
+
+export default {
+  createCustomer,
+  createCheckoutSession,
+  createPortalSession,
+  verifyWebhookSignature,
+  normalizePaymentEvent,
+};

--- a/backend/lib/billing/stripePlatformAdapter.js
+++ b/backend/lib/billing/stripePlatformAdapter.js
@@ -92,7 +92,7 @@ export function verifyWebhookSignature({ rawBody, signature }) {
   if (!rawBody) throw new Error('verifyWebhookSignature: rawBody required');
   if (!signature) throw new Error('verifyWebhookSignature: signature required');
 
-  const cfg = requirePlatformBillingConfig();
+  const cfg = requirePlatformBillingConfig({ requireWebhookSecret: true });
   const stripe = new Stripe(cfg.stripeSecretKey, { apiVersion: cfg.stripeApiVersion });
 
   try {

--- a/backend/lib/billing/subscriptionService.js
+++ b/backend/lib/billing/subscriptionService.js
@@ -1,0 +1,221 @@
+/**
+ * Platform Billing -- Subscription Service
+ *
+ * Assigns plans to tenants, changes plans, and cancels subscriptions.
+ * Enforces the "only one non-canceled subscription per tenant" rule
+ * (also enforced at DB level via partial unique index).
+ */
+
+import logger from '../logger.js';
+import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
+import { syncTenantBillingState } from './billingStateMachine.js';
+
+function computeRenewalDate(interval, from = new Date()) {
+  const d = new Date(from);
+  if (interval === 'month') {
+    d.setUTCMonth(d.getUTCMonth() + 1);
+  } else if (interval === 'year') {
+    d.setUTCFullYear(d.getUTCFullYear() + 1);
+  } else {
+    return null; // one_time has no renewal
+  }
+  return d.toISOString();
+}
+
+/**
+ * Get the tenant's active (non-canceled) subscription, if any.
+ */
+export async function getActiveSubscription(supabase, tenantId) {
+  if (!tenantId) throw new Error('getActiveSubscription: tenantId required');
+  const { data, error } = await supabase
+    .from('tenant_subscriptions')
+    .select('*, billing_plans(*)')
+    .eq('tenant_id', tenantId)
+    .neq('status', 'canceled')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error) throw new Error(`getActiveSubscription: ${error.message}`);
+  return data;
+}
+
+/**
+ * Assign a billing plan to a tenant. Fails if tenant already has an
+ * active subscription -- use changePlan() for that.
+ *
+ * @param {object} supabase
+ * @param {object} params
+ * @param {string} params.tenant_id
+ * @param {string} params.plan_code             - e.g. 'starter_monthly'
+ * @param {string|null} [params.actor_id]
+ * @param {string} [params.provider_subscription_id]
+ * @param {string} [params.request_id]
+ */
+export async function assignPlan(supabase, params) {
+  const {
+    tenant_id,
+    plan_code,
+    actor_id = null,
+    provider_subscription_id = null,
+    request_id,
+  } = params;
+
+  if (!tenant_id) throw new Error('assignPlan: tenant_id required');
+  if (!plan_code) throw new Error('assignPlan: plan_code required');
+
+  const { data: plan, error: planErr } = await supabase
+    .from('billing_plans')
+    .select('*')
+    .eq('code', plan_code)
+    .eq('is_active', true)
+    .maybeSingle();
+  if (planErr) throw new Error(`assignPlan: ${planErr.message}`);
+  if (!plan) throw new Error(`assignPlan: plan "${plan_code}" not found or inactive`);
+
+  const existing = await getActiveSubscription(supabase, tenant_id);
+  if (existing) {
+    throw new Error('assignPlan: tenant already has an active subscription -- use changePlan()');
+  }
+
+  const start_date = new Date().toISOString();
+  const renewal_date = computeRenewalDate(plan.billing_interval);
+
+  const { data: sub, error: subErr } = await supabase
+    .from('tenant_subscriptions')
+    .insert({
+      tenant_id,
+      billing_plan_id: plan.id,
+      status: 'active',
+      start_date,
+      renewal_date,
+      provider_subscription_id,
+    })
+    .select('*')
+    .single();
+  if (subErr) throw new Error(`assignPlan: ${subErr.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.PLAN_ASSIGNED,
+    source: actor_id ? 'admin' : 'system',
+    actor_id,
+    payload: {
+      subscription_id: sub.id,
+      plan_code,
+      plan_id: plan.id,
+      amount_cents: plan.amount_cents,
+    },
+    request_id,
+  });
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.SUBSCRIPTION_CREATED,
+    source: actor_id ? 'admin' : 'system',
+    actor_id,
+    payload: { subscription_id: sub.id, plan_code },
+    request_id,
+  });
+
+  await syncTenantBillingState(supabase, tenant_id);
+  logger.info({ tenant_id, plan_code, subscription_id: sub.id }, '[Subscriptions] Plan assigned');
+
+  return sub;
+}
+
+/**
+ * Change a tenant's plan. Cancels existing active sub and creates a new one.
+ * Emits plan.changed.
+ */
+export async function changePlan(supabase, params) {
+  const { tenant_id, plan_code, actor_id = null, request_id } = params;
+
+  if (!tenant_id) throw new Error('changePlan: tenant_id required');
+  if (!plan_code) throw new Error('changePlan: plan_code required');
+
+  const existing = await getActiveSubscription(supabase, tenant_id);
+  if (!existing) {
+    throw new Error('changePlan: no active subscription -- use assignPlan()');
+  }
+
+  // Validate new plan exists before canceling old one
+  const { data: newPlan } = await supabase
+    .from('billing_plans')
+    .select('id, code, billing_interval, amount_cents, is_active')
+    .eq('code', plan_code)
+    .maybeSingle();
+  if (!newPlan || !newPlan.is_active) {
+    throw new Error(`changePlan: plan "${plan_code}" not found or inactive`);
+  }
+  if (newPlan.id === existing.billing_plan_id) {
+    throw new Error(`changePlan: tenant is already on "${plan_code}"`);
+  }
+
+  // Cancel existing
+  await supabase
+    .from('tenant_subscriptions')
+    .update({ status: 'canceled', canceled_at: new Date().toISOString() })
+    .eq('id', existing.id);
+
+  // Create new
+  const newSub = await assignPlan(supabase, { tenant_id, plan_code, actor_id, request_id });
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.PLAN_CHANGED,
+    source: actor_id ? 'admin' : 'system',
+    actor_id,
+    payload: {
+      from_subscription_id: existing.id,
+      to_subscription_id: newSub.id,
+      from_plan_id: existing.billing_plan_id,
+      to_plan_id: newPlan.id,
+      to_plan_code: plan_code,
+    },
+    request_id,
+  });
+
+  return newSub;
+}
+
+/**
+ * Cancel a tenant's active subscription.
+ */
+export async function cancelSubscription(supabase, { tenant_id, actor_id, request_id, reason }) {
+  if (!tenant_id) throw new Error('cancelSubscription: tenant_id required');
+  if (!actor_id) throw new Error('cancelSubscription: actor_id required');
+
+  const existing = await getActiveSubscription(supabase, tenant_id);
+  if (!existing) throw new Error('cancelSubscription: no active subscription');
+
+  const { data: canceled, error } = await supabase
+    .from('tenant_subscriptions')
+    .update({ status: 'canceled', canceled_at: new Date().toISOString() })
+    .eq('id', existing.id)
+    .select('*')
+    .single();
+  if (error) throw new Error(`cancelSubscription: ${error.message}`);
+
+  await logBillingEvent(supabase, {
+    tenant_id,
+    event_type: BILLING_EVENTS.SUBSCRIPTION_CANCELED,
+    source: 'admin',
+    actor_id,
+    payload: {
+      subscription_id: existing.id,
+      plan_id: existing.billing_plan_id,
+      reason: reason || null,
+    },
+    request_id,
+  });
+
+  await syncTenantBillingState(supabase, tenant_id);
+  return canceled;
+}
+
+export default {
+  getActiveSubscription,
+  assignPlan,
+  changePlan,
+  cancelSubscription,
+};

--- a/backend/lib/billing/subscriptionService.js
+++ b/backend/lib/billing/subscriptionService.js
@@ -139,11 +139,14 @@ export async function changePlan(supabase, params) {
   }
 
   // Validate new plan exists before canceling old one
-  const { data: newPlan } = await supabase
+  const { data: newPlan, error: newPlanError } = await supabase
     .from('billing_plans')
     .select('id, code, billing_interval, amount_cents, is_active')
     .eq('code', plan_code)
     .maybeSingle();
+  if (newPlanError) {
+    throw new Error(`changePlan: ${newPlanError.message}`);
+  }
   if (!newPlan || !newPlan.is_active) {
     throw new Error(`changePlan: plan "${plan_code}" not found or inactive`);
   }
@@ -152,13 +155,26 @@ export async function changePlan(supabase, params) {
   }
 
   // Cancel existing
-  await supabase
+  const { error: cancelError } = await supabase
     .from('tenant_subscriptions')
     .update({ status: 'canceled', canceled_at: new Date().toISOString() })
     .eq('id', existing.id);
+  if (cancelError) {
+    throw new Error(`changePlan: failed to cancel existing subscription: ${cancelError.message}`);
+  }
 
-  // Create new
-  const newSub = await assignPlan(supabase, { tenant_id, plan_code, actor_id, request_id });
+  // Create new -- rollback cancel on failure
+  let newSub;
+  try {
+    newSub = await assignPlan(supabase, { tenant_id, plan_code, actor_id, request_id });
+  } catch (assignErr) {
+    // Attempt to restore old subscription
+    await supabase
+      .from('tenant_subscriptions')
+      .update({ status: existing.status, canceled_at: null })
+      .eq('id', existing.id);
+    throw new Error(`changePlan: assignPlan failed, rolled back cancel: ${assignErr.message}`);
+  }
 
   await logBillingEvent(supabase, {
     tenant_id,

--- a/backend/migrations/154_platform_billing_foundation.sql
+++ b/backend/migrations/154_platform_billing_foundation.sql
@@ -1,0 +1,497 @@
+-- Migration 154: Platform Billing Foundation (Phase 1)
+--
+-- Purpose: Establish the durable billing foundation that lets AiSHA charge
+--          tenant organizations, accept payments, display invoices in the tenant
+--          portal, and support billing exemptions.
+--
+-- Impact: ADDITIVE ONLY -- no existing tables modified except a new nullable
+--         column added to `tenant` (billing_state).
+--
+-- Apply to: dev (efzqxjpfewkrgpdootte) FIRST, then prod (ehjlenywplgyiahgxkfj)
+--
+-- Domain scope: PLATFORM BILLING ONLY (AiSHA <-> tenant). Does NOT touch the
+--               Cal.com tenant<->client flow (session_packages, session_credits,
+--               booking_sessions, stripe-webhook.js at /api/webhooks/stripe).
+--
+-- Tables created:
+--   - billing_plans               (catalog of plans offered by AiSHA)
+--   - billing_accounts            (one per tenant -- contact/company/tax/exemption)
+--   - tenant_subscriptions        (active plan assignment per tenant)
+--   - invoices                    (platform-issued invoices)
+--   - invoice_line_items          (line items per invoice)
+--   - payments                    (payment attempts and captures)
+--   - billing_events              (immutable audit log of all billing actions)
+--
+-- Column added:
+--   - tenant.billing_state TEXT   (derived/cached state label; source of truth
+--                                  lives in tenant_subscriptions + billing_accounts)
+--
+-- Decisions locked:
+--   - Exemption scope: boolean flag (billing_accounts.billing_exempt + reason).
+--   - Platform Stripe credentials: NOT stored here -- read from Doppler
+--     (STRIPE_PLATFORM_SECRET_KEY, STRIPE_PLATFORM_WEBHOOK_SECRET).
+--     tenant_integrations remains Cal.com-only.
+
+BEGIN;
+
+-- =============================================================================
+-- tenant.billing_state column
+-- =============================================================================
+-- Derived cache only. Authoritative state is computed from tenant_subscriptions
+-- + billing_accounts.billing_exempt. Held here for cheap read access and for
+-- suspension middleware to gate non-billing routes without a join.
+
+ALTER TABLE public.tenant
+    ADD COLUMN IF NOT EXISTS billing_state TEXT
+    DEFAULT 'active'
+    CHECK (billing_state IN (
+        'active',
+        'past_due',
+        'grace_period',
+        'suspended',
+        'billing_exempt',
+        'canceled'
+    ));
+
+CREATE INDEX IF NOT EXISTS idx_tenant_billing_state
+    ON public.tenant (billing_state)
+    WHERE billing_state <> 'active';
+
+COMMENT ON COLUMN public.tenant.billing_state IS
+    'Derived/cached platform billing state. Source of truth: tenant_subscriptions.status + billing_accounts.billing_exempt. Updated by billingStateMachine service.';
+
+-- =============================================================================
+-- billing_plans (platform-wide catalog)
+-- =============================================================================
+-- Not tenant-scoped: one catalog for the whole platform.
+
+CREATE TABLE IF NOT EXISTS public.billing_plans (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    description TEXT,
+    billing_interval TEXT NOT NULL
+        CHECK (billing_interval IN ('month', 'year', 'one_time')),
+    amount_cents INTEGER NOT NULL CHECK (amount_cents >= 0),
+    currency TEXT NOT NULL DEFAULT 'usd',
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    features_json JSONB NOT NULL DEFAULT '{}'::JSONB,
+    module_entitlements_json JSONB NOT NULL DEFAULT '{}'::JSONB,
+    seat_limit INTEGER,
+    usage_rules_json JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_billing_plans_active
+    ON public.billing_plans (is_active) WHERE is_active = true;
+
+COMMENT ON TABLE public.billing_plans IS
+    'Platform-wide catalog of plans AiSHA offers to tenants. Not tenant-scoped.';
+
+ALTER TABLE public.billing_plans ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS billing_plans_read_all ON public.billing_plans;
+CREATE POLICY billing_plans_read_all ON public.billing_plans
+    FOR SELECT USING (is_active = true);
+
+DROP POLICY IF EXISTS billing_plans_service_role ON public.billing_plans;
+CREATE POLICY billing_plans_service_role ON public.billing_plans
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- billing_accounts
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.billing_accounts (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL UNIQUE
+        REFERENCES public.tenant(id) ON DELETE CASCADE,
+
+    -- Billing contact
+    billing_contact_name TEXT,
+    billing_email TEXT,
+    company_name TEXT,
+    billing_address JSONB NOT NULL DEFAULT '{}'::JSONB,
+    tax_id TEXT,
+    currency TEXT NOT NULL DEFAULT 'usd',
+
+    -- Provider binding
+    payment_provider TEXT NOT NULL DEFAULT 'stripe'
+        CHECK (payment_provider IN ('stripe', 'manual')),
+    provider_customer_id TEXT,
+
+    -- Billing mode
+    -- MVP: boolean exemption only. `billing_mode` retained for forward
+    -- compatibility but constrained to two values for now.
+    billing_mode TEXT NOT NULL DEFAULT 'standard_billing'
+        CHECK (billing_mode IN ('standard_billing', 'manual_billing')),
+
+    -- Exemption (boolean flag + audit trail)
+    billing_exempt BOOLEAN NOT NULL DEFAULT false,
+    exempt_reason TEXT,
+    exempt_set_by UUID,  -- references users(id), not enforced here to avoid migration order coupling
+    exempt_set_at TIMESTAMPTZ,
+
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- If exempt, we require a reason and an actor for audit safety
+    CONSTRAINT billing_accounts_exempt_audit_required
+        CHECK (
+            billing_exempt = false
+            OR (exempt_reason IS NOT NULL AND exempt_set_by IS NOT NULL AND exempt_set_at IS NOT NULL)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_billing_accounts_tenant
+    ON public.billing_accounts (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_billing_accounts_exempt
+    ON public.billing_accounts (billing_exempt) WHERE billing_exempt = true;
+CREATE INDEX IF NOT EXISTS idx_billing_accounts_provider_customer
+    ON public.billing_accounts (provider_customer_id)
+    WHERE provider_customer_id IS NOT NULL;
+
+COMMENT ON TABLE public.billing_accounts IS
+    'One per tenant. Billing profile + exemption state.';
+COMMENT ON COLUMN public.billing_accounts.billing_exempt IS
+    'If true, tenant is indefinitely exempt from platform billing. No invoices generated, no dunning, no suspension. Requires reason + actor + timestamp.';
+
+ALTER TABLE public.billing_accounts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS billing_accounts_tenant_read ON public.billing_accounts;
+CREATE POLICY billing_accounts_tenant_read ON public.billing_accounts
+    FOR SELECT USING (
+        tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+    );
+
+DROP POLICY IF EXISTS billing_accounts_service_role ON public.billing_accounts;
+CREATE POLICY billing_accounts_service_role ON public.billing_accounts
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- tenant_subscriptions
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tenant_subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL
+        REFERENCES public.tenant(id) ON DELETE CASCADE,
+    billing_plan_id UUID NOT NULL
+        REFERENCES public.billing_plans(id) ON DELETE RESTRICT,
+
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN (
+            'draft',
+            'active',
+            'past_due',
+            'grace_period',
+            'suspended',
+            'canceled'
+        )),
+
+    provider_subscription_id TEXT,
+    start_date TIMESTAMPTZ NOT NULL DEFAULT now(),
+    renewal_date TIMESTAMPTZ,
+    canceled_at TIMESTAMPTZ,
+    grace_period_ends_at TIMESTAMPTZ,
+    suspended_at TIMESTAMPTZ,
+
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Only one non-canceled subscription per tenant at a time
+CREATE UNIQUE INDEX IF NOT EXISTS uq_tenant_subscriptions_one_active
+    ON public.tenant_subscriptions (tenant_id)
+    WHERE status <> 'canceled';
+
+CREATE INDEX IF NOT EXISTS idx_tenant_subscriptions_tenant
+    ON public.tenant_subscriptions (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_tenant_subscriptions_status
+    ON public.tenant_subscriptions (status) WHERE status <> 'canceled';
+CREATE INDEX IF NOT EXISTS idx_tenant_subscriptions_renewal
+    ON public.tenant_subscriptions (renewal_date)
+    WHERE status IN ('active', 'past_due', 'grace_period');
+CREATE INDEX IF NOT EXISTS idx_tenant_subscriptions_provider
+    ON public.tenant_subscriptions (provider_subscription_id)
+    WHERE provider_subscription_id IS NOT NULL;
+
+ALTER TABLE public.tenant_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_subscriptions_tenant_read ON public.tenant_subscriptions;
+CREATE POLICY tenant_subscriptions_tenant_read ON public.tenant_subscriptions
+    FOR SELECT USING (
+        tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+    );
+
+DROP POLICY IF EXISTS tenant_subscriptions_service_role ON public.tenant_subscriptions;
+CREATE POLICY tenant_subscriptions_service_role ON public.tenant_subscriptions
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- invoices
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.invoices (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL
+        REFERENCES public.tenant(id) ON DELETE CASCADE,
+    subscription_id UUID
+        REFERENCES public.tenant_subscriptions(id) ON DELETE SET NULL,
+
+    invoice_number TEXT NOT NULL,
+    issue_date TIMESTAMPTZ NOT NULL DEFAULT now(),
+    due_date TIMESTAMPTZ NOT NULL,
+
+    status TEXT NOT NULL DEFAULT 'draft'
+        CHECK (status IN (
+            'draft',
+            'open',
+            'paid',
+            'void',
+            'uncollectible'
+        )),
+
+    subtotal_cents INTEGER NOT NULL DEFAULT 0 CHECK (subtotal_cents >= 0),
+    tax_total_cents INTEGER NOT NULL DEFAULT 0 CHECK (tax_total_cents >= 0),
+    total_cents INTEGER NOT NULL DEFAULT 0 CHECK (total_cents >= 0),
+    amount_paid_cents INTEGER NOT NULL DEFAULT 0 CHECK (amount_paid_cents >= 0),
+    balance_due_cents INTEGER NOT NULL DEFAULT 0,
+
+    currency TEXT NOT NULL DEFAULT 'usd',
+
+    external_invoice_id TEXT,
+    hosted_invoice_url TEXT,
+    pdf_url TEXT,
+    memo TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT invoices_unique_number_per_tenant UNIQUE (tenant_id, invoice_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoices_tenant
+    ON public.invoices (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_status
+    ON public.invoices (status) WHERE status IN ('open', 'draft');
+CREATE INDEX IF NOT EXISTS idx_invoices_due_date
+    ON public.invoices (due_date) WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_invoices_subscription
+    ON public.invoices (subscription_id) WHERE subscription_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_invoices_external
+    ON public.invoices (external_invoice_id) WHERE external_invoice_id IS NOT NULL;
+
+ALTER TABLE public.invoices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS invoices_tenant_read ON public.invoices;
+CREATE POLICY invoices_tenant_read ON public.invoices
+    FOR SELECT USING (
+        tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+    );
+
+DROP POLICY IF EXISTS invoices_service_role ON public.invoices;
+CREATE POLICY invoices_service_role ON public.invoices
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- invoice_line_items
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.invoice_line_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    invoice_id UUID NOT NULL
+        REFERENCES public.invoices(id) ON DELETE CASCADE,
+    item_type TEXT NOT NULL
+        CHECK (item_type IN ('subscription', 'setup_fee', 'usage', 'adjustment', 'credit', 'discount')),
+    description TEXT NOT NULL,
+    quantity INTEGER NOT NULL DEFAULT 1 CHECK (quantity > 0),
+    unit_price_cents INTEGER NOT NULL,
+    amount_cents INTEGER NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoice_line_items_invoice
+    ON public.invoice_line_items (invoice_id);
+
+ALTER TABLE public.invoice_line_items ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS invoice_line_items_tenant_read ON public.invoice_line_items;
+CREATE POLICY invoice_line_items_tenant_read ON public.invoice_line_items
+    FOR SELECT USING (
+        invoice_id IN (
+            SELECT id FROM public.invoices
+            WHERE tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+        )
+    );
+
+DROP POLICY IF EXISTS invoice_line_items_service_role ON public.invoice_line_items;
+CREATE POLICY invoice_line_items_service_role ON public.invoice_line_items
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- payments
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.payments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL
+        REFERENCES public.tenant(id) ON DELETE CASCADE,
+    invoice_id UUID
+        REFERENCES public.invoices(id) ON DELETE SET NULL,
+
+    amount_cents INTEGER NOT NULL CHECK (amount_cents >= 0),
+    currency TEXT NOT NULL DEFAULT 'usd',
+    status TEXT NOT NULL
+        CHECK (status IN ('pending', 'succeeded', 'failed', 'refunded', 'partially_refunded')),
+
+    provider_payment_intent_id TEXT,
+    provider_charge_id TEXT,
+    payment_method_type TEXT,
+    paid_at TIMESTAMPTZ,
+    receipt_url TEXT,
+    failure_reason TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Idempotency: a given Stripe payment_intent produces exactly one payment row
+CREATE UNIQUE INDEX IF NOT EXISTS uq_payments_provider_payment_intent
+    ON public.payments (provider_payment_intent_id)
+    WHERE provider_payment_intent_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_payments_tenant
+    ON public.payments (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_payments_invoice
+    ON public.payments (invoice_id) WHERE invoice_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_payments_status
+    ON public.payments (status);
+
+ALTER TABLE public.payments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS payments_tenant_read ON public.payments;
+CREATE POLICY payments_tenant_read ON public.payments
+    FOR SELECT USING (
+        tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+    );
+
+DROP POLICY IF EXISTS payments_service_role ON public.payments;
+CREATE POLICY payments_service_role ON public.payments
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- billing_events (immutable audit log)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.billing_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID
+        REFERENCES public.tenant(id) ON DELETE CASCADE,
+
+    event_type TEXT NOT NULL,
+    -- Canonical event types (enforced at app layer):
+    --   invoice.created, invoice.sent, invoice.past_due, invoice.paid, invoice.voided
+    --   payment.received, payment.failed, payment.refunded
+    --   subscription.created, subscription.canceled, subscription.renewed
+    --   tenant.suspension_warning, tenant.suspended, tenant.unsuspended
+    --   tenant.billing_exempt_set, tenant.billing_exempt_removed
+    --   plan.assigned, plan.changed
+
+    source TEXT NOT NULL
+        CHECK (source IN ('system', 'admin', 'webhook', 'api')),
+    actor_id UUID,
+    payload_json JSONB NOT NULL DEFAULT '{}'::JSONB,
+    request_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_billing_events_tenant
+    ON public.billing_events (tenant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_billing_events_type
+    ON public.billing_events (event_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_billing_events_actor
+    ON public.billing_events (actor_id, created_at DESC)
+    WHERE actor_id IS NOT NULL;
+
+-- Immutable: no UPDATE, no DELETE. Enforce with trigger.
+CREATE OR REPLACE FUNCTION public.billing_events_prevent_modification()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'billing_events is append-only -- % not permitted', TG_OP;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_billing_events_no_update ON public.billing_events;
+CREATE TRIGGER trg_billing_events_no_update
+    BEFORE UPDATE OR DELETE ON public.billing_events
+    FOR EACH ROW EXECUTE FUNCTION public.billing_events_prevent_modification();
+
+ALTER TABLE public.billing_events ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS billing_events_tenant_read ON public.billing_events;
+CREATE POLICY billing_events_tenant_read ON public.billing_events
+    FOR SELECT USING (
+        tenant_id = (current_setting('app.current_tenant_id', true))::uuid
+    );
+
+DROP POLICY IF EXISTS billing_events_service_role ON public.billing_events;
+CREATE POLICY billing_events_service_role ON public.billing_events
+    TO service_role USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- updated_at triggers
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.billing_set_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$;
+
+DO $$
+DECLARE
+    t TEXT;
+BEGIN
+    FOREACH t IN ARRAY ARRAY[
+        'billing_plans',
+        'billing_accounts',
+        'tenant_subscriptions',
+        'invoices',
+        'payments'
+    ]
+    LOOP
+        EXECUTE format(
+            'DROP TRIGGER IF EXISTS trg_%I_set_updated_at ON public.%I;
+             CREATE TRIGGER trg_%I_set_updated_at
+                BEFORE UPDATE ON public.%I
+                FOR EACH ROW EXECUTE FUNCTION public.billing_set_updated_at();',
+            t, t, t, t
+        );
+    END LOOP;
+END $$;
+
+-- =============================================================================
+-- Seed default plans (idempotent)
+-- =============================================================================
+
+INSERT INTO public.billing_plans (code, name, description, billing_interval, amount_cents, currency, is_active)
+VALUES
+    ('starter_monthly',    'Starter',    'Entry tier -- CRM core + AI assistant', 'month', 4900,  'usd', true),
+    ('growth_monthly',     'Growth',     'Starter + workflows + campaigns',       'month', 14900, 'usd', true),
+    ('pro_monthly',        'Pro',        'Growth + CARE + multi-team',            'month', 29900, 'usd', true)
+ON CONFLICT (code) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Platform Billing Foundation — Phase 1

Adds the core billing infrastructure for AiSHA CRM platform billing. This is an **additive-only** change — no existing tables or features are modified.

### Migration 154: Billing Schema

7 new tables with full RLS and tenant isolation:

| Table | Purpose |
|-------|---------|
| `billing_plans` | Plan definitions (starter, growth, pro) |
| `billing_accounts` | Per-tenant billing accounts linked to Stripe |
| `tenant_subscriptions` | Active subscriptions with plan/period tracking |
| `invoices` | Invoice records with status lifecycle |
| `invoice_line_items` | Line-item detail per invoice |
| `payments` | Payment records linked to invoices |
| `billing_events` | Immutable audit log of all billing events |

Also adds `billing_state` column to `tenants` table with allowed values: `active`, `past_due`, `grace_period`, `suspended`, `billing_exempt`, `canceled` (default: `active`).

### Service Layer (`backend/lib/billing/`)

- **billingAccountService** — create/get/update billing accounts
- **billingStateMachine** — enforces valid state transitions with audit trail
- **subscriptionService** — subscription CRUD with plan changes
- **invoiceService** — invoice generation with line items
- **paymentProvider** — abstract payment interface
- **stripePlatformAdapter** — Stripe integration (customer/subscription/payment intent)
- **billingEventLogger** — immutable event logging
- **config** — centralized billing configuration

### Tests (8 files)

- Unit tests for all billing services
- Schema alignment test verifying migration 154 applied correctly
- Domain separation validation (billing tables don&#39;t touch Cal.com tables)
- All 2350 backend tests pass (0 failures)

### Key Design Decisions

- **Domain separation**: Billing tables are completely separate from Cal.com scheduling tables
- **Immutable audit**: `billing_events` table has UPDATE/DELETE triggers that raise exceptions
- **State machine**: Tenant billing state transitions are validated and logged
- **Stripe-ready**: Platform adapter follows Stripe API patterns but is behind an abstract interface
- **Default plans seeded**: 3 plans (starter_monthly / growth_monthly / pro_monthly) inserted by migration