### PR TITLE
fix(billing): address PR #517 review comments (follow-up)

### DIFF
--- a/backend/__tests__/billing/billingEventLogger.test.js
+++ b/backend/__tests__/billing/billingEventLogger.test.js
@@ -41,9 +41,14 @@ function mockSupabase({ insertResult = null, insertError = null } = {}) {
 }
 
 describe('billingEventLogger -- BILLING_EVENTS constants', () => {
-  it('exports all 18 canonical event types', () => {
-    // 5 invoice + 3 payment + 3 subscription + 5 tenant + 2 plan = 18
-    assert.equal(VALID_EVENT_TYPES.size, 18);
+  it('exports all 19 canonical event types', () => {
+    // 5 invoice + 3 payment + 4 subscription + 5 tenant + 2 plan = 19
+    assert.equal(VALID_EVENT_TYPES.size, 19);
+  });
+
+  it('includes subscription.status_changed (added PR #517)', () => {
+    assert.ok(VALID_EVENT_TYPES.has('subscription.status_changed'));
+    assert.equal(BILLING_EVENTS.SUBSCRIPTION_STATUS_CHANGED, 'subscription.status_changed');
   });
 
   it('all event types are dotted namespace.action form', () => {

--- a/backend/__tests__/billing/invoiceService.test.js
+++ b/backend/__tests__/billing/invoiceService.test.js
@@ -356,3 +356,130 @@ describe('invoiceService -- voidInvoice', () => {
     await assert.rejects(() => voidInvoice(mock, { invoice_id: invoice.id }), /actor_id required/);
   });
 });
+
+describe('invoiceService -- sumLineItems NaN safety (PR #517 issue 6)', () => {
+  it('does NOT produce NaN when amount_cents and quantity are both missing', async () => {
+    const mock = fresh();
+    // Line item missing BOTH amount_cents and quantity -- previously this
+    // reduced to `undefined * N` => NaN propagating into subtotal/total.
+    // Fixed behaviour: treat missing quantity as 1.
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [{ item_type: 'subscription', description: 'S', unit_price_cents: 4900 }],
+    });
+    assert.equal(invoice.subtotal_cents, 4900);
+    assert.equal(invoice.total_cents, 4900);
+    assert.ok(!Number.isNaN(invoice.subtotal_cents), 'subtotal must not be NaN');
+  });
+
+  it('treats missing unit_price_cents as 0 (no NaN propagation)', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        { item_type: 'subscription', description: 'S', unit_price_cents: 500 },
+        { item_type: 'adjustment', description: 'Free item', quantity: 2 },
+      ],
+    });
+    // 500 + (2 * 0) == 500
+    assert.equal(invoice.subtotal_cents, 500);
+  });
+
+  it('prefers explicit amount_cents over quantity*unit_price_cents', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [
+        {
+          item_type: 'adjustment',
+          description: 'Override',
+          quantity: 10,
+          unit_price_cents: 999,
+          amount_cents: 1234,
+        },
+      ],
+    });
+    assert.equal(invoice.subtotal_cents, 1234);
+  });
+});
+
+describe('invoiceService -- BillingError propagation (PR #517 issue 4)', () => {
+  it('throws BillingError with code=INVALID_INPUT on missing tenant_id', async () => {
+    const mock = fresh();
+    const { BillingError, BILLING_ERROR_CODES } = await import('../../lib/billing/errors.js');
+    await assert.rejects(
+      () =>
+        createInvoice(mock, {
+          line_items: [{ item_type: 's', description: 'x', quantity: 1, unit_price_cents: 1 }],
+        }),
+      (err) =>
+        err instanceof BillingError &&
+        err.statusCode === 400 &&
+        err.code === BILLING_ERROR_CODES.INVALID_INPUT,
+    );
+  });
+
+  it('throws BillingError with code=EXEMPT when tenant is billing-exempt', async () => {
+    const mock = fresh();
+    mock.db.billing_accounts = [
+      {
+        id: 'ba',
+        tenant_id: TENANT,
+        billing_exempt: true,
+        exempt_reason: 'pilot',
+        exempt_set_by: 'u',
+        exempt_set_at: new Date().toISOString(),
+      },
+    ];
+    const { BillingError, BILLING_ERROR_CODES } = await import('../../lib/billing/errors.js');
+    await assert.rejects(
+      () =>
+        createInvoice(mock, {
+          tenant_id: TENANT,
+          line_items: [{ item_type: 's', description: 'x', quantity: 1, unit_price_cents: 1 }],
+        }),
+      (err) =>
+        err instanceof BillingError &&
+        err.statusCode === 409 &&
+        err.code === BILLING_ERROR_CODES.EXEMPT,
+    );
+  });
+
+  it('throws BillingError with code=NOT_FOUND when voiding a missing invoice', async () => {
+    const mock = fresh();
+    const { BillingError, BILLING_ERROR_CODES } = await import('../../lib/billing/errors.js');
+    await assert.rejects(
+      () =>
+        voidInvoice(mock, {
+          invoice_id: '00000000-0000-0000-0000-000000000000',
+          actor_id: ACTOR,
+        }),
+      (err) =>
+        err instanceof BillingError &&
+        err.statusCode === 404 &&
+        err.code === BILLING_ERROR_CODES.NOT_FOUND,
+    );
+  });
+
+  it('throws BillingError with code=INVOICE_PAID when voiding a paid invoice', async () => {
+    const mock = fresh();
+    const { invoice } = await createInvoice(mock, {
+      tenant_id: TENANT,
+      line_items: [{ item_type: 's', description: 'x', quantity: 1, unit_price_cents: 100 }],
+    });
+    await issueInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR });
+    await recordPayment(mock, {
+      invoice_id: invoice.id,
+      amount_cents: 100,
+      provider_payment_intent_id: 'pi_paid',
+    });
+    const { BillingError, BILLING_ERROR_CODES } = await import('../../lib/billing/errors.js');
+    await assert.rejects(
+      () => voidInvoice(mock, { invoice_id: invoice.id, actor_id: ACTOR }),
+      (err) =>
+        err instanceof BillingError &&
+        err.statusCode === 400 &&
+        err.code === BILLING_ERROR_CODES.INVOICE_PAID,
+    );
+  });
+});

--- a/backend/__tests__/routes/billing-admin.routes.test.js
+++ b/backend/__tests__/routes/billing-admin.routes.test.js
@@ -147,7 +147,7 @@ describe('Subscription management', () => {
     const res = await request(buildApp(superadmin))
       .post(`/api/billing-admin/tenants/${TENANT}/subscription`)
       .send({ plan_code: 'growth_monthly' });
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 409); // PR #517: CONFLICT is the correct code
     assert.match(res.body.message, /already has/);
   });
 
@@ -231,7 +231,7 @@ describe('Invoice management', () => {
     assert.equal(res.body.data.invoice.total_cents, 4900);
   });
 
-  it('POST returns 400 when tenant is exempt', async () => {
+  it('POST returns 409 when tenant is exempt', async () => {
     await request(buildApp(superadmin))
       .post(`/api/billing-admin/tenants/${TENANT}/exemption`)
       .send({ reason: 'comp' });
@@ -242,7 +242,7 @@ describe('Invoice management', () => {
           { item_type: 'subscription', description: 'x', quantity: 1, unit_price_cents: 100 },
         ],
       });
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 409); // PR #517: EXEMPT -> 409 Conflict
     assert.match(res.body.message, /exempt/);
   });
 
@@ -308,5 +308,76 @@ describe('GET /tenants/:tenantId/events audit trail', () => {
     assert.ok(res.body.data.length > 0);
     const types = res.body.data.map((e) => e.event_type);
     assert.ok(types.includes('plan.assigned'));
+  });
+});
+
+describe('GET /tenants/:tenantId -- unknown tenant (PR #517 issue 1)', () => {
+  it('returns 404 for unknown tenant (not 500)', async () => {
+    const UNKNOWN = '99999999-9999-9999-9999-999999999999';
+    const res = await request(buildApp(superadmin)).get(`/api/billing-admin/tenants/${UNKNOWN}`);
+    assert.equal(res.status, 404);
+    assert.equal(res.body.status, 'error');
+    assert.match(res.body.message, /Tenant not found/);
+    // No billing_accounts row should have been created for the unknown tenant
+    const created = mockClient.db.billing_accounts.find((a) => a.tenant_id === UNKNOWN);
+    assert.equal(created, undefined, 'billing_accounts must not be created for unknown tenant');
+  });
+
+  it('returns 200 with billing summary when tenant exists', async () => {
+    const res = await request(buildApp(superadmin)).get(`/api/billing-admin/tenants/${TENANT}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, 'success');
+    assert.equal(res.body.data.tenant.id, TENANT);
+    assert.ok(res.body.data.billing_account);
+  });
+});
+
+describe('BillingError code surfacing in responses (PR #517 issue 4)', () => {
+  it('POST subscription twice -> 409 CONFLICT with code in body', async () => {
+    await request(buildApp(superadmin))
+      .post(`/api/billing-admin/tenants/${TENANT}/subscription`)
+      .send({ plan_code: 'starter_monthly' });
+
+    const res = await request(buildApp(superadmin))
+      .post(`/api/billing-admin/tenants/${TENANT}/subscription`)
+      .send({ plan_code: 'growth_monthly' });
+
+    assert.equal(res.status, 409);
+    assert.equal(res.body.code, 'CONFLICT');
+    assert.match(res.body.message, /already has an active subscription/);
+  });
+
+  it('POST invoice on billing-exempt tenant -> 409 EXEMPT', async () => {
+    // Mark tenant billing-exempt
+    await request(buildApp(superadmin))
+      .post(`/api/billing-admin/tenants/${TENANT}/exemption`)
+      .send({ reason: 'pilot account' });
+
+    const res = await request(buildApp(superadmin))
+      .post(`/api/billing-admin/tenants/${TENANT}/invoices`)
+      .send({
+        line_items: [
+          { item_type: 'subscription', description: 'x', quantity: 1, unit_price_cents: 100 },
+        ],
+      });
+
+    assert.equal(res.status, 409);
+    assert.equal(res.body.code, 'EXEMPT');
+  });
+
+  it('POST subscription with missing plan_code -> 400 INVALID_INPUT', async () => {
+    const res = await request(buildApp(superadmin))
+      .post(`/api/billing-admin/tenants/${TENANT}/subscription`)
+      .send({});
+    assert.equal(res.status, 400);
+    assert.equal(res.body.code, 'INVALID_INPUT');
+  });
+
+  it('POST void on missing invoice -> 404 NOT_FOUND', async () => {
+    const res = await request(buildApp(superadmin))
+      .post(`/api/billing-admin/invoices/00000000-0000-0000-0000-000000000000/void`)
+      .send({ reason: 'test' });
+    assert.equal(res.status, 404);
+    assert.equal(res.body.code, 'NOT_FOUND');
   });
 });

--- a/backend/__tests__/routes/billing.routes.test.js
+++ b/backend/__tests__/routes/billing.routes.test.js
@@ -291,3 +291,66 @@ describe('POST /api/billing/portal-session', () => {
     assert.match(res.body.message, /No Stripe customer/);
   });
 });
+
+describe('resolveTenantId slug/UUID canonicalisation (PR #517 issue 2)', () => {
+  // After validateTenantAccess resolves the tenant, req.tenant is
+  //   { id: <uuid>, tenant_id: <slug>, name: <string> }.
+  // This test injects req.tenant directly to verify resolveTenantId
+  // accepts requests whose body/query carries the slug form, not just UUID.
+
+  const SLUG = 'acme-corp';
+
+  function buildAppWithCanonicalTenant(user, canonical) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.user = user;
+      req.tenant = canonical;
+      next();
+    });
+    app.use('/api/billing', createBillingRoutes(null, { getSupabaseClient: () => mockClient }));
+    return app;
+  }
+
+  it('accepts slug in body when middleware has resolved UUID in req.tenant.id', async () => {
+    const user = { id: 'u1', role: 'admin', tenant_uuid: TENANT, tenant_id: SLUG };
+    const app = buildAppWithCanonicalTenant(user, { id: TENANT, tenant_id: SLUG, name: 'Acme' });
+
+    // Previously: body.tenant_id=SLUG !== req.tenant.id=UUID -> 400 mismatch
+    // Now: resolveTenantId accepts either UUID or slug -> 200
+    const res = await request(app).get('/api/billing/account').query({ tenant_id: SLUG });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.status, 'success');
+    // Downstream DB was queried with canonical UUID, not slug
+    const account = mockClient.db.billing_accounts.find((a) => a.tenant_id === TENANT);
+    assert.ok(account, 'billing_account must be created under canonical UUID');
+  });
+
+  it('accepts UUID in body when middleware has resolved UUID in req.tenant.id', async () => {
+    const user = { id: 'u1', role: 'admin', tenant_uuid: TENANT, tenant_id: SLUG };
+    const app = buildAppWithCanonicalTenant(user, { id: TENANT, tenant_id: SLUG, name: 'Acme' });
+    const res = await request(app).get('/api/billing/account').query({ tenant_id: TENANT });
+    assert.equal(res.status, 200);
+  });
+
+  it('still returns 400 mismatch when body tenant_id is a DIFFERENT tenant', async () => {
+    const user = { id: 'u1', role: 'admin', tenant_uuid: TENANT, tenant_id: SLUG };
+    const app = buildAppWithCanonicalTenant(user, { id: TENANT, tenant_id: SLUG, name: 'Acme' });
+    const res = await request(app)
+      .get('/api/billing/account')
+      .query({ tenant_id: 'different-slug' });
+    assert.equal(res.status, 400);
+    assert.match(res.body.message, /tenant_id mismatch/);
+  });
+
+  it('returns 400 tenant_id required when superadmin has no tenant selected', async () => {
+    // Superadmins are the only role that can reach resolveTenantId without
+    // validateTenantAccess having populated req.tenant, because the middleware
+    // only auto-injects tenant_id for non-superadmin roles and 403s admins
+    // without a tenant_uuid.
+    const superadmin = { id: 'sa', role: 'superadmin', tenant_uuid: null, tenant_id: null };
+    const res = await request(buildApp(superadmin)).get('/api/billing/account');
+    assert.equal(res.status, 400);
+    assert.match(res.body.message, /tenant_id is required/);
+  });
+});

--- a/backend/__tests__/routes/stripe-platform-webhook.test.js
+++ b/backend/__tests__/routes/stripe-platform-webhook.test.js
@@ -525,3 +525,240 @@ describe('customer.subscription.deleted', () => {
     assert.equal(mockClient.db.tenant_subscriptions[0].status, 'active');
   });
 });
+
+describe('Webhook preflight: missing webhook secret (PR #517 issue 7)', () => {
+  it('returns 503 when STRIPE_PLATFORM_WEBHOOK_SECRET is missing (not 400)', async () => {
+    process.env.STRIPE_PLATFORM_SECRET_KEY = 'sk_test_placeholder';
+    delete process.env.STRIPE_PLATFORM_WEBHOOK_SECRET;
+    // Previously: verifyWebhookSignature would throw on missing secret and
+    // the catch mapped it to 400 "Invalid signature" — misleading operators.
+    // Fixed: explicit preflight returns 503 misconfiguration.
+    const res = await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from('{}'));
+    assert.equal(res.status, 503);
+    assert.match(res.body.error, /webhook secret not configured/i);
+  });
+});
+
+describe('checkout.session.completed assignPlan error propagation (PR #517 issue 3)', () => {
+  it('re-throws non-race assignPlan errors -> 500 so Stripe retries', async () => {
+    // Set up: NO matching plan so assignPlan will throw an INACTIVE_PLAN
+    // BillingError (message: plan "ghost_plan" not found or inactive).
+    // Previously the catch swallowed this as "race" and returned 200.
+    stubbedEvent = {
+      id: 'evt_ck_err_1',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_err',
+          metadata: { tenant_id: TENANT, plan_code: 'ghost_plan' },
+          subscription: 'sub_x',
+          payment_intent: null,
+          amount_total: 0,
+        },
+      },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'checkout.session.completed' };
+
+    const res = await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    assert.equal(res.status, 500);
+    assert.match(res.body.error, /not found or inactive/);
+    // No subscription should have been silently "recorded"
+    assert.equal(mockClient.db.tenant_subscriptions.length, 0);
+  });
+
+  it('swallows race error when tenant already has an active subscription', async () => {
+    // Seed an existing active subscription for the tenant
+    mockClient.db.tenant_subscriptions.push({
+      id: 'sub_existing',
+      tenant_id: TENANT,
+      billing_plan_id: 'p1',
+      status: 'active',
+      provider_subscription_id: null,
+      created_at: '2026-01-01',
+    });
+    // Seed an open invoice so the payment recording path has something to attach to
+    mockClient.db.invoices.push({
+      id: 'inv_race',
+      tenant_id: TENANT,
+      status: 'open',
+      total_cents: 4900,
+      amount_paid_cents: 0,
+      balance_due_cents: 4900,
+      currency: 'usd',
+      created_at: '2026-01-01',
+    });
+
+    stubbedEvent = {
+      id: 'evt_ck_race_1',
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_race',
+          metadata: { tenant_id: TENANT, plan_code: 'starter_monthly' },
+          subscription: 'sub_new',
+          payment_intent: 'pi_race',
+          amount_total: 4900,
+        },
+      },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'checkout.session.completed' };
+
+    // The webhook checks existingActive first, so it won't even call
+    // assignPlan. This test confirms the happy "already has subscription"
+    // path still returns 200 and records payment.
+    const res = await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    assert.equal(res.status, 200);
+    const payment = mockClient.db.payments.find((p) => p.provider_payment_intent_id === 'pi_race');
+    assert.ok(payment, 'payment must be recorded despite existing subscription');
+  });
+});
+
+describe('customer.subscription.updated event type (PR #517 issue 5)', () => {
+  beforeEach(() => {
+    mockClient.db.tenant_subscriptions.push({
+      id: 'sub_evt_1',
+      tenant_id: TENANT,
+      billing_plan_id: 'p1',
+      status: 'active',
+      provider_subscription_id: 'sub_stripe_evt_1',
+      created_at: '2026-01-01',
+    });
+  });
+
+  it('emits SUBSCRIPTION_STATUS_CHANGED (not RENEWED) on active -> past_due', async () => {
+    stubbedEvent = {
+      id: 'evt_status_1',
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_stripe_evt_1', status: 'past_due', cancel_at_period_end: false } },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'customer.subscription.updated' };
+
+    await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    const evt = mockClient.db.billing_events.find(
+      (e) => e.payload_json?.provider_subscription_id === 'sub_stripe_evt_1',
+    );
+    assert.ok(evt);
+    assert.equal(evt.event_type, 'subscription.status_changed');
+    assert.notEqual(evt.event_type, 'subscription.renewed');
+  });
+
+  it('emits SUBSCRIPTION_STATUS_CHANGED on active -> suspended (unpaid)', async () => {
+    stubbedEvent = {
+      id: 'evt_status_2',
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_stripe_evt_1', status: 'unpaid', cancel_at_period_end: false } },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'customer.subscription.updated' };
+
+    await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    const evt = mockClient.db.billing_events.find(
+      (e) => e.payload_json?.provider_subscription_id === 'sub_stripe_evt_1',
+    );
+    assert.equal(evt.event_type, 'subscription.status_changed');
+  });
+
+  it('emits SUBSCRIPTION_RENEWED on past_due -> active (recovery)', async () => {
+    // Seed local row as past_due first
+    mockClient.db.tenant_subscriptions[mockClient.db.tenant_subscriptions.length - 1].status =
+      'past_due';
+
+    stubbedEvent = {
+      id: 'evt_status_3',
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_stripe_evt_1', status: 'active', cancel_at_period_end: false } },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'customer.subscription.updated' };
+
+    await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    const evt = mockClient.db.billing_events.find(
+      (e) => e.payload_json?.provider_subscription_id === 'sub_stripe_evt_1',
+    );
+    assert.equal(evt.event_type, 'subscription.renewed');
+  });
+
+  it('emits SUBSCRIPTION_CANCELED on any -> canceled', async () => {
+    stubbedEvent = {
+      id: 'evt_status_4',
+      type: 'customer.subscription.updated',
+      data: { object: { id: 'sub_stripe_evt_1', status: 'canceled', cancel_at_period_end: false } },
+    };
+    stubbedNormalized = { tenant_id: TENANT, type: 'customer.subscription.updated' };
+
+    await request(buildApp())
+      .post('/api/webhooks/stripe-platform')
+      .set('stripe-signature', 'sig')
+      .set('content-type', 'application/json')
+      .send(Buffer.from(JSON.stringify(stubbedEvent)));
+
+    const evt = mockClient.db.billing_events.find(
+      (e) => e.payload_json?.provider_subscription_id === 'sub_stripe_evt_1',
+    );
+    assert.equal(evt.event_type, 'subscription.canceled');
+  });
+});
+
+describe('pickSubscriptionUpdateEventType helper (unit, PR #517 issue 5)', () => {
+  let pickFn;
+  before(async () => {
+    ({ pickSubscriptionUpdateEventType: pickFn } = await import(
+      '../../routes/stripe-platform-webhook.js'
+    ));
+  });
+
+  it('canceled always wins', () => {
+    assert.equal(pickFn({ previous: 'active', next: 'canceled' }), 'subscription.canceled');
+    assert.equal(pickFn({ previous: 'past_due', next: 'canceled' }), 'subscription.canceled');
+    assert.equal(pickFn({ previous: 'suspended', next: 'canceled' }), 'subscription.canceled');
+  });
+
+  it('non-active -> active = renewed', () => {
+    assert.equal(pickFn({ previous: 'past_due', next: 'active' }), 'subscription.renewed');
+    assert.equal(pickFn({ previous: 'suspended', next: 'active' }), 'subscription.renewed');
+    assert.equal(pickFn({ previous: 'draft', next: 'active' }), 'subscription.renewed');
+  });
+
+  it('active -> active is status_changed (same-state update, e.g. cancel_at_period_end flip)', () => {
+    assert.equal(pickFn({ previous: 'active', next: 'active' }), 'subscription.status_changed');
+  });
+
+  it('active -> past_due / suspended = status_changed', () => {
+    assert.equal(pickFn({ previous: 'active', next: 'past_due' }), 'subscription.status_changed');
+    assert.equal(pickFn({ previous: 'active', next: 'suspended' }), 'subscription.status_changed');
+  });
+
+  it('past_due -> suspended = status_changed', () => {
+    assert.equal(
+      pickFn({ previous: 'past_due', next: 'suspended' }),
+      'subscription.status_changed',
+    );
+  });
+});

--- a/backend/lib/billing/billingAccountService.js
+++ b/backend/lib/billing/billingAccountService.js
@@ -13,13 +13,19 @@
 import logger from '../logger.js';
 import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
 import { syncTenantBillingState } from './billingStateMachine.js';
+import { BillingError, BILLING_ERROR_CODES } from './errors.js';
 
 /**
  * Get the billing_account row for a tenant (creates it empty on first access).
  * @returns {Promise<object>} billing_accounts row
  */
 export async function getOrCreateBillingAccount(supabase, tenantId) {
-  if (!tenantId) throw new Error('getOrCreateBillingAccount: tenantId required');
+  if (!tenantId) {
+    throw new BillingError('getOrCreateBillingAccount: tenantId required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const { data: existing, error: selErr } = await supabase
     .from('billing_accounts')
@@ -57,7 +63,12 @@ export async function getOrCreateBillingAccount(supabase, tenantId) {
  * Does NOT touch billing_exempt -- use setExemption() for that.
  */
 export async function updateBillingProfile(supabase, tenantId, updates) {
-  if (!tenantId) throw new Error('updateBillingProfile: tenantId required');
+  if (!tenantId) {
+    throw new BillingError('updateBillingProfile: tenantId required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const allowed = [
     'billing_contact_name',
@@ -78,12 +89,18 @@ export async function updateBillingProfile(supabase, tenantId, updates) {
   const forbidden = ['billing_exempt', 'exempt_reason', 'exempt_set_by', 'exempt_set_at'];
   for (const k of forbidden) {
     if (updates[k] !== undefined) {
-      throw new Error(`updateBillingProfile: use setExemption() to modify ${k}`);
+      throw new BillingError(`updateBillingProfile: use setExemption() to modify ${k}`, {
+        statusCode: 400,
+        code: BILLING_ERROR_CODES.INVALID_INPUT,
+      });
     }
   }
 
   if (Object.keys(clean).length === 0) {
-    throw new Error('updateBillingProfile: no updatable fields provided');
+    throw new BillingError('updateBillingProfile: no updatable fields provided', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
   }
 
   // Ensure account exists
@@ -113,9 +130,24 @@ export async function updateBillingProfile(supabase, tenantId, updates) {
  * @returns {Promise<{account: object, stateChange: object}>}
  */
 export async function setExemption(supabase, { tenant_id, reason, actor_id, request_id }) {
-  if (!tenant_id) throw new Error('setExemption: tenant_id required');
-  if (!reason || !reason.trim()) throw new Error('setExemption: reason required');
-  if (!actor_id) throw new Error('setExemption: actor_id required');
+  if (!tenant_id) {
+    throw new BillingError('setExemption: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!reason || !reason.trim()) {
+    throw new BillingError('setExemption: reason required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!actor_id) {
+    throw new BillingError('setExemption: actor_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   await getOrCreateBillingAccount(supabase, tenant_id);
 
@@ -161,8 +193,18 @@ export async function setExemption(supabase, { tenant_id, reason, actor_id, requ
  * @returns {Promise<{account: object, stateChange: object}>}
  */
 export async function removeExemption(supabase, { tenant_id, actor_id, request_id }) {
-  if (!tenant_id) throw new Error('removeExemption: tenant_id required');
-  if (!actor_id) throw new Error('removeExemption: actor_id required');
+  if (!tenant_id) {
+    throw new BillingError('removeExemption: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!actor_id) {
+    throw new BillingError('removeExemption: actor_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const { data: current } = await supabase
     .from('billing_accounts')
@@ -171,7 +213,10 @@ export async function removeExemption(supabase, { tenant_id, actor_id, request_i
     .maybeSingle();
 
   if (!current || !current.billing_exempt) {
-    throw new Error('removeExemption: tenant is not currently exempt');
+    throw new BillingError('removeExemption: tenant is not currently exempt', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.CONFLICT,
+    });
   }
 
   const { data: account, error } = await supabase

--- a/backend/lib/billing/billingEventLogger.js
+++ b/backend/lib/billing/billingEventLogger.js
@@ -32,6 +32,7 @@ export const BILLING_EVENTS = Object.freeze({
   SUBSCRIPTION_CREATED: 'subscription.created',
   SUBSCRIPTION_CANCELED: 'subscription.canceled',
   SUBSCRIPTION_RENEWED: 'subscription.renewed',
+  SUBSCRIPTION_STATUS_CHANGED: 'subscription.status_changed',
 
   // Tenant state
   TENANT_SUSPENSION_WARNING: 'tenant.suspension_warning',

--- a/backend/lib/billing/index.js
+++ b/backend/lib/billing/index.js
@@ -19,8 +19,10 @@ export * as eventLogger from './billingEventLogger.js';
 export * as stripe from './stripePlatformAdapter.js';
 export * as providerInterface from './paymentProvider.js';
 export * as config from './config.js';
+export * as errors from './errors.js';
 
 export { BILLING_EVENTS } from './billingEventLogger.js';
+export { BillingError, BILLING_ERROR_CODES, classifyBillingError } from './errors.js';
 export {
   BILLING_STATES,
   computeBillingState,

--- a/backend/lib/billing/invoiceService.js
+++ b/backend/lib/billing/invoiceService.js
@@ -12,6 +12,7 @@
 import logger from '../logger.js';
 import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
 import { syncTenantBillingState } from './billingStateMachine.js';
+import { BillingError, BILLING_ERROR_CODES } from './errors.js';
 
 const DEFAULT_DUE_DAYS = 14;
 
@@ -53,7 +54,15 @@ export async function generateInvoiceNumber(supabase, tenantId) {
 }
 
 function sumLineItems(items) {
-  return items.reduce((s, li) => s + (li.amount_cents ?? li.quantity * li.unit_price_cents), 0);
+  return items.reduce((s, li) => {
+    if (li.amount_cents != null) return s + li.amount_cents;
+    // Default quantity to 1 (matches normalization below in createInvoice),
+    // and default unit_price_cents to 0 to avoid NaN propagation if a
+    // caller accidentally omits it.
+    const qty = li.quantity ?? 1;
+    const unit = li.unit_price_cents ?? 0;
+    return s + qty * unit;
+  }, 0);
 }
 
 /**
@@ -86,9 +95,17 @@ export async function createInvoice(supabase, params) {
     request_id,
   } = params;
 
-  if (!tenant_id) throw new Error('createInvoice: tenant_id required');
+  if (!tenant_id) {
+    throw new BillingError('createInvoice: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
   if (!Array.isArray(line_items) || line_items.length === 0) {
-    throw new Error('createInvoice: at least one line_item required');
+    throw new BillingError('createInvoice: at least one line_item required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
   }
 
   // Exemption guard
@@ -98,11 +115,19 @@ export async function createInvoice(supabase, params) {
     .eq('tenant_id', tenant_id)
     .maybeSingle();
   if (account?.billing_exempt === true) {
-    throw new Error('createInvoice: tenant is billing-exempt; no invoice created');
+    throw new BillingError('createInvoice: tenant is billing-exempt; no invoice created', {
+      statusCode: 409,
+      code: BILLING_ERROR_CODES.EXEMPT,
+    });
   }
 
   const subtotal = sumLineItems(line_items);
-  if (subtotal < 0) throw new Error('createInvoice: subtotal cannot be negative');
+  if (subtotal < 0) {
+    throw new BillingError('createInvoice: subtotal cannot be negative', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
   const total = subtotal + tax_total_cents;
 
   const invoice_number = await generateInvoiceNumber(supabase, tenant_id);
@@ -130,16 +155,20 @@ export async function createInvoice(supabase, params) {
 
   const lineRows = line_items.map((li) => {
     if (li.quantity != null && li.quantity <= 0) {
-      throw new Error(`createInvoice: line item quantity must be > 0, got ${li.quantity}`);
+      throw new BillingError(`createInvoice: line item quantity must be > 0, got ${li.quantity}`, {
+        statusCode: 400,
+        code: BILLING_ERROR_CODES.INVALID_INPUT,
+      });
     }
     const qty = li.quantity || 1;
+    const unit = li.unit_price_cents ?? 0;
     return {
       invoice_id: invoice.id,
       item_type: li.item_type,
       description: li.description,
       quantity: qty,
-      unit_price_cents: li.unit_price_cents,
-      amount_cents: li.amount_cents ?? qty * li.unit_price_cents,
+      unit_price_cents: unit,
+      amount_cents: li.amount_cents ?? qty * unit,
       metadata: li.metadata || {},
     };
   });
@@ -177,16 +206,29 @@ export async function createInvoice(supabase, params) {
  * Issue a draft invoice (draft -> open). Emits invoice.sent event.
  */
 export async function issueInvoice(supabase, { invoice_id, actor_id, request_id }) {
-  if (!invoice_id) throw new Error('issueInvoice: invoice_id required');
+  if (!invoice_id) {
+    throw new BillingError('issueInvoice: invoice_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const { data: invoice, error: selErr } = await supabase
     .from('invoices')
     .select('*')
     .eq('id', invoice_id)
     .single();
-  if (selErr || !invoice) throw new Error('issueInvoice: invoice not found');
+  if (selErr || !invoice) {
+    throw new BillingError('issueInvoice: invoice not found', {
+      statusCode: 404,
+      code: BILLING_ERROR_CODES.NOT_FOUND,
+    });
+  }
   if (invoice.status !== 'draft') {
-    throw new Error(`issueInvoice: invoice is ${invoice.status}, must be draft`);
+    throw new BillingError(`issueInvoice: invoice is ${invoice.status}, must be draft`, {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVOICE_STATE,
+    });
   }
 
   const { data: updated, error: updErr } = await supabase
@@ -240,9 +282,17 @@ export async function recordPayment(supabase, params) {
     request_id,
   } = params;
 
-  if (!invoice_id) throw new Error('recordPayment: invoice_id required');
+  if (!invoice_id) {
+    throw new BillingError('recordPayment: invoice_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
   if (!amount_cents || amount_cents <= 0) {
-    throw new Error('recordPayment: amount_cents must be > 0');
+    throw new BillingError('recordPayment: amount_cents must be > 0', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
   }
 
   const { data: invoice, error: invErr } = await supabase
@@ -250,9 +300,17 @@ export async function recordPayment(supabase, params) {
     .select('*')
     .eq('id', invoice_id)
     .single();
-  if (invErr || !invoice) throw new Error('recordPayment: invoice not found');
+  if (invErr || !invoice) {
+    throw new BillingError('recordPayment: invoice not found', {
+      statusCode: 404,
+      code: BILLING_ERROR_CODES.NOT_FOUND,
+    });
+  }
   if (invoice.status === 'void' || invoice.status === 'uncollectible') {
-    throw new Error(`recordPayment: invoice is ${invoice.status}`);
+    throw new BillingError(`recordPayment: invoice is ${invoice.status}`, {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVOICE_STATE,
+    });
   }
 
   // Idempotency check
@@ -356,16 +414,36 @@ export async function recordPayment(supabase, params) {
  * Void an invoice. Only valid for non-paid invoices. Clears balance_due.
  */
 export async function voidInvoice(supabase, { invoice_id, actor_id, request_id, reason }) {
-  if (!invoice_id) throw new Error('voidInvoice: invoice_id required');
-  if (!actor_id) throw new Error('voidInvoice: actor_id required');
+  if (!invoice_id) {
+    throw new BillingError('voidInvoice: invoice_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!actor_id) {
+    throw new BillingError('voidInvoice: actor_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const { data: invoice, error: selErr } = await supabase
     .from('invoices')
     .select('*')
     .eq('id', invoice_id)
     .single();
-  if (selErr || !invoice) throw new Error('voidInvoice: invoice not found');
-  if (invoice.status === 'paid') throw new Error('voidInvoice: cannot void a paid invoice');
+  if (selErr || !invoice) {
+    throw new BillingError('voidInvoice: invoice not found', {
+      statusCode: 404,
+      code: BILLING_ERROR_CODES.NOT_FOUND,
+    });
+  }
+  if (invoice.status === 'paid') {
+    throw new BillingError('voidInvoice: cannot void a paid invoice', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVOICE_PAID,
+    });
+  }
   if (invoice.status === 'void') return invoice; // idempotent
 
   const { data: voided, error: updErr } = await supabase

--- a/backend/lib/billing/subscriptionService.js
+++ b/backend/lib/billing/subscriptionService.js
@@ -9,6 +9,7 @@
 import logger from '../logger.js';
 import { logBillingEvent, BILLING_EVENTS } from './billingEventLogger.js';
 import { syncTenantBillingState } from './billingStateMachine.js';
+import { BillingError, BILLING_ERROR_CODES } from './errors.js';
 
 function computeRenewalDate(interval, from = new Date()) {
   const d = new Date(from);
@@ -26,7 +27,12 @@ function computeRenewalDate(interval, from = new Date()) {
  * Get the tenant's active (non-canceled) subscription, if any.
  */
 export async function getActiveSubscription(supabase, tenantId) {
-  if (!tenantId) throw new Error('getActiveSubscription: tenantId required');
+  if (!tenantId) {
+    throw new BillingError('getActiveSubscription: tenantId required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
   const { data, error } = await supabase
     .from('tenant_subscriptions')
     .select('*, billing_plans(*)')
@@ -60,8 +66,18 @@ export async function assignPlan(supabase, params) {
     request_id,
   } = params;
 
-  if (!tenant_id) throw new Error('assignPlan: tenant_id required');
-  if (!plan_code) throw new Error('assignPlan: plan_code required');
+  if (!tenant_id) {
+    throw new BillingError('assignPlan: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!plan_code) {
+    throw new BillingError('assignPlan: plan_code required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const { data: plan, error: planErr } = await supabase
     .from('billing_plans')
@@ -70,11 +86,19 @@ export async function assignPlan(supabase, params) {
     .eq('is_active', true)
     .maybeSingle();
   if (planErr) throw new Error(`assignPlan: ${planErr.message}`);
-  if (!plan) throw new Error(`assignPlan: plan "${plan_code}" not found or inactive`);
+  if (!plan) {
+    throw new BillingError(`assignPlan: plan "${plan_code}" not found or inactive`, {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INACTIVE_PLAN,
+    });
+  }
 
   const existing = await getActiveSubscription(supabase, tenant_id);
   if (existing) {
-    throw new Error('assignPlan: tenant already has an active subscription -- use changePlan()');
+    throw new BillingError(
+      'assignPlan: tenant already has an active subscription -- use changePlan()',
+      { statusCode: 409, code: BILLING_ERROR_CODES.CONFLICT },
+    );
   }
 
   const start_date = new Date().toISOString();
@@ -130,12 +154,25 @@ export async function assignPlan(supabase, params) {
 export async function changePlan(supabase, params) {
   const { tenant_id, plan_code, actor_id = null, request_id } = params;
 
-  if (!tenant_id) throw new Error('changePlan: tenant_id required');
-  if (!plan_code) throw new Error('changePlan: plan_code required');
+  if (!tenant_id) {
+    throw new BillingError('changePlan: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!plan_code) {
+    throw new BillingError('changePlan: plan_code required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const existing = await getActiveSubscription(supabase, tenant_id);
   if (!existing) {
-    throw new Error('changePlan: no active subscription -- use assignPlan()');
+    throw new BillingError('changePlan: no active subscription -- use assignPlan()', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.NO_ACTIVE_SUBSCRIPTION,
+    });
   }
 
   // Validate new plan exists before canceling old one
@@ -148,10 +185,16 @@ export async function changePlan(supabase, params) {
     throw new Error(`changePlan: ${newPlanError.message}`);
   }
   if (!newPlan || !newPlan.is_active) {
-    throw new Error(`changePlan: plan "${plan_code}" not found or inactive`);
+    throw new BillingError(`changePlan: plan "${plan_code}" not found or inactive`, {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INACTIVE_PLAN,
+    });
   }
   if (newPlan.id === existing.billing_plan_id) {
-    throw new Error(`changePlan: tenant is already on "${plan_code}"`);
+    throw new BillingError(`changePlan: tenant is already on "${plan_code}"`, {
+      statusCode: 409,
+      code: BILLING_ERROR_CODES.CONFLICT,
+    });
   }
 
   // Cancel existing
@@ -198,11 +241,26 @@ export async function changePlan(supabase, params) {
  * Cancel a tenant's active subscription.
  */
 export async function cancelSubscription(supabase, { tenant_id, actor_id, request_id, reason }) {
-  if (!tenant_id) throw new Error('cancelSubscription: tenant_id required');
-  if (!actor_id) throw new Error('cancelSubscription: actor_id required');
+  if (!tenant_id) {
+    throw new BillingError('cancelSubscription: tenant_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
+  if (!actor_id) {
+    throw new BillingError('cancelSubscription: actor_id required', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.INVALID_INPUT,
+    });
+  }
 
   const existing = await getActiveSubscription(supabase, tenant_id);
-  if (!existing) throw new Error('cancelSubscription: no active subscription');
+  if (!existing) {
+    throw new BillingError('cancelSubscription: no active subscription', {
+      statusCode: 400,
+      code: BILLING_ERROR_CODES.NO_ACTIVE_SUBSCRIPTION,
+    });
+  }
 
   const { data: canceled, error } = await supabase
     .from('tenant_subscriptions')

--- a/backend/routes/billing-admin.js
+++ b/backend/routes/billing-admin.js
@@ -29,6 +29,21 @@ import {
   voidInvoice,
   listInvoices,
 } from '../lib/billing/invoiceService.js';
+import { classifyBillingError } from '../lib/billing/errors.js';
+
+/**
+ * Route-local error responder. Prefers BillingError.statusCode; falls
+ * back to the legacy regex pattern for any Error raised by code that
+ * hasn't been migrated to BillingError yet.
+ */
+function respondError(res, err, legacyPattern) {
+  const status = classifyBillingError(err, legacyPattern);
+  res.status(status).json({
+    status: 'error',
+    message: err.message,
+    code: err.code || null,
+  });
+}
 
 export default function createBillingAdminRoutes(_pgPool, opts = {}) {
   const getClient = opts.getSupabaseClient || getSupabaseClient;
@@ -43,14 +58,24 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       const { tenantId } = req.params;
       const supabase = getClient();
 
-      const [{ data: tenant }, account, subscription, invoices] = await Promise.all([
-        supabase.from('tenant').select('id, name, billing_state').eq('id', tenantId).maybeSingle(),
+      // 1) Verify tenant exists BEFORE any billing-side work.
+      //    billing_accounts.tenant_id is FK -> tenant(id); skipping this
+      //    check causes getOrCreateBillingAccount() to 500 on unknown IDs.
+      //    Also capture error so DB failures don't masquerade as 404.
+      const { data: tenant, error: tenantErr } = await supabase
+        .from('tenant')
+        .select('id, name, billing_state')
+        .eq('id', tenantId)
+        .maybeSingle();
+      if (tenantErr) throw new Error(tenantErr.message);
+      if (!tenant) return res.status(404).json({ status: 'error', message: 'Tenant not found' });
+
+      // 2) Tenant confirmed — now fetch billing info in parallel.
+      const [account, subscription, invoices] = await Promise.all([
         getOrCreateBillingAccount(supabase, tenantId),
         getActiveSubscription(supabase, tenantId),
         listInvoices(supabase, tenantId, { limit: 20 }),
       ]);
-
-      if (!tenant) return res.status(404).json({ status: 'error', message: 'Tenant not found' });
 
       res.json({
         status: 'success',
@@ -80,8 +105,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.status(201).json({ status: 'success', data: sub });
     } catch (err) {
       logger.error('[BillingAdmin] POST subscription error', { error: err.message });
-      const code = /already has|not found|inactive|required/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /already has|not found|inactive|required/);
     }
   });
 
@@ -99,8 +123,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: sub });
     } catch (err) {
       logger.error('[BillingAdmin] PUT subscription error', { error: err.message });
-      const code = /no active|already on|not found|inactive|required/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /no active|already on|not found|inactive|required/);
     }
   });
 
@@ -118,8 +141,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: canceled });
     } catch (err) {
       logger.error('[BillingAdmin] DELETE subscription error', { error: err.message });
-      const code = /no active|required/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /no active|required/);
     }
   });
 
@@ -140,8 +162,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: result });
     } catch (err) {
       logger.error('[BillingAdmin] POST exemption error', { error: err.message });
-      const code = /required/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /required/);
     }
   });
 
@@ -157,8 +178,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: result });
     } catch (err) {
       logger.error('[BillingAdmin] DELETE exemption error', { error: err.message });
-      const code = /not currently exempt|required/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /not currently exempt|required/);
     }
   });
 
@@ -184,8 +204,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.status(201).json({ status: 'success', data: result });
     } catch (err) {
       logger.error('[BillingAdmin] POST invoices error', { error: err.message });
-      const code = /exempt|required|negative|quantity/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /exempt|required|negative|quantity/);
     }
   });
 
@@ -200,8 +219,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: invoice });
     } catch (err) {
       logger.error('[BillingAdmin] POST issue error', { error: err.message });
-      const code = /not found|must be draft/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /not found|must be draft/);
     }
   });
 
@@ -221,8 +239,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: result });
     } catch (err) {
       logger.error('[BillingAdmin] POST mark-paid error', { error: err.message });
-      const code = /not found|void|uncollectible|must be|> 0/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /not found|void|uncollectible|must be|> 0/);
     }
   });
 
@@ -239,8 +256,7 @@ export default function createBillingAdminRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: invoice });
     } catch (err) {
       logger.error('[BillingAdmin] POST void error', { error: err.message });
-      const code = /not found|cannot void/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      respondError(res, err, /not found|cannot void/);
     }
   });
 

--- a/backend/routes/billing.js
+++ b/backend/routes/billing.js
@@ -22,16 +22,27 @@ import { getActiveSubscription } from '../lib/billing/subscriptionService.js';
 import { listInvoices } from '../lib/billing/invoiceService.js';
 import * as stripeAdapter from '../lib/billing/stripePlatformAdapter.js';
 import { getPlatformBillingConfig } from '../lib/billing/config.js';
+import { classifyBillingError } from '../lib/billing/errors.js';
 
-function resolveTenantId(req) {
-  const fromMiddleware = req.tenant?.id;
+export function resolveTenantId(req) {
+  // req.tenant is populated by validateTenantAccess after canonical resolution
+  // of whatever identifier was supplied (UUID, slug, or 'system').
+  // { id: <uuid>, tenant_id: <slug>, name: <string> }
+  const canonicalUuid = req.tenant?.id;
+  const canonicalSlug = req.tenant?.tenant_id;
   const fromRequest = req.query?.tenant_id || req.body?.tenant_id;
-  if (fromMiddleware) {
-    if (fromRequest && fromRequest !== fromMiddleware) {
+
+  if (canonicalUuid) {
+    // Accept match against either the resolved UUID or the resolved slug —
+    // both are canonical forms of the same tenant. This matches how
+    // validateTenantAccess itself compares tenant identifiers.
+    if (fromRequest && fromRequest !== canonicalUuid && fromRequest !== canonicalSlug) {
       return { error: 'tenant_id mismatch' };
     }
-    return { tenant_id: fromMiddleware };
+    // Always return the canonical UUID for downstream DB queries
+    return { tenant_id: canonicalUuid };
   }
+
   if (fromRequest) return { tenant_id: fromRequest };
   return { error: 'tenant_id is required' };
 }
@@ -91,8 +102,12 @@ export default function createBillingRoutes(_pgPool, opts = {}) {
       res.json({ status: 'success', data: updated });
     } catch (err) {
       logger.error('[Billing] PUT /account error', { error: err.message });
-      const code = /setExemption|no updatable/.test(err.message) ? 400 : 500;
-      res.status(code).json({ status: 'error', message: err.message });
+      const status = classifyBillingError(err, /setExemption|no updatable/);
+      res.status(status).json({
+        status: 'error',
+        message: err.message,
+        code: err.code || null,
+      });
     }
   });
 

--- a/backend/routes/stripe-platform-webhook.js
+++ b/backend/routes/stripe-platform-webhook.js
@@ -35,6 +35,24 @@ import { logBillingEvent, BILLING_EVENTS } from '../lib/billing/billingEventLogg
 import { syncTenantBillingState } from '../lib/billing/billingStateMachine.js';
 import { getPlatformBillingConfig } from '../lib/billing/config.js';
 
+/**
+ * Pick the correct billing event type for a subscription.updated webhook
+ * based on the status transition. Avoids misrepresenting a delinquency
+ * (active -> past_due) as a subscription renewal in the audit trail.
+ *
+ *   * -> canceled                        => SUBSCRIPTION_CANCELED
+ *   non-active -> active                  => SUBSCRIPTION_RENEWED
+ *                                            (recovery from past_due, re-activation, etc.)
+ *   anything else (e.g. active -> past_due,
+ *   active -> suspended, past_due -> suspended,
+ *   cancel_at_period_end flag flip)       => SUBSCRIPTION_STATUS_CHANGED
+ */
+export function pickSubscriptionUpdateEventType({ previous, next }) {
+  if (next === 'canceled') return BILLING_EVENTS.SUBSCRIPTION_CANCELED;
+  if (next === 'active' && previous !== 'active') return BILLING_EVENTS.SUBSCRIPTION_RENEWED;
+  return BILLING_EVENTS.SUBSCRIPTION_STATUS_CHANGED;
+}
+
 export function createStripePlatformWebhookRouter(opts = {}) {
   const getClient = opts.getSupabaseClient || defaultGetSupabaseClient;
   const stripeAdapter = opts.stripeAdapter || defaultStripeAdapter;
@@ -47,9 +65,20 @@ export function createStripePlatformWebhookRouter(opts = {}) {
     async (req, res) => {
       const signature = req.headers['stripe-signature'];
 
-      if (!getPlatformBillingConfig().isConfigured) {
+      const cfg = getPlatformBillingConfig();
+      if (!cfg.isConfigured) {
         logger.warn('[StripePlatformWebhook] Received event but platform billing not configured');
         return res.status(503).json({ error: 'Platform billing not configured' });
+      }
+      // Webhook signature verification needs both the secret key and the
+      // webhook secret. Check explicitly here so a missing webhook secret
+      // surfaces as 503 (misconfiguration) rather than 400 (invalid signature)
+      // — otherwise operators get a misleading error during setup.
+      if (!cfg.stripeWebhookSecret) {
+        logger.warn(
+          '[StripePlatformWebhook] STRIPE_PLATFORM_WEBHOOK_SECRET missing — cannot verify signatures',
+        );
+        return res.status(503).json({ error: 'Platform billing webhook secret not configured' });
       }
 
       // Prefer req.rawBody (set by express.json verify callback in initMiddleware) over
@@ -169,8 +198,23 @@ async function handleCheckoutCompleted(supabase, event, normalized, requestId) {
           request_id: requestId,
         });
       } catch (err) {
-        // Race: someone else assigned; log and continue to payment recording
-        logger.warn('[StripePlatformWebhook] assignPlan failed (may be race)', {
+        // Only swallow the known idempotency race: if another worker/webhook
+        // assigned a plan between our SELECT and the INSERT, assignPlan()
+        // re-throws with "tenant already has an active subscription".
+        // All other failures (plan deactivated, transient DB error, RLS
+        // denial, etc.) MUST propagate so Stripe retries the webhook —
+        // otherwise we ack 200 with no local subscription row.
+        const isRace = /already has an active subscription/i.test(err.message);
+        if (!isRace) {
+          logger.error('[StripePlatformWebhook] assignPlan failed (non-race)', {
+            error: err.message,
+            tenant_id: tenantId,
+            plan_code: planCode,
+            session_id: session.id,
+          });
+          throw err;
+        }
+        logger.warn('[StripePlatformWebhook] assignPlan race ignored', {
           error: err.message,
           tenant_id: tenantId,
           plan_code: planCode,
@@ -342,10 +386,10 @@ async function handleSubscriptionUpdated(supabase, event, requestId) {
 
   await logBillingEvent(supabase, {
     tenant_id: localSub.tenant_id,
-    event_type:
-      nextStatus === 'canceled'
-        ? BILLING_EVENTS.SUBSCRIPTION_CANCELED
-        : BILLING_EVENTS.SUBSCRIPTION_RENEWED,
+    event_type: pickSubscriptionUpdateEventType({
+      previous: localSub.status,
+      next: nextStatus,
+    }),
     source: 'webhook',
     payload: {
       subscription_id: localSub.id,


### PR DESCRIPTION
## Summary

Follow-up to PR #517 (merged before review fixes were pushed). This PR contains all code changes addressing the 7 Copilot/Codex review comments.

## Changes

| Issue | Severity | File | Fix |
|-------|----------|------|-----|
| 1 | P1 | `billing-admin.js` | Sequential tenant lookup before FK-dependent insert; DB errors → 500, missing → 404 |
| 2 | P2 | `billing.js` | `resolveTenantId` accepts both UUID and slug forms |
| 3 | P1 | `stripe-platform-webhook.js` | `assignPlan` catch only swallows known "already has active subscription" race; all other errors propagate as 500 for Stripe retry |
| 4 | Copilot | `billing-admin.js` | `BillingError` class replaces regex-on-message status classification; 409 for CONFLICT cases (duplicate subscription, exempt tenant) |
| 5 | Copilot | `stripe-platform-webhook.js` | `SUBSCRIPTION_STATUS_CHANGED` event; `RENEWED` only on non-active → active; accurate audit trail |
| 6 | Copilot | `invoiceService.js` | `sumLineItems` NaN-safe: default quantity=1, unit_price_cents=0 |
| 7 | Copilot | `stripe-platform-webhook.js` | Explicit webhook secret preflight returns 503 when `STRIPE_PLATFORM_WEBHOOK_SECRET` missing |

## Files changed (13 modified + 3 new)

**Production:**
- `backend/routes/billing-admin.js`
- `backend/routes/billing.js`
- `backend/routes/stripe-platform-webhook.js`
- `backend/lib/billing/billingAccountService.js`
- `backend/lib/billing/billingEventLogger.js`
- `backend/lib/billing/invoiceService.js`
- `backend/lib/billing/subscriptionService.js`
- `backend/lib/billing/index.js`
- `backend/lib/billing/errors.js` *(new)*

**Tests:**
- `backend/__tests__/billing/billingEventLogger.test.js`
- `backend/__tests__/billing/invoiceService.test.js`
- `backend/__tests__/routes/billing-admin.routes.test.js`
- `backend/__tests__/routes/billing.routes.test.js`
- `backend/__tests__/routes/stripe-platform-webhook.test.js`
- `backend/__tests__/billing/errors.test.js` *(new)*
- `backend/__tests__/billing/pr517-review-fixes.test.js` *(new)*

## Testing

- Pre-commit: ESLint + CARE playbook tests ✅
- Pre-push: Full backend suite — 2453 pass, 0 fail ✅