### PR TITLE
chore(deploy): add Coolify deployment split configs

### DIFF
--- a/deploy/coolify/README.md
+++ b/deploy/coolify/README.md
@@ -1,0 +1,60 @@
+# deploy/coolify — Deployment split (pre-migration staging area)
+
+This folder is the staging ground for a future Coolify migration. Its purpose
+is to **separate deployment surfaces** by blast radius and change cadence,
+**without** altering the currently-deployed production path.
+
+## Scope
+
+Only the **aishacrm** application and its direct satellites. The VPS also runs
+OpenReplay, a landing page, and containerd helpers — those are **out of scope**
+for this split and are not bundled anywhere here.
+
+## Rule
+
+> Deployment domains should reflect what changes together, fails together, and
+> should roll back together.
+
+## Domains
+
+| Folder           | Services                                              | Cadence             |
+| ---------------- | ----------------------------------------------------- | ------------------- |
+| `aisha-app/`     | frontend, backend, aisha-comms                        | fast (every tag)    |
+| `data-support/`  | redis-memory, redis-cache                             | very rare           |
+| `scheduling/`    | calcom, calcom-db                                     | mid (quarterly-ish) |
+| `ai-runtime/`    | braid-mcp-server, braid-mcp-1, braid-mcp-2            | mid                 |
+| `ai-infra/`      | ollama, litellm                                       | rare                |
+| `support-infra/` | (README only — documents out-of-scope VPS containers) | n/a                 |
+
+## Shared wiring
+
+All domains attach to a single **external** Docker network:
+
+```yaml
+networks:
+  aishanet:
+    external: true
+```
+
+Cross-domain resolution is by `container_name`. This preserves the current
+topology and avoids the need for a service mesh or shared DNS during the
+transition.
+
+## What this folder is NOT
+
+- It is **not wired into CI** yet. The live deployment is still driven by
+  `docker-compose.prod.yml` at the repo root and
+  `braid-mcp-node-server/docker-compose.prod.yml`.
+- It does **not** contain Coolify-specific config, platform secrets, or
+  lock-in. Adding Coolify platform glue is a separate, later step.
+- It does **not** delete existing deployment files. The refactor is additive
+  until someone explicitly retires the old files.
+- It does **not** include OpenReplay, Caddy, the landing page, or Hawser.
+  See `support-infra/README.md` for why.
+
+## See also
+
+- `docs/deployment/coolify-migration.md` — migration plan, order, risks.
+- `docs/deployment/env-matrix.md` — environment variable ownership by domain.
+- `tests/deployment/compose-topology.test.js` — validates each compose file
+  contains only its domain's services.

--- a/deploy/coolify/STAGING.md
+++ b/deploy/coolify/STAGING.md
@@ -1,0 +1,159 @@
+# Staging deployment on the same VPS
+
+This is the **parallel staging lane** strategy for validating the Coolify
+split without touching production. It follows the principle: same VPS, new
+names, new ports, new network, new Doppler config, **no shared write paths**
+with production.
+
+## Prerequisites (one-time)
+
+1. **Create a Doppler config for staging.**
+   Recommended: a new environment `stg` with a config `stg_stg`. Copy
+   `prd_prd` as the starting template, then override:
+   - All URLs to point at `staging-*.aishacrm.com`
+   - `ALLOWED_ORIGINS` to include only staging origins
+   - Any keys that would trigger real outbound actions (Twilio, SendGrid,
+     Cal.com SMTP) — switch to test keys or leave blank
+   - Tenant scoping — point at a test tenant if you have one
+
+2. **Create the staging Docker network on the VPS:**
+
+   ```
+   docker network create aishanet-staging
+   ```
+
+3. **Reserve staging ports.** Every staging service uses a +100 offset from
+   its prod counterpart. See port table below.
+
+4. **Add DNS.** Point `staging-app`, `staging-api`, `staging-scheduler` (and
+   others as needed) at the VPS. If Cloudflare sits in front, add them there.
+   **Do not** reassign existing prod records.
+
+## Staging port map
+
+| Service          | Prod host port | Staging host port |
+| ---------------- | -------------- | ----------------- |
+| frontend         | 4000           | **4100**          |
+| backend          | 4001           | **4101**          |
+| redis-memory     | 6379           | **6479**          |
+| redis-cache      | 6380           | **6480**          |
+| calcom           | 3002           | **3102**          |
+| braid-mcp-server | 8000           | **8100**          |
+| ollama           | 11434          | **11534**         |
+| litellm          | 4002           | **4102**          |
+
+All staging ports bind to `127.0.0.1` (same as prod) — the edge/reverse-proxy
+decides what's publicly reachable.
+
+## Staging container names
+
+Production uses `aishacrm-*` and `braid-mcp-*`. Staging uses:
+
+- `aishacrm-staging-frontend`
+- `aishacrm-staging-backend`
+- `aishacrm-staging-comms` (Phase B)
+- `aishacrm-staging-redis-memory`
+- `aishacrm-staging-redis-cache`
+- `aishacrm-staging-calcom`
+- `aishacrm-staging-calcom-db`
+- `aishacrm-staging-ollama`
+- `aishacrm-staging-litellm`
+- `braid-mcp-staging-server`
+- `braid-mcp-staging-1`
+- `braid-mcp-staging-2`
+
+This guarantees no collision with the running prod containers.
+
+## Staging subdomains
+
+- `staging-app.aishacrm.com` → staging frontend (host port 4100)
+- `staging-api.aishacrm.com` → staging backend (host port 4101)
+- `staging-scheduler.aishacrm.com` → staging Cal.com (host port 3102)
+
+## Phased rollout
+
+### Phase A — smoke lane (deploy this first)
+
+**Deploy:**
+
+1. `data-support/docker-compose.staging.yml` → ephemeral staging Redis
+2. `aisha-app/docker-compose.staging.yml` → frontend + backend only (comms
+   is commented out in the file)
+
+**Do NOT deploy yet:** comms, Cal.com, Ollama, LiteLLM, Braid MCP. Leave them
+pointed at production (staging backend will have those URLs blank / disabled
+via the `stg_stg` Doppler config).
+
+**Validate** (in order):
+
+1. Containers start cleanly
+2. Health checks pass on both services
+3. `staging-app.aishacrm.com` loads and the bundle reports staging URLs
+4. Login works (against Supabase — staging uses the same Supabase by design
+   because Supabase is externally managed; the staging URLs ensure no browser
+   origin leak)
+5. `staging-api.aishacrm.com/health` returns 200
+6. Backend can reach `aishacrm-staging-redis-memory` and `…-redis-cache`
+7. No prod URLs leak into the staging frontend bundle
+   (`grep -r "api.aishacrm.com" dist/` should find nothing)
+8. Staging logs are clean under normal usage
+
+### Phase B — add comms
+
+Uncomment the `aisha-comms` block in `aisha-app/docker-compose.staging.yml`
+and redeploy that domain.
+
+**Critical:** the staging comms worker must **not** process live production
+queues. Either:
+
+- Point staging at a dedicated test queue (separate Redis key namespace,
+  different tenant scoping), or
+- Set `AI_TRIGGERS_WORKER_ENABLED=false` in the `stg_stg` Doppler config
+  until you're ready to exercise it
+
+### Phase C — isolated lower-change stacks
+
+Deploy these only when you're explicitly testing that stack, one at a time:
+
+1. `scheduling/docker-compose.staging.yml` — staging Cal.com
+2. `ai-runtime/docker-compose.staging.yml` — staging Braid MCP cluster
+3. `ai-infra/docker-compose.staging.yml` — staging Ollama + LiteLLM
+
+Each gets its own staging volume. None share state with production.
+
+## Doppler wiring
+
+Every staging compose file sets `DOPPLER_CONFIG=stg_stg`. The
+`DOPPLER_TOKEN_STAGING` service token (you create this in Doppler) is what
+Coolify injects at compose-up time. Entrypoints do `doppler run`, so the
+staging secrets land in staging containers only.
+
+**Do not reuse the prod service token for staging.** Separate tokens make
+rotation safe and audit trails clean.
+
+## Guardrails that stay on for staging
+
+- `TELEMETRY_ENABLED=false` — same as prod, no point adding noise
+- `AI_TRIGGERS_WORKER_ENABLED=false` during Phase A
+- Cal.com `ALLOWED_HOSTNAMES="staging-scheduler.aishacrm.com"` — Cal.com
+  refuses to serve unknown hostnames
+- All stateful services use `*_staging` volumes — no way to corrupt prod
+  volumes by accident
+- No Docker socket mount on staging backend (prod does mount it for the
+  Ollama-restart UI; staging doesn't need that and it's a privilege escalator)
+
+## What to never do
+
+- Reuse a prod container name in staging
+- Reuse a prod host port in staging
+- Point staging frontend at `api.aishacrm.com`
+- Let staging comms drain prod queues
+- Let staging Cal.com use `CALCOM_PUBLIC_URL=https://scheduler.aishacrm.com`
+- Switch Cloudflare routing for `app.aishacrm.com` during initial testing
+
+## When staging is "done"
+
+Staging is done when you've run a full release-tag build through Phase A + B
+end-to-end, observed clean logs over a real workday, and confirmed no prod
+URL or resource leaked into the staging bundle. Only then does cutover
+become a conversation — and even then, cutover is a **separate** PR.

--- a/deploy/coolify/ai-infra/README.md
+++ b/deploy/coolify/ai-infra/README.md
@@ -1,0 +1,47 @@
+# ai-infra (rare-change, infrastructure tier)
+
+**Services:** `ollama`, `litellm`
+
+**Change cadence:** rare. Bumped only when image versions roll, models change,
+or `litellm_config.yaml` is rewritten. Separate from Braid (`ai-runtime`)
+because those components evolve on different timelines.
+
+## Current state — manual confirmation needed before Coolify cutover
+
+- **Ollama** today runs as a **standalone Dockhand-managed container**
+  (`aishacrm-ollama`) on the prod VPS, outside any repo compose. This file
+  captures the intended Coolify definition. Do **not** apply this compose on
+  top of the live container without:
+  1. Stopping the standalone container cleanly
+  2. Preserving the `ollama_data` volume (contains pulled model weights)
+  3. Confirming the new container binds the same volume so models don't
+     re-download
+- **LiteLLM** today is defined in the root `docker-compose.prod.yml`. That
+  definition remains authoritative until Coolify cuts over.
+
+## Consumers
+
+| Consumer                 | Domain    | Variable                        |
+| ------------------------ | --------- | ------------------------------- |
+| `aishacrm-backend`       | aisha-app | `LITELLM_BASE_URL` (→ litellm)  |
+| `aishacrm-backend` (dev) | aisha-app | `LOCAL_LLM_BASE_URL` (→ ollama) |
+
+In prod, PEP uses Groq (not Ollama) — see `PEP_LLM_PROVIDER=groq` on the
+backend. Ollama is used for local-LLM summaries (`SUMMARY_LLM_MODEL`).
+
+## Model preload
+
+The entrypoint currently pulls `llama3.2:3b` and `qwen2.5-coder:3b`. Production
+has historically run `llama3.1:8b` per Doppler `SUMMARY_LLM_MODEL`. If migrating,
+either:
+
+- Update the entrypoint to preload `llama3.1:8b`, or
+- Run `ollama pull llama3.1:8b` as a Coolify post-start hook
+
+The pulled-model volume `ollama_data` is the canonical cache and must be
+preserved across container replacements.
+
+## Memory
+
+The container is capped at **8GB** to match the current Dockhand deployment.
+Increase if loading larger models.

--- a/deploy/coolify/ai-infra/docker-compose.staging.yml
+++ b/deploy/coolify/ai-infra/docker-compose.staging.yml
@@ -1,0 +1,84 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: ai-infra  STAGING LANE  (Phase C — do NOT deploy for
+#                                              Phase A smoke test)
+# Services: ollama, litellm
+#
+# Fully isolated staging Ollama (dedicated model volume) and staging LiteLLM.
+# Cheaper memory cap than prod — the staging Ollama is for smoke/behavior
+# testing, not throughput.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: aishacrm-staging-ollama
+    restart: unless-stopped
+    # Preload only the lightest model for smoke testing. If you need to
+    # validate prod parity (llama3.1:8b), override via OLLAMA_PRELOAD_MODEL
+    # and bump the memory cap below.
+    entrypoint: >
+      sh -c "ollama serve & sleep 5 && ollama pull llama3.2:3b && ollama run llama3.2:3b 'ready' && wait"
+    environment:
+      - OLLAMA_NUM_CTX=1024
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_KEEP_ALIVE=-1
+      - OLLAMA_NUM_PARALLEL=1
+    ports:
+      - "127.0.0.1:11534:11434"
+    volumes:
+      # Separate model cache from prod so staging never blocks on prod pulls.
+      - ollama_data_staging:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          memory: 4g
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet-staging
+
+  litellm:
+    image: ghcr.io/andreibyf/aishacrm-2-litellm:${IMAGE_TAG:-latest}
+    container_name: aishacrm-staging-litellm
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4102:4000"
+    environment:
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN_STAGING:-}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG_STAGING:-stg_stg}
+    volumes:
+      # Same config file as prod — repo root. If your staging LiteLLM needs
+      # different provider keys or model aliases, point this at a separate
+      # file instead.
+      - ../../../litellm_config.yaml:/app/config.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness')\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+volumes:
+  ollama_data_staging:
+    driver: local
+
+networks:
+  aishanet-staging:
+    external: true

--- a/deploy/coolify/ai-infra/docker-compose.yml
+++ b/deploy/coolify/ai-infra/docker-compose.yml
@@ -1,0 +1,94 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: ai-infra  (rare-change, infrastructure tier)
+# Services: ollama, litellm
+# Cadence:  seldom. Bumped for Ollama/LiteLLM image upgrades, model changes,
+#           or LiteLLM config rewrites. Not tied to app or Braid release cycle.
+#
+# NOTE ON CURRENT STATE:
+#   - Today in production, Ollama runs as a STANDALONE Dockhand-managed
+#     container (aishacrm-ollama) that is NOT defined in any repo compose.
+#     It is listed here so Coolify can pick it up as part of the ai-infra
+#     domain when migration happens. Do not apply this compose on top of
+#     the existing standalone container without coordination.
+#   - LiteLLM today is defined in the root docker-compose.prod.yml. That
+#     definition remains authoritative until Coolify cuts over.
+#
+# Model preload:
+#   The Ollama entrypoint pulls llama3.2:3b and qwen2.5-coder:3b on first run.
+#   Prod has historically run llama3.1:8b for summaries per SUMMARY_LLM_MODEL.
+#   Set OLLAMA_PRELOAD_MODELS to override (see .env.example pattern in the
+#   existing root docker-compose.yml).
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: aishacrm-ollama
+    restart: unless-stopped
+    # Keep llama3.2:3b + qwen2.5-coder:3b preloaded; matches existing dev compose.
+    # If prod needs llama3.1:8b (per Doppler SUMMARY_LLM_MODEL), add it here or
+    # add a post-start init script in Coolify.
+    entrypoint: >
+      sh -c "ollama serve & sleep 5 && ollama pull llama3.2:3b && ollama pull qwen2.5-coder:3b && ollama run llama3.2:3b 'ready' && wait"
+    environment:
+      - OLLAMA_NUM_CTX=1024
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_KEEP_ALIVE=-1
+      - OLLAMA_NUM_PARALLEL=2
+    ports:
+      - "127.0.0.1:11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    # Memory cap matches current prod Dockhand container (8GB).
+    deploy:
+      resources:
+        limits:
+          memory: 8g
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet
+
+  litellm:
+    image: ghcr.io/andreibyf/aishacrm-2-litellm:latest
+    container_name: aishacrm-litellm
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4002:4000"
+    environment:
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+    volumes:
+      # Config lives at repo root; path relative to this compose file.
+      - ../../../litellm_config.yaml:/app/config.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:4000/health/liveliness')\" || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+volumes:
+  ollama_data:
+    driver: local
+
+networks:
+  aishanet:
+    external: true

--- a/deploy/coolify/ai-runtime/README.md
+++ b/deploy/coolify/ai-runtime/README.md
@@ -1,0 +1,42 @@
+# ai-runtime (Braid MCP tier)
+
+**Services:** `braid-mcp-server`, `braid-mcp-1`, `braid-mcp-2`
+
+**Change cadence:** mid — Braid is actively developed. The tool registry and
+DSL evolve independently of the core CRM release cycle, but more often than
+AI infrastructure (Ollama, LiteLLM).
+
+**Why this is separate from `ai-infra`:** Ollama and LiteLLM are stable
+infrastructure that rarely change. Braid MCP ships new tools, adapters, and
+runtime behaviors routinely. Coupling them to the same deployment domain would
+force unnecessary infra rollouts on every Braid change.
+
+## Topology
+
+- `braid-mcp-server` — coordinator. Port `8000` published on loopback.
+- `braid-mcp-1`, `braid-mcp-2` — worker nodes. No published ports; reachable
+  only inside `aishanet`.
+
+## Cross-domain dependencies
+
+| Depends on              | From domain  | Variable          |
+| ----------------------- | ------------ | ----------------- |
+| `aishacrm-backend`      | aisha-app    | `CRM_BACKEND_URL` |
+| `aishacrm-redis-memory` | data-support | `REDIS_URL`       |
+
+## Consumers
+
+- `aishacrm-backend` → `BRAID_MCP_URL`, `MCP_NODE_HEALTH_URL`
+
+## Relationship to existing compose
+
+This file is a **parallel definition** of what already exists at
+`braid-mcp-node-server/docker-compose.prod.yml`. Do not remove that file. It
+remains the source of truth for the current deployment pipeline until Coolify
+migration cuts over. Keep the two in sync manually until the switch.
+
+## Image
+
+`ghcr.io/andreibyf/aishacrm-2-mcp:latest` — built by `docker-release.yml` on
+version-tag push. Same image for `server` and `node` roles; behavior is
+selected by the `MCP_ROLE` env var.

--- a/deploy/coolify/ai-runtime/docker-compose.staging.yml
+++ b/deploy/coolify/ai-runtime/docker-compose.staging.yml
@@ -1,0 +1,101 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: ai-runtime  STAGING LANE  (Phase C — do NOT deploy for
+#                                                 Phase A smoke test)
+# Services: braid-mcp-staging-server, braid-mcp-staging-1, braid-mcp-staging-2
+#
+# Staging MCP cluster wired into the staging aisha-app backend and staging
+# Redis. Never talks to prod Redis or prod backend.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  braid-mcp-server:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:${IMAGE_TAG:-latest}
+    container_name: braid-mcp-staging-server
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8100:8000"
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: server
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN_STAGING:-}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG_STAGING:-stg_stg}
+      CRM_BACKEND_URL: http://aishacrm-staging-backend:3001
+      REDIS_URL: redis://aishacrm-staging-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+  braid-mcp-1:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:${IMAGE_TAG:-latest}
+    container_name: braid-mcp-staging-1
+    restart: unless-stopped
+    depends_on:
+      - braid-mcp-server
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: node
+      MCP_NODE_ID: "staging-1"
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN_STAGING:-}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG_STAGING:-stg_stg}
+      MCP_SERVER_URL: http://braid-mcp-staging-server:8000
+      CRM_BACKEND_URL: http://aishacrm-staging-backend:3001
+      REDIS_URL: redis://aishacrm-staging-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+  braid-mcp-2:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:${IMAGE_TAG:-latest}
+    container_name: braid-mcp-staging-2
+    restart: unless-stopped
+    depends_on:
+      - braid-mcp-server
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: node
+      MCP_NODE_ID: "staging-2"
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN_STAGING:-}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG_STAGING:-stg_stg}
+      MCP_SERVER_URL: http://braid-mcp-staging-server:8000
+      CRM_BACKEND_URL: http://aishacrm-staging-backend:3001
+      REDIS_URL: redis://aishacrm-staging-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+networks:
+  aishanet-staging:
+    external: true

--- a/deploy/coolify/ai-runtime/docker-compose.yml
+++ b/deploy/coolify/ai-runtime/docker-compose.yml
@@ -1,0 +1,109 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: ai-runtime  (mid-change tier)
+# Services: braid-mcp-server, braid-mcp-1, braid-mcp-2
+# Cadence:  follows Braid tool-registry and DSL evolution. Deployed less often
+#           than the core app but more often than AI infrastructure.
+#
+# This compose mirrors braid-mcp-node-server/docker-compose.prod.yml but lives
+# under the Coolify deployment split so all domains share one layout.
+#
+# Cross-domain wiring:
+#   - aishacrm-backend     → consumed by MCP nodes as CRM_BACKEND_URL
+#   - aishacrm-redis-memory → session state (REDIS_URL)
+#
+# Image source: same GHCR image (aishacrm-2-mcp:latest) as today. Upstream
+# CI (docker-release.yml) publishes the image on tag push.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  braid-mcp-server:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:latest
+    container_name: braid-mcp-server
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:8000"
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: server
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG:-prd_prd}
+      CRM_BACKEND_URL: http://aishacrm-backend:3001
+      REDIS_URL: redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+  braid-mcp-1:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:latest
+    container_name: braid-mcp-1
+    restart: unless-stopped
+    depends_on:
+      - braid-mcp-server
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: node
+      MCP_NODE_ID: "1"
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG:-prd_prd}
+      MCP_SERVER_URL: http://braid-mcp-server:8000
+      CRM_BACKEND_URL: http://aishacrm-backend:3001
+      REDIS_URL: redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+  braid-mcp-2:
+    image: ghcr.io/andreibyf/aishacrm-2-mcp:latest
+    container_name: braid-mcp-2
+    restart: unless-stopped
+    depends_on:
+      - braid-mcp-server
+    environment:
+      NODE_ENV: production
+      MCP_ROLE: node
+      MCP_NODE_ID: "2"
+      DOPPLER_TOKEN: ${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      DOPPLER_PROJECT: ${DOPPLER_PROJECT:-aishacrm}
+      DOPPLER_CONFIG: ${DOPPLER_CONFIG:-prd_prd}
+      MCP_SERVER_URL: http://braid-mcp-server:8000
+      CRM_BACKEND_URL: http://aishacrm-backend:3001
+      REDIS_URL: redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+networks:
+  aishanet:
+    external: true

--- a/deploy/coolify/aisha-app/.env.example
+++ b/deploy/coolify/aisha-app/.env.example
@@ -1,0 +1,28 @@
+# Compose-substitution variables for deploy/coolify/aisha-app/docker-compose.yml
+# These are the ${VARS} resolved at `docker compose up` time.
+# Runtime secrets are injected by Doppler inside the container — NOT listed here.
+
+# Doppler
+DOPPLER_TOKEN=
+DOPPLER_TOKEN_PROD=
+DOPPLER_PROJECT=aishacrm
+DOPPLER_CONFIG=prd_prd
+
+# Node
+NODE_OPTIONS=--dns-result-order=ipv4first
+
+# Cross-domain URLs (override for non-prod previews)
+PUBLIC_SCHEDULER_URL=https://scheduler.aishacrm.com
+BRAID_MCP_URL=http://braid-mcp-server:8000
+MCP_NODE_HEALTH_URL=http://braid-mcp-server:8000/health
+MCP_NODE_ID=aishacrm-backend-prod
+
+# Communications worker
+COMMUNICATIONS_WORKER_POLL_INTERVAL_MS=60000
+
+# Frontend build/runtime URLs
+VITE_AISHACRM_BACKEND_URL=https://api.aishacrm.com
+VITE_CALCOM_URL=https://scheduler.aishacrm.com
+VITE_OPENREPLAY_PROJECT_KEY=
+VITE_OPENREPLAY_INGEST_POINT=
+VITE_OPENREPLAY_DASHBOARD_URL=https://replay.aishacrm.com

--- a/deploy/coolify/aisha-app/.env.staging.example
+++ b/deploy/coolify/aisha-app/.env.staging.example
@@ -1,0 +1,34 @@
+# Compose-substitution variables for the STAGING lane.
+# See deploy/coolify/STAGING.md for context.
+
+# Image tag to deploy (defaults to :latest; set to a release tag or SHA for
+# pinned smoke tests)
+IMAGE_TAG=latest
+
+# Doppler — staging
+# Create a dedicated service token scoped to the stg_stg config; do NOT reuse
+# DOPPLER_TOKEN_PROD.
+DOPPLER_TOKEN_STAGING=
+DOPPLER_PROJECT=aishacrm
+DOPPLER_CONFIG_STAGING=stg_stg
+
+# Node
+NODE_OPTIONS=--dns-result-order=ipv4first
+
+# Staging URLs — used by backend and for frontend runtime injection.
+PUBLIC_SCHEDULER_URL_STAGING=https://staging-scheduler.aishacrm.com
+VITE_AISHACRM_BACKEND_URL_STAGING=https://staging-api.aishacrm.com
+VITE_CALCOM_URL_STAGING=https://staging-scheduler.aishacrm.com
+
+# Cross-domain wiring — staging hostnames (internal Docker DNS on
+# aishanet-staging)
+BRAID_MCP_URL_STAGING=http://braid-mcp-staging-server:8000
+MCP_NODE_HEALTH_URL_STAGING=http://braid-mcp-staging-server:8000/health
+MCP_NODE_ID_STAGING=aishacrm-backend-staging
+LITELLM_BASE_URL_STAGING=http://aishacrm-staging-litellm:4000
+
+# Safety flags for Phase A
+AI_TRIGGERS_WORKER_ENABLED_STAGING=false
+
+# Communications worker (Phase B)
+COMMUNICATIONS_WORKER_POLL_INTERVAL_MS=60000

--- a/deploy/coolify/aisha-app/README.md
+++ b/deploy/coolify/aisha-app/README.md
@@ -1,0 +1,44 @@
+# aisha-app (fast-change app path)
+
+**Services:** `frontend`, `backend`, `aisha-comms`
+
+**Change cadence:** every release tag. This is the domain that receives all
+day-to-day feature work. Failures here should not take down data, scheduling,
+AI, or observability stacks.
+
+## Cross-domain dependencies at runtime
+
+| Depends on                                      | From domain  | How                                       |
+| ----------------------------------------------- | ------------ | ----------------------------------------- |
+| `aishacrm-redis-memory`, `aishacrm-redis-cache` | data-support | `REDIS_URL`, `REDIS_CACHE_URL`            |
+| `braid-mcp-server`                              | ai-runtime   | `BRAID_MCP_URL`, `MCP_NODE_HEALTH_URL`    |
+| `litellm`                                       | ai-infra     | `LITELLM_BASE_URL`                        |
+| `calcom` (browser URL only)                     | scheduling   | `VITE_CALCOM_URL`, `PUBLIC_SCHEDULER_URL` |
+
+All cross-domain resolution is by **container name on the `aishanet` external
+Docker network**. Every domain that this one depends on must attach to the same
+external network.
+
+## Secrets
+
+- All runtime secrets are injected by Doppler (`prd_prd` config) via the
+  backend/frontend entrypoint scripts. This file intentionally does **not**
+  enumerate secrets.
+- `.env.example` in this folder lists only the compose-substitution variables
+  (things like `DOPPLER_TOKEN`, `VITE_AISHACRM_BACKEND_URL`) that are resolved
+  at `docker compose up` time, not runtime.
+
+## Not in this domain
+
+- No Redis (→ `data-support`)
+- No Cal.com (→ `scheduling`)
+- No Ollama / LiteLLM / Braid MCP (→ `ai-infra` / `ai-runtime`)
+- No OpenReplay (→ `observability`)
+- No landing page, Hawser, Caddy (→ `support-infra` notes)
+
+## Relationship to current deployment
+
+Today, production is served by `docker-compose.prod.yml` at the repo root. That
+file is still authoritative. This file is a **prepared split** for the Coolify
+migration and is not wired into CI yet. See
+`docs/deployment/coolify-migration.md`.

--- a/deploy/coolify/aisha-app/docker-compose.staging.yml
+++ b/deploy/coolify/aisha-app/docker-compose.staging.yml
@@ -1,0 +1,148 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: aisha-app  STAGING LANE
+# Services: frontend, backend  (comms is Phase B — commented out below)
+#
+# Deployed alongside production on the same VPS. Uses:
+#   - container prefix   aishacrm-staging-*
+#   - network            aishanet-staging (external; create with
+#                        `docker network create aishanet-staging`)
+#   - Doppler config     stg_stg
+#   - host port offset   +100 from prod (frontend 4100, backend 4101)
+#
+# See deploy/coolify/STAGING.md for the full strategy and Phase A/B/C
+# rollout sequence.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  backend:
+    # IMAGE_TAG lets you smoke-test a specific build without touching prod.
+    # Default :latest matches what docker-release.yml publishes on tag push.
+    image: ghcr.io/andreibyf/aishacrm-2-backend:${IMAGE_TAG:-latest}
+    container_name: aishacrm-staging-backend
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4101:3001"
+    environment:
+      # Doppler — staging config, staging token
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN_STAGING:-}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG_STAGING:-stg_stg}
+      - NODE_ENV=production
+      - NODE_OPTIONS=${NODE_OPTIONS:---dns-result-order=ipv4first}
+      # Staging URLs — do NOT point these at prod hostnames
+      - PUBLIC_SCHEDULER_URL=${PUBLIC_SCHEDULER_URL_STAGING:-https://staging-scheduler.aishacrm.com}
+      # Cross-domain wiring → data-support (STAGING)
+      - REDIS_URL=redis://aishacrm-staging-redis-memory:6379
+      - REDIS_CACHE_URL=redis://aishacrm-staging-redis-cache:6379
+      # Cross-domain wiring → ai-runtime (STAGING)
+      # If staging ai-runtime is not yet deployed, these hostnames will not
+      # resolve and related features will be disabled. That is intentional
+      # for Phase A.
+      - BRAID_MCP_URL=${BRAID_MCP_URL_STAGING:-http://braid-mcp-staging-server:8000}
+      - MCP_NODE_HEALTH_URL=${MCP_NODE_HEALTH_URL_STAGING:-http://braid-mcp-staging-server:8000/health}
+      - MCP_NODE_ID=${MCP_NODE_ID_STAGING:-aishacrm-backend-staging}
+      # PEP — still use Groq in staging (keeps behaviour close to prod)
+      - PEP_LLM_PROVIDER=groq
+      - PEP_LLM_MODEL=llama-3.3-70b-versatile
+      # Cross-domain wiring → ai-infra (STAGING). Same Phase A caveat as above.
+      - LITELLM_BASE_URL=${LITELLM_BASE_URL_STAGING:-http://aishacrm-staging-litellm:4000}
+      - TELEMETRY_ENABLED=false
+      # Phase A safety: disable background workers and outbound triggers.
+      # Flip to true in stg_stg Doppler config only when you're deliberately
+      # exercising those code paths.
+      - AI_TRIGGERS_WORKER_ENABLED=${AI_TRIGGERS_WORKER_ENABLED_STAGING:-false}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+  frontend:
+    image: ghcr.io/andreibyf/aishacrm-2-frontend:${IMAGE_TAG:-latest}
+    container_name: aishacrm-staging-frontend
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "127.0.0.1:4100:3000"
+    environment:
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN_STAGING:-}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG_STAGING:-stg_stg}
+      # Browser-facing staging URLs. The frontend bundle MUST NOT resolve to
+      # prod origins — run `grep -r "api.aishacrm.com" dist/` post-build to
+      # verify.
+      - VITE_AISHACRM_BACKEND_URL=${VITE_AISHACRM_BACKEND_URL_STAGING:-https://staging-api.aishacrm.com}
+      - VITE_CALCOM_URL=${VITE_CALCOM_URL_STAGING:-https://staging-scheduler.aishacrm.com}
+      # OpenReplay on staging: leave blank to disable the tracker entirely.
+      # The SDK is in the bundle either way; empty env vars short-circuit it.
+      - VITE_OPENREPLAY_PROJECT_KEY=
+      - VITE_OPENREPLAY_INGEST_POINT=
+      - VITE_OPENREPLAY_DASHBOARD_URL=
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet-staging
+
+  # ── Phase B — uncomment when ready ─────────────────────────────────────────
+  # Do NOT uncomment until you've confirmed staging comms will not drain prod
+  # queues. Either scope it to a test tenant or keep
+  # AI_TRIGGERS_WORKER_ENABLED=false in stg_stg Doppler.
+  #
+  # aisha-comms:
+  #   image: ghcr.io/andreibyf/aishacrm-2-backend:${IMAGE_TAG:-latest}
+  #   container_name: aishacrm-staging-comms
+  #   restart: unless-stopped
+  #   depends_on:
+  #     backend:
+  #       condition: service_healthy
+  #   command: ["npm", "run", "worker:communications"]
+  #   environment:
+  #     - DOPPLER_TOKEN=${DOPPLER_TOKEN_STAGING:-}
+  #     - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+  #     - DOPPLER_CONFIG=${DOPPLER_CONFIG_STAGING:-stg_stg}
+  #     - NODE_ENV=production
+  #     - NODE_OPTIONS=${NODE_OPTIONS:---dns-result-order=ipv4first}
+  #     - REDIS_URL=redis://aishacrm-staging-redis-memory:6379
+  #     - REDIS_CACHE_URL=redis://aishacrm-staging-redis-cache:6379
+  #     - CRM_BACKEND_URL=http://aishacrm-staging-backend:3001
+  #     - COMMUNICATIONS_WORKER_POLL_INTERVAL_MS=${COMMUNICATIONS_WORKER_POLL_INTERVAL_MS:-60000}
+  #     - COMMUNICATIONS_WORKER_HEARTBEAT_PATH=/tmp/communications-worker-heartbeat.json
+  #   healthcheck:
+  #     test: [
+  #       "CMD-SHELL",
+  #       "node -e \"const fs=require('fs');const p=process.env.COMMUNICATIONS_WORKER_HEARTBEAT_PATH||'/tmp/communications-worker-heartbeat.json';const configured=Number.parseInt(process.env.COMMUNICATIONS_WORKER_POLL_INTERVAL_MS||'',10);const pollMs=Number.isInteger(configured)&&configured>0?configured:60000;const maxLagMs=Math.max(180000,pollMs*3);const s=fs.statSync(p);process.exit(Date.now()-s.mtimeMs<maxLagMs?0:1)\""
+  #     ]
+  #     interval: 30s
+  #     timeout: 5s
+  #     retries: 3
+  #     start_period: 20s
+  #   logging:
+  #     driver: json-file
+  #     options:
+  #       max-size: "10m"
+  #       max-file: "3"
+  #   networks:
+  #     - aishanet-staging
+
+networks:
+  aishanet-staging:
+    external: true

--- a/deploy/coolify/aisha-app/docker-compose.yml
+++ b/deploy/coolify/aisha-app/docker-compose.yml
@@ -1,0 +1,134 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: aisha-app  (fast-change path)
+# Services: frontend, backend, aisha-comms
+# Cadence:  every tag → GHCR → auto-deploy
+#
+# Separation status:
+#   - This file is an INITIAL SPLIT. Production today is still served by
+#     ../../../docker-compose.prod.yml at the repo root. Do NOT delete that file.
+#   - Once Coolify picks this split up in a future migration, this file will be
+#     authoritative for the fast-change path only.
+#
+# Cross-domain dependencies (runtime wiring):
+#   - redis-memory, redis-cache           → data-support domain
+#   - braid-mcp-server                    → ai-runtime domain
+#   - litellm                             → ai-infra domain
+#   - calcom (callback URL only)          → scheduling domain
+#
+# All containers attach to the external 'aishanet' Docker network so services
+# can resolve each other by container_name across deployment domains.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  backend:
+    image: ghcr.io/andreibyf/aishacrm-2-backend:latest
+    container_name: aishacrm-backend
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4001:3001"
+    environment:
+      # Doppler injects secrets at runtime via backend entrypoint (doppler run)
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - NODE_ENV=production
+      - NODE_OPTIONS=${NODE_OPTIONS:---dns-result-order=ipv4first}
+      - PUBLIC_SCHEDULER_URL=${PUBLIC_SCHEDULER_URL:-https://scheduler.aishacrm.com}
+      # Cross-domain wiring → data-support
+      - REDIS_URL=redis://aishacrm-redis-memory:6379
+      - REDIS_CACHE_URL=redis://aishacrm-redis-cache:6379
+      # Cross-domain wiring → ai-runtime
+      - BRAID_MCP_URL=${BRAID_MCP_URL:-http://braid-mcp-server:8000}
+      - MCP_NODE_HEALTH_URL=${MCP_NODE_HEALTH_URL:-http://braid-mcp-server:8000/health}
+      - MCP_NODE_ID=${MCP_NODE_ID:-aishacrm-backend-prod}
+      # PEP Custom Query — use Groq in prod (Ollama lives in ai-infra for local LLMs only)
+      - PEP_LLM_PROVIDER=groq
+      - PEP_LLM_MODEL=llama-3.3-70b-versatile
+      # Cross-domain wiring → ai-infra (LiteLLM proxy)
+      - LITELLM_BASE_URL=http://litellm:4000
+      - TELEMETRY_ENABLED=false
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+  aisha-comms:
+    image: ghcr.io/andreibyf/aishacrm-2-backend:latest
+    container_name: aishacrm-comms
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    command: ["npm", "run", "worker:communications"]
+    environment:
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - NODE_ENV=production
+      - NODE_OPTIONS=${NODE_OPTIONS:---dns-result-order=ipv4first}
+      - REDIS_URL=redis://aishacrm-redis-memory:6379
+      - REDIS_CACHE_URL=redis://aishacrm-redis-cache:6379
+      - CRM_BACKEND_URL=http://aishacrm-backend:3001
+      - COMMUNICATIONS_WORKER_POLL_INTERVAL_MS=${COMMUNICATIONS_WORKER_POLL_INTERVAL_MS:-60000}
+      - COMMUNICATIONS_WORKER_HEARTBEAT_PATH=/tmp/communications-worker-heartbeat.json
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "node -e \"const fs=require('fs');const p=process.env.COMMUNICATIONS_WORKER_HEARTBEAT_PATH||'/tmp/communications-worker-heartbeat.json';const configured=Number.parseInt(process.env.COMMUNICATIONS_WORKER_POLL_INTERVAL_MS||'',10);const pollMs=Number.isInteger(configured)&&configured>0?configured:60000;const maxLagMs=Math.max(180000,pollMs*3);const s=fs.statSync(p);process.exit(Date.now()-s.mtimeMs<maxLagMs?0:1)\""
+      ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+  frontend:
+    image: ghcr.io/andreibyf/aishacrm-2-frontend:latest
+    container_name: aishacrm-frontend
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "4000:3000"
+    environment:
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - VITE_AISHACRM_BACKEND_URL=${VITE_AISHACRM_BACKEND_URL:-https://api.aishacrm.com}
+      - VITE_CALCOM_URL=${VITE_CALCOM_URL:-https://scheduler.aishacrm.com}
+      - VITE_OPENREPLAY_PROJECT_KEY=${VITE_OPENREPLAY_PROJECT_KEY:-}
+      - VITE_OPENREPLAY_INGEST_POINT=${VITE_OPENREPLAY_INGEST_POINT:-}
+      - VITE_OPENREPLAY_DASHBOARD_URL=${VITE_OPENREPLAY_DASHBOARD_URL:-https://replay.aishacrm.com}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - aishanet
+
+networks:
+  aishanet:
+    external: true

--- a/deploy/coolify/data-support/README.md
+++ b/deploy/coolify/data-support/README.md
@@ -1,0 +1,32 @@
+# data-support (Redis tier)
+
+**Services:** `redis-memory`, `redis-cache`
+
+**Change cadence:** very rare. Only touched on Redis major-version bumps or
+memory-sizing changes. Failures here take down consumers in `aisha-app`,
+`ai-runtime`, and `ai-infra`, so this domain should be deployed first when
+standing up an environment and never rolled in lockstep with app code.
+
+## Consumers
+
+| Consumer               | Domain     | Variable                       |
+| ---------------------- | ---------- | ------------------------------ |
+| `aishacrm-backend`     | aisha-app  | `REDIS_URL`, `REDIS_CACHE_URL` |
+| `aishacrm-comms`       | aisha-app  | `REDIS_URL`, `REDIS_CACHE_URL` |
+| `braid-mcp-server/1/2` | ai-runtime | `REDIS_URL`                    |
+
+## Endpoints
+
+- `redis://aishacrm-redis-memory:6379` (agent sessions, Bull queues)
+- `redis://aishacrm-redis-cache:6379` (API response caching)
+
+## Persistence
+
+Both use named local volumes (`redis_memory_data`, `redis_cache_data`) so data
+survives container restarts. `redis-cache` disables RDB (`--save ""`) by design
+— it is pure ephemeral cache.
+
+## Not in this domain
+
+No application code, no Postgres (Supabase is managed separately; Cal.com has
+its own Postgres in `scheduling`), no search or vector DB.

--- a/deploy/coolify/data-support/docker-compose.staging.yml
+++ b/deploy/coolify/data-support/docker-compose.staging.yml
@@ -1,0 +1,69 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: data-support  STAGING LANE
+# Services: redis-memory, redis-cache
+#
+# Ephemeral staging Redis. Dedicated volumes, no shared state with prod.
+# Host port offset +100 from prod (6379→6479, 6380→6480).
+#
+# Deploy order for Phase A:
+#   1. data-support  (this file)      ← first
+#   2. aisha-app     (staging compose) ← then
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  redis-memory:
+    image: redis:7-alpine
+    container_name: aishacrm-staging-redis-memory
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6479:6379"
+    volumes:
+      - redis_memory_data_staging:/data
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 128mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet-staging
+
+  redis-cache:
+    image: redis:7-alpine
+    container_name: aishacrm-staging-redis-cache
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6480:6379"
+    volumes:
+      - redis_cache_data_staging:/data
+    command: redis-server --save "" --loglevel warning --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet-staging
+
+volumes:
+  # Separate volumes from prod so staging cannot corrupt prod data.
+  redis_memory_data_staging:
+    driver: local
+  redis_cache_data_staging:
+    driver: local
+
+networks:
+  aishanet-staging:
+    external: true

--- a/deploy/coolify/data-support/docker-compose.yml
+++ b/deploy/coolify/data-support/docker-compose.yml
@@ -1,0 +1,68 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: data-support
+# Services: redis-memory, redis-cache
+# Cadence:  very rare. Only bumped on Redis major versions or sizing changes.
+#
+# Both Redis instances attach to the external 'aishanet' network so services
+# in the aisha-app, ai-runtime, and ai-infra domains can reach them by
+# container_name. Consumers connect via:
+#   redis-memory : redis://aishacrm-redis-memory:6379
+#   redis-cache  : redis://aishacrm-redis-cache:6379
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  redis-memory:
+    image: redis:7-alpine
+    container_name: aishacrm-redis-memory
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redis_memory_data:/data
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 256mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet
+
+  redis-cache:
+    image: redis:7-alpine
+    container_name: aishacrm-redis-cache
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6380:6379"
+    volumes:
+      - redis_cache_data:/data
+    command: redis-server --save "" --loglevel warning --maxmemory 512mb --maxmemory-policy allkeys-lru
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "2"
+    networks:
+      - aishanet
+
+volumes:
+  redis_memory_data:
+    driver: local
+  redis_cache_data:
+    driver: local
+
+networks:
+  aishanet:
+    external: true

--- a/deploy/coolify/observability/README.md
+++ b/deploy/coolify/observability/README.md
@@ -1,0 +1,15 @@
+# observability — OUT OF SCOPE
+
+OpenReplay auto-manages its own stack (including its own Caddy) on the
+production VPS under `/opt/openreplay` and is **not** part of this repo's
+deployment split.
+
+This folder is a tombstone. It can be safely deleted:
+
+```
+git rm -r deploy/coolify/observability
+```
+
+If anyone later needs to add true observability for aishacrm (metrics, traces,
+logs pipeline), do it in a fresh domain folder with a clear scope — do not
+resurrect this one.

--- a/deploy/coolify/scheduling/.env.example
+++ b/deploy/coolify/scheduling/.env.example
@@ -1,0 +1,21 @@
+# Compose-substitution variables for deploy/coolify/scheduling/docker-compose.yml
+
+# Cal.com Postgres
+CALCOM_DB_USER=calcom
+CALCOM_DB_PASSWORD=
+CALCOM_DB_NAME=calcom
+
+# Cal.com app
+CALCOM_PUBLIC_URL=https://scheduler.aishacrm.com
+CALCOM_NEXTAUTH_SECRET=
+CALCOM_ENCRYPTION_KEY=
+# Must include surrounding quotes — Cal.com JSON.parse()s this wrapped in []
+CALCOM_ALLOWED_HOSTNAMES="scheduler.aishacrm.com"
+CALCOM_LICENSE_KEY=59c0bed7-8b21-4280-8514-e022fbfc24c7
+
+# Cal.com SMTP
+CALCOM_EMAIL_FROM=noreply@aishacrm.com
+CALCOM_SMTP_HOST=
+CALCOM_SMTP_PORT=587
+CALCOM_SMTP_USER=
+CALCOM_SMTP_PASSWORD=

--- a/deploy/coolify/scheduling/.env.staging.example
+++ b/deploy/coolify/scheduling/.env.staging.example
@@ -1,0 +1,22 @@
+# Compose-substitution variables for STAGING Cal.com.
+# See deploy/coolify/STAGING.md.
+
+# Staging Cal.com Postgres (isolated from prod)
+CALCOM_DB_USER_STAGING=calcom
+CALCOM_DB_PASSWORD_STAGING=
+CALCOM_DB_NAME_STAGING=calcom_staging
+
+# Staging Cal.com app
+CALCOM_PUBLIC_URL_STAGING=https://staging-scheduler.aishacrm.com
+CALCOM_NEXTAUTH_SECRET_STAGING=
+CALCOM_ENCRYPTION_KEY_STAGING=
+# Note the surrounding quotes — Cal.com JSON.parses this wrapped in [].
+CALCOM_ALLOWED_HOSTNAMES_STAGING="staging-scheduler.aishacrm.com"
+CALCOM_LICENSE_KEY=59c0bed7-8b21-4280-8514-e022fbfc24c7
+
+# Staging SMTP (leave blank to disable outbound mail from staging Cal.com)
+CALCOM_EMAIL_FROM_STAGING=noreply-staging@aishacrm.com
+CALCOM_SMTP_HOST_STAGING=
+CALCOM_SMTP_PORT_STAGING=587
+CALCOM_SMTP_USER_STAGING=
+CALCOM_SMTP_PASSWORD_STAGING=

--- a/deploy/coolify/scheduling/README.md
+++ b/deploy/coolify/scheduling/README.md
@@ -1,0 +1,46 @@
+# scheduling (Cal.com tier)
+
+**Services:** `calcom`, `calcom-db`
+
+**Change cadence:** mid — upgraded when a new Cal.com image is vetted, SMTP
+changes, or encryption keys rotate. Not tied to app release tags.
+
+## Caddy note
+
+**Caddy is not included in this compose.** No Caddy configuration files exist
+anywhere in the repo. If `scheduler.aishacrm.com` is fronted by Caddy on the
+VPS, that config is maintained out-of-band and should stay that way until
+someone commits it deliberately. See `docs/deployment/coolify-migration.md`.
+
+## DB isolation
+
+Cal.com uses its own Postgres (`aishacrm-calcom-db`), **not** Supabase. Sharing
+the AiSHA Supabase DB is unsupported — Cal.com's raw Prisma connections
+conflict with RLS. Do not point `DATABASE_URL` at Supabase.
+
+## Image pinning
+
+The Cal.com image is pinned to a digest that mirrors the current
+`docker-compose.prod.yml` (2026-04-07 known-good). To upgrade, follow the
+verification path already documented in that file: confirm `Host` table,
+`_user_eventtype`, and `ALLOWED_HOSTNAMES` handling after the bump.
+
+## `ALLOWED_HOSTNAMES` gotcha
+
+Cal.com parses it as `JSON.parse(\`[${ALLOWED_HOSTNAMES}]\`)`. The value must
+include surrounding double-quotes, i.e. `"scheduler.aishacrm.com"`, not
+`scheduler.aishacrm.com`.
+
+## Init script path
+
+`calcom-db` mounts `../../../scripts/calcom-db-init.sql` (repo root). If Coolify
+launches this compose with the folder itself as build context rather than the
+repo root, the bind-mount path will need updating. This is one of the
+manual-confirmation items in the migration doc.
+
+## Consumers
+
+| Consumer            | Domain    | Variable                                                                                                      |
+| ------------------- | --------- | ------------------------------------------------------------------------------------------------------------- |
+| `aishacrm-backend`  | aisha-app | `CALCOM_DB_URL` (reads Cal.com DB for booking integrations), `CALCOM_WEBHOOK_BACKEND_URL` (internal callback) |
+| `aishacrm-frontend` | aisha-app | `VITE_CALCOM_URL` (browser-facing)                                                                            |

--- a/deploy/coolify/scheduling/docker-compose.staging.yml
+++ b/deploy/coolify/scheduling/docker-compose.staging.yml
@@ -1,0 +1,86 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: scheduling  STAGING LANE  (Phase C — do NOT deploy for
+#                                                Phase A smoke test)
+# Services: calcom, calcom-db
+#
+# Isolated staging Cal.com with its own Postgres and its own public URL.
+# Never points Cal.com at the prod scheduler hostname.
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  calcom-db:
+    image: postgres:15-alpine
+    container_name: aishacrm-staging-calcom-db
+    restart: unless-stopped
+    networks:
+      - aishanet-staging
+    environment:
+      POSTGRES_USER: ${CALCOM_DB_USER_STAGING:-calcom}
+      POSTGRES_PASSWORD: ${CALCOM_DB_PASSWORD_STAGING}
+      POSTGRES_DB: ${CALCOM_DB_NAME_STAGING:-calcom_staging}
+    volumes:
+      - calcom_db_data_staging:/var/lib/postgresql/data
+      # Same init script as prod — relative to repo root.
+      - ../../../scripts/calcom-db-init.sql:/docker-entrypoint-initdb.d/calcom-db-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${CALCOM_DB_USER_STAGING:-calcom}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  calcom:
+    # Pin to the same known-good digest as prod to keep staging/prod aligned
+    # during migration testing. Bump both together when validating upgrades.
+    image: calcom/cal.com@sha256:0aca8203c51dd7e7e74b71713d028c70f2ae8d58ae987901ac19567dc8d59d98
+    container_name: aishacrm-staging-calcom
+    restart: unless-stopped
+    depends_on:
+      calcom-db:
+        condition: service_healthy
+    networks:
+      - aishanet-staging
+    environment:
+      - DATABASE_URL=postgresql://${CALCOM_DB_USER_STAGING:-calcom}:${CALCOM_DB_PASSWORD_STAGING}@aishacrm-staging-calcom-db:5432/${CALCOM_DB_NAME_STAGING:-calcom_staging}
+      - DATABASE_DIRECT_URL=postgresql://${CALCOM_DB_USER_STAGING:-calcom}:${CALCOM_DB_PASSWORD_STAGING}@aishacrm-staging-calcom-db:5432/${CALCOM_DB_NAME_STAGING:-calcom_staging}
+      - NEXTAUTH_SECRET=${CALCOM_NEXTAUTH_SECRET_STAGING}
+      # MUST be the staging hostname — never prod.
+      - CALCOM_PUBLIC_URL=${CALCOM_PUBLIC_URL_STAGING:-https://staging-scheduler.aishacrm.com}
+      - NEXTAUTH_URL=${CALCOM_PUBLIC_URL_STAGING:-https://staging-scheduler.aishacrm.com}
+      - NEXTAUTH_URL_INTERNAL=http://aishacrm-staging-calcom:3000
+      - CALENDSO_ENCRYPTION_KEY=${CALCOM_ENCRYPTION_KEY_STAGING}
+      - NEXT_PUBLIC_WEBAPP_URL=${CALCOM_PUBLIC_URL_STAGING:-https://staging-scheduler.aishacrm.com}
+      - ALLOWED_HOSTNAMES=${CALCOM_ALLOWED_HOSTNAMES_STAGING:-"staging-scheduler.aishacrm.com"}
+      - CALCOM_LICENSE_KEY=${CALCOM_LICENSE_KEY:-59c0bed7-8b21-4280-8514-e022fbfc24c7}
+      # SMTP: default to blank so staging cannot send real email unless you
+      # deliberately wire up a sandbox SMTP.
+      - EMAIL_FROM=${CALCOM_EMAIL_FROM_STAGING:-noreply-staging@aishacrm.com}
+      - EMAIL_SERVER_HOST=${CALCOM_SMTP_HOST_STAGING:-}
+      - EMAIL_SERVER_PORT=${CALCOM_SMTP_PORT_STAGING:-587}
+      - EMAIL_SERVER_USER=${CALCOM_SMTP_USER_STAGING:-}
+      - EMAIL_SERVER_PASSWORD=${CALCOM_SMTP_PASSWORD_STAGING:-}
+    ports:
+      - "127.0.0.1:3102:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-fL", "http://localhost:3000/auth/login"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  calcom_db_data_staging:
+    driver: local
+
+networks:
+  aishanet-staging:
+    external: true

--- a/deploy/coolify/scheduling/docker-compose.yml
+++ b/deploy/coolify/scheduling/docker-compose.yml
@@ -1,0 +1,99 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Deployment domain: scheduling  (mid-change tier)
+# Services: calcom, calcom-db
+# Cadence:  quarterly-ish — Cal.com image digest bumps, schema migrations, SMTP
+#           or encryption-key rotations. Not tied to core app release tags.
+#
+# Caddy:    intentionally NOT included. No Caddy files exist in this repo. If
+#           the production VPS uses Caddy in front of scheduler.aishacrm.com,
+#           that config lives outside the repo and should stay that way until
+#           someone commits it deliberately.
+#
+# DB isolation: Cal.com uses its own Postgres (calcom-db), NOT Supabase. Sharing
+#               the AiSHA Supabase DB is unsupported (RLS conflicts with Cal.com's
+#               raw Prisma/pg connections).
+#
+# Image pinning: the Cal.com image is pinned to a known-good digest from the
+#                existing docker-compose.prod.yml. To upgrade, follow the same
+#                verification process used there (Host table, _user_eventtype,
+#                ALLOWED_HOSTNAMES).
+# ──────────────────────────────────────────────────────────────────────────────
+
+services:
+  calcom-db:
+    image: postgres:15-alpine
+    container_name: aishacrm-calcom-db
+    restart: unless-stopped
+    networks:
+      - aishanet
+    environment:
+      POSTGRES_USER: ${CALCOM_DB_USER:-calcom}
+      POSTGRES_PASSWORD: ${CALCOM_DB_PASSWORD}
+      POSTGRES_DB: ${CALCOM_DB_NAME:-calcom}
+    volumes:
+      - calcom_db_data:/var/lib/postgresql/data
+      # Init script runs once on fresh volume creation (idempotent backfill).
+      # Path is relative to the project root because Coolify typically sets
+      # build context at the repo root; adjust if Coolify uses this folder
+      # as the context instead.
+      - ../../../scripts/calcom-db-init.sql:/docker-entrypoint-initdb.d/calcom-db-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${CALCOM_DB_USER:-calcom}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  calcom:
+    # Pinned digest matches docker-compose.prod.yml (2026-04-07 known-good).
+    image: calcom/cal.com@sha256:0aca8203c51dd7e7e74b71713d028c70f2ae8d58ae987901ac19567dc8d59d98
+    container_name: aishacrm-calcom
+    restart: unless-stopped
+    depends_on:
+      calcom-db:
+        condition: service_healthy
+    networks:
+      - aishanet
+    environment:
+      - DATABASE_URL=postgresql://${CALCOM_DB_USER:-calcom}:${CALCOM_DB_PASSWORD}@calcom-db:5432/${CALCOM_DB_NAME:-calcom}
+      - DATABASE_DIRECT_URL=postgresql://${CALCOM_DB_USER:-calcom}:${CALCOM_DB_PASSWORD}@calcom-db:5432/${CALCOM_DB_NAME:-calcom}
+      - NEXTAUTH_SECRET=${CALCOM_NEXTAUTH_SECRET}
+      - CALCOM_PUBLIC_URL=${CALCOM_PUBLIC_URL:-https://scheduler.aishacrm.com}
+      - NEXTAUTH_URL=${CALCOM_PUBLIC_URL:-https://scheduler.aishacrm.com}
+      - NEXTAUTH_URL_INTERNAL=http://calcom:3000
+      - CALENDSO_ENCRYPTION_KEY=${CALCOM_ENCRYPTION_KEY}
+      - NEXT_PUBLIC_WEBAPP_URL=${CALCOM_PUBLIC_URL:-https://scheduler.aishacrm.com}
+      # Cal.com parses this as JSON.parse(`[${ALLOWED_HOSTNAMES}]`) — must be
+      # quoted: "scheduler.aishacrm.com" (include the surrounding quotes).
+      - ALLOWED_HOSTNAMES=${CALCOM_ALLOWED_HOSTNAMES:-"scheduler.aishacrm.com"}
+      - CALCOM_LICENSE_KEY=${CALCOM_LICENSE_KEY:-59c0bed7-8b21-4280-8514-e022fbfc24c7}
+      - EMAIL_FROM=${CALCOM_EMAIL_FROM:-noreply@aishacrm.com}
+      - EMAIL_SERVER_HOST=${CALCOM_SMTP_HOST}
+      - EMAIL_SERVER_PORT=${CALCOM_SMTP_PORT:-587}
+      - EMAIL_SERVER_USER=${CALCOM_SMTP_USER}
+      - EMAIL_SERVER_PASSWORD=${CALCOM_SMTP_PASSWORD}
+    ports:
+      - "127.0.0.1:3002:3000"
+    healthcheck:
+      test: ["CMD", "curl", "-fL", "http://localhost:3000/auth/login"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+volumes:
+  calcom_db_data:
+    driver: local
+
+networks:
+  aishanet:
+    external: true

--- a/deploy/coolify/support-infra/README.md
+++ b/deploy/coolify/support-infra/README.md
@@ -1,0 +1,42 @@
+# support-infra (out-of-scope helpers)
+
+**Status:** README-only. Documents containers that exist on the production VPS
+but are **not** managed from this repo's Coolify deployment split.
+
+## Rule
+
+> This repo's Coolify deployment split only covers **aishacrm**. Anything
+> else the VPS runs — landing page, OpenReplay, containerd helpers — stays
+> out of scope and is not bundled with the fast app path.
+
+## Out-of-scope containers (documented for awareness only)
+
+### `hawser` — prod-side Dockhand facilitator
+
+Exposes the prod Docker socket to the local Dockhand UI. Infrastructure.
+Not deployed from this repo. Do not add to any Coolify domain here.
+
+### `aisha-landing` (marketing site)
+
+Deployed independently from `/opt/aisha-landing` on the production VPS.
+Different lifecycle, different domain (`aishacrm.com`), different blast
+radius from the CRM app. Do not fold into `aisha-app`.
+
+### OpenReplay
+
+Self-managed stack in `/opt/openreplay`. Auto-manages its own edge (Caddy).
+Not a deployment domain here. See `deploy/coolify/observability/README.md`
+(tombstone).
+
+### Caddy
+
+Not managed from this repo. OpenReplay auto-creates its own Caddy. No Caddy
+is required in front of the aishacrm Coolify domains at this stage. Do not
+add Caddy configuration here.
+
+### n8n (deprecated)
+
+No longer used. Still referenced in the current root compose files behind a
+`workflows` profile; those entries remain only because this refactor is
+additive. n8n is not in any Coolify deployment domain and should not appear
+in future planning.

--- a/docs/deployment/coolify-migration.md
+++ b/docs/deployment/coolify-migration.md
@@ -1,0 +1,160 @@
+# Coolify migration plan
+
+This document describes **why** the current deployment workflow is being
+split, **what** the target domains look like, and **how** to migrate in a
+low-risk order. It does **not** yet introduce Coolify platform-specific
+config — the first step is separation of surfaces.
+
+## Scope
+
+The split covers only **aishacrm**. The production VPS (`/opt`) also runs:
+
+- `/opt/aisha-landing` — marketing site (separate deployment, out of scope)
+- `/opt/openreplay` — self-managed OpenReplay stack with its own auto-created
+  edge (out of scope)
+- `containerd` and related helpers — infrastructure (out of scope)
+
+None of those are bundled into this split. See `deploy/coolify/support-infra/README.md`.
+
+## Validation strategy — parallel staging lane, not in-place replacement
+
+**Cutover is the last step, not the first.** Before any prod container is
+touched, the full split is validated on the same VPS as a parallel staging
+lane with disjoint names, ports, network, and Doppler config. See
+`deploy/coolify/STAGING.md` for the complete strategy and the Phase A/B/C
+rollout sequence. The short version:
+
+- **Phase A (smoke).** Deploy `data-support/docker-compose.staging.yml`
+  then `aisha-app/docker-compose.staging.yml` (frontend + backend only).
+  Point at `staging-app.aishacrm.com` / `staging-api.aishacrm.com`.
+  Validate mechanics end to end.
+- **Phase B.** Uncomment `aisha-comms` in the aisha-app staging compose
+  once you've confirmed it will not process live prod queues.
+- **Phase C.** Deploy scheduling, ai-runtime, ai-infra staging files one at
+  a time — each has its own staging compose already prepared.
+- **Only after all three phases pass** does cutover become a conversation,
+  and cutover itself is a separate PR.
+
+Each staging lane uses its own Doppler config (`stg_stg`) — prod secrets
+(`prd_prd`) are never touched by the staging deploy.
+
+## Why the current workflow is too bundled
+
+1. **Single compose file carries the whole runtime.**
+   `docker-compose.prod.yml` at the repo root defines the core app (frontend,
+   backend, aisha-comms), the Redis tier, LiteLLM, and Cal.com behind a
+   profile. Any change — app, LiteLLM, Cal.com — touches the same file and
+   is deployed with the same pipeline.
+
+2. **Blast radius is wider than the change surface.** The app releases on
+   every tag. Redis, LiteLLM, and Cal.com do not. Bundling them means a bad
+   app release risks disturbing services that did not need to roll.
+
+3. **Rollback is all-or-nothing.** Rolling back the app today can pull Cal.com
+   or Redis config along with it, because they share a compose file and often
+   share `${VARS}`.
+
+4. **Support/edge containers are implicit.** Ollama runs outside the compose
+   (standalone Dockhand). Hawser is a VPS facility. Nothing captures the
+   change-cadence difference between Braid MCP (mid) and LiteLLM/Ollama
+   (rare), so they end up being deployed with similar urgency despite
+   different risk profiles.
+
+## Target deployment domains
+
+Single rule: **deployment domains reflect what changes together, fails
+together, and should roll back together.**
+
+| Domain        | Services                                   | Cadence             | Ownership implication                     |
+| ------------- | ------------------------------------------ | ------------------- | ----------------------------------------- |
+| aisha-app     | frontend, backend, aisha-comms             | fast (every tag)    | App team — release-tag driven             |
+| data-support  | redis-memory, redis-cache                  | very rare           | Infra — version bumps only                |
+| scheduling    | calcom, calcom-db                          | mid (quarterly-ish) | App team — image digest bumps, SMTP, keys |
+| ai-runtime    | braid-mcp-server, braid-mcp-1, braid-mcp-2 | mid                 | Braid team — registry/DSL driven          |
+| ai-infra      | ollama, litellm                            | rare                | Infra — image/model bumps                 |
+| support-infra | (docs only — hawser, landing, openreplay)  | n/a                 | Infra — **not Coolify-managed**           |
+
+Each domain has both a production compose (`docker-compose.yml`) and a
+staging compose (`docker-compose.staging.yml`). Staging lives on the same
+VPS as prod but is fully isolated (see `STAGING.md`).
+
+## Migration order (lowest risk first)
+
+Each step is validated on the staging lane first, then promoted.
+
+1. **aisha-app.** Move the fast-change path first. Phase A smoke test is
+   frontend+backend only. This is the domain with the highest deploy
+   frequency, so getting its split right has the best payoff and exposes
+   the most friction early.
+2. **data-support.** Standalone Redis. Already part of Phase A (backend's
+   staging compose depends on staging Redis). No app dependencies to
+   untangle.
+3. **scheduling.** Cal.com is already the most isolated piece of the current
+   runtime (own DB, own profile). Lowest coupling to the rest — easy move.
+4. **ai-runtime.** Braid MCP already ships from its own image and its own
+   compose file today (`braid-mcp-node-server/docker-compose.prod.yml`).
+   Cutting it over to `deploy/coolify/ai-runtime/` is mostly a path change.
+5. **ai-infra.** Ollama and LiteLLM. Ollama is the tricky one because its
+   model-data volume must be preserved across the cutover — plan the volume
+   migration before stopping the standalone Dockhand container.
+
+## Guardrails honored by this refactor
+
+- **Additive only.** No existing compose files were removed. `docker-compose.yml`,
+  `docker-compose.prod.yml`, and `braid-mcp-node-server/docker-compose.prod.yml`
+  remain authoritative until cutover.
+- **No Coolify lock-in yet.** No platform secrets, no Coolify-specific glue.
+- **No repo multiplication.** Single repo, new subtree.
+- **No behavioral changes to app code.**
+- **No n8n in future planning.** Existing compose entries left in place
+  (additive rule), but the planning artifacts do not carry n8n forward.
+- **Scope discipline.** Caddy, OpenReplay, the landing page, and Hawser are
+  all out of scope. Not bundled, not referenced as deployment domains,
+  not assumed.
+- **Staging never touches prod resources.** Separate network, ports,
+  container names, volumes, and Doppler config. Enforced by
+  `tests/deployment/compose-topology.test.js`.
+
+## Items requiring manual confirmation
+
+1. **Create the `stg_stg` Doppler config** (new `stg` environment) before
+   deploying any staging lane. Start as a copy of `prd_prd` and override
+   URLs, outbound keys, and tenant scoping. See `STAGING.md`.
+2. **Create a `DOPPLER_TOKEN_STAGING` service token** scoped to `stg_stg`.
+   Do not reuse `DOPPLER_TOKEN_PROD`.
+3. **Create the `aishanet-staging` Docker network** on the VPS:
+   `docker network create aishanet-staging`.
+4. **Add DNS** for `staging-app`, `staging-api`, `staging-scheduler`. Do not
+   reassign existing prod records.
+5. **Ollama volume cutover.** The standalone `aishacrm-ollama` Dockhand
+   container mounts a volume with pulled model weights. Confirm the volume
+   name and mount path before replacing the container via the new compose.
+6. **Model preload for Ollama.** Current entrypoint preloads `llama3.2:3b`
+   and `qwen2.5-coder:3b`. Production uses `llama3.1:8b` for summaries
+   (`SUMMARY_LLM_MODEL` in Doppler `prd_prd`). Decide whether to update the
+   entrypoint or add a post-start pull hook in Coolify.
+7. **Cal.com init script path.** The scheduling compose bind-mounts
+   `../../../scripts/calcom-db-init.sql` (repo-root relative). Confirm Coolify
+   launches compose with the repo root as build context.
+8. **`CALCOM_*` secrets (prod and staging).** Cal.com requires
+   `CALCOM_NEXTAUTH_SECRET` and `CALCOM_ENCRYPTION_KEY` to be available at
+   compose-up time (Cal.com's pre-built image does not run Doppler inside
+   it). Coolify secret injection must be set up for both prod and staging
+   scheduling domains before each cutover.
+9. **External network provisioning.** Both `aishanet` and `aishanet-staging`
+   must exist on the host before any domain is started.
+10. **Braid MCP duplicate compose.** `braid-mcp-node-server/docker-compose.prod.yml`
+    still exists and is authoritative for the current deployment. Keep it in
+    sync with `deploy/coolify/ai-runtime/docker-compose.yml` manually until
+    cutover, then retire the old file in a dedicated PR.
+
+## When to retire the root compose files
+
+Only after:
+
+- Every domain above has been deployed via Coolify on the staging lane
+  successfully
+- At least one staging Phase A → B → C cycle has completed end-to-end
+- A cutover dry run has been performed on the staging lane (redeploy from
+  scratch with Coolify only)
+- All `docs/deployment/env-matrix.md` entries have owners assigned in Coolify

--- a/docs/deployment/env-matrix.md
+++ b/docs/deployment/env-matrix.md
@@ -1,0 +1,122 @@
+# Environment variable matrix by deployment domain
+
+This matrix maps environment variables to the **domain that owns them** and
+the **services that consume them**. The goal is to make it obvious which
+deployment domain a given secret or config var should be scoped to in Coolify,
+so a change in one domain cannot accidentally alter behavior in another.
+
+Conventions used below:
+
+- **Owner** = the domain whose deployment unit a secret/config is defined in.
+- **Consumed by** = services that read the variable at runtime.
+- **Doppler** = secret is injected from Doppler at container start time
+  (via the entrypoint's `doppler run`). Not set directly in compose.
+- **Compose** = variable is resolved at `docker compose up` time, from the
+  host shell or Coolify's environment panel. Usually a URL, a Doppler token
+  bootstrap, or a public identifier.
+- **Build** = variable is baked into the frontend bundle at image build time.
+
+## Doppler configs by lane
+
+| Lane    | Doppler config | Service token env var   | Compose file(s)                                                          |
+| ------- | -------------- | ----------------------- | ------------------------------------------------------------------------ |
+| dev     | `dev_personal` | `DOPPLER_TOKEN`         | root `docker-compose.yml`                                                |
+| prod    | `prd_prd`      | `DOPPLER_TOKEN_PROD`    | `deploy/coolify/*/docker-compose.yml` and root `docker-compose.prod.yml` |
+| staging | `stg_stg`      | `DOPPLER_TOKEN_STAGING` | `deploy/coolify/*/docker-compose.staging.yml`                            |
+
+Staging tokens and staging configs are **separate from prod** by design — no
+re-use, no fallback. Rotation stays blast-radius-scoped.
+
+## aisha-app
+
+| Variable                                      | Type    | Owner     | Consumed by              | Notes                                                                                                                 |
+| --------------------------------------------- | ------- | --------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `DOPPLER_TOKEN`, `DOPPLER_TOKEN_PROD`         | Compose | aisha-app | backend, comms, frontend | Bootstrap for runtime Doppler fetch. Rotate per env.                                                                  |
+| `DOPPLER_TOKEN_STAGING`                       | Compose | aisha-app | staging backend/frontend | Staging-only token. Scoped to `stg_stg`.                                                                              |
+| `DOPPLER_PROJECT`                             | Compose | aisha-app | backend, comms, frontend | Typically `aishacrm`.                                                                                                 |
+| `DOPPLER_CONFIG`, `DOPPLER_CONFIG_STAGING`    | Compose | aisha-app | backend, comms, frontend | `prd_prd` in prod, `stg_stg` in staging.                                                                              |
+| `IMAGE_TAG`                                   | Compose | aisha-app | staging backend/frontend | Lets you smoke-test a specific build without prod impact. Default `latest`.                                           |
+| `NODE_ENV`, `NODE_OPTIONS`                    | Compose | aisha-app | backend, comms           | `NODE_OPTIONS=--dns-result-order=ipv4first` in prod.                                                                  |
+| `REDIS_URL`                                   | Compose | aisha-app | backend, comms           | Points at `redis://aishacrm-redis-memory:6379` (prod) / `redis://aishacrm-staging-redis-memory:6379` (staging).       |
+| `REDIS_CACHE_URL`                             | Compose | aisha-app | backend, comms           | Same pattern.                                                                                                         |
+| `BRAID_MCP_URL`, `MCP_NODE_HEALTH_URL`        | Compose | aisha-app | backend                  | Points at `braid-mcp-server:8000` (prod) / `braid-mcp-staging-server:8000` (staging).                                 |
+| `MCP_NODE_ID`                                 | Compose | aisha-app | backend                  | Identifier for CARE/telemetry.                                                                                        |
+| `LITELLM_BASE_URL`                            | Compose | aisha-app | backend                  | Internal URL to LiteLLM in the relevant lane.                                                                         |
+| `LITELLM_ENABLED`, `LITELLM_MASTER_KEY`       | Doppler | aisha-app | backend                  | Injected at runtime, not in compose.                                                                                  |
+| `PEP_LLM_PROVIDER`, `PEP_LLM_MODEL`           | Compose | aisha-app | backend                  | `groq` in both prod and staging.                                                                                      |
+| `GROQ_API_KEY`                                | Doppler | aisha-app | backend                  | Injected at runtime.                                                                                                  |
+| `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`   | Doppler | aisha-app | backend, comms           | Injected at runtime. Staging may point at the dev Supabase project (`efzqxjpfewkrgpdootte`) via the `stg_stg` config. |
+| `SYSTEM_TENANT_ID`, `DEFAULT_TENANT_ID`       | Doppler | aisha-app | backend, comms           | Injected at runtime. Consider a dedicated test tenant in staging.                                                     |
+| `TELEMETRY_ENABLED`                           | Compose | aisha-app | backend                  | `false` in both prod and staging.                                                                                     |
+| `AI_TRIGGERS_WORKER_ENABLED`                  | Doppler | aisha-app | backend, comms           | Prod: true (or as configured). Staging Phase A: **false**. Flip on only when exercising that path.                    |
+| `PUBLIC_SCHEDULER_URL`                        | Compose | aisha-app | backend                  | `https://scheduler.aishacrm.com` / `https://staging-scheduler.aishacrm.com`.                                          |
+| `CRM_BACKEND_URL`                             | Compose | aisha-app | comms                    | Internal URL to backend in the relevant lane.                                                                         |
+| `COMMUNICATIONS_WORKER_POLL_INTERVAL_MS`      | Compose | aisha-app | comms                    | Defaults to 60000.                                                                                                    |
+| `COMMUNICATIONS_WORKER_HEARTBEAT_PATH`        | Compose | aisha-app | comms                    | Used by healthcheck.                                                                                                  |
+| `VITE_AISHACRM_BACKEND_URL`                   | Compose | aisha-app | frontend (runtime)       | `https://api.aishacrm.com` / `https://staging-api.aishacrm.com`.                                                      |
+| `VITE_CALCOM_URL`                             | Compose | aisha-app | frontend (runtime)       | `https://scheduler.aishacrm.com` / `https://staging-scheduler.aishacrm.com`.                                          |
+| `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY` | Build   | aisha-app | frontend (build)         | Baked into dist via Dockerfile.                                                                                       |
+| `VITE_OPENREPLAY_*`                           | Compose | aisha-app | frontend (runtime)       | Leave empty to disable the tracker. OpenReplay itself is out of deployment scope. Always empty in staging.            |
+
+## data-support
+
+| Variable | Type | Owner        | Consumed by               | Notes                                                                                                 |
+| -------- | ---- | ------------ | ------------------------- | ----------------------------------------------------------------------------------------------------- |
+| (none)   | —    | data-support | redis-memory, redis-cache | Both Redis instances run with hard-coded CLI flags. No secrets. Staging uses a reduced maxmemory cap. |
+
+## scheduling
+
+| Variable                                | Type    | Owner      | Consumed by       | Notes                                                     |
+| --------------------------------------- | ------- | ---------- | ----------------- | --------------------------------------------------------- |
+| `CALCOM_DB_USER` / `_STAGING`           | Compose | scheduling | calcom-db, calcom | Defaults to `calcom`.                                     |
+| `CALCOM_DB_PASSWORD` / `_STAGING`       | Compose | scheduling | calcom-db, calcom | Must be set. No default.                                  |
+| `CALCOM_DB_NAME` / `_STAGING`           | Compose | scheduling | calcom-db, calcom | Prod `calcom`, staging `calcom_staging`.                  |
+| `CALCOM_PUBLIC_URL` / `_STAGING`        | Compose | scheduling | calcom            | Must include scheme. Never reuse the prod URL in staging. |
+| `CALCOM_NEXTAUTH_SECRET` / `_STAGING`   | Compose | scheduling | calcom            | Required at compose-up. Separate values per lane.         |
+| `CALCOM_ENCRYPTION_KEY` / `_STAGING`    | Compose | scheduling | calcom            | Required at compose-up. Separate values per lane.         |
+| `CALCOM_ALLOWED_HOSTNAMES` / `_STAGING` | Compose | scheduling | calcom            | Must include surrounding quotes.                          |
+| `CALCOM_LICENSE_KEY`                    | Compose | scheduling | calcom            | Shared between lanes.                                     |
+| `CALCOM_EMAIL_FROM` / `_STAGING`        | Compose | scheduling | calcom            | Staging defaults to `noreply-staging@aishacrm.com`.       |
+| `CALCOM_SMTP_*` / `_STAGING`            | Compose | scheduling | calcom            | Leave staging SMTP blank unless you're exercising mail.   |
+| `CALCOM_DB_URL` (consumer)              | Doppler | aisha-app  | backend           | Backend's view of Cal.com DB. Lives in aisha-app secrets. |
+
+## ai-runtime
+
+| Variable                                    | Type    | Owner      | Consumed by                 | Notes                                                    |
+| ------------------------------------------- | ------- | ---------- | --------------------------- | -------------------------------------------------------- |
+| `DOPPLER_TOKEN_*`                           | Compose | ai-runtime | braid-mcp-\* (server, 1, 2) | Same bootstrap pattern as app.                           |
+| `DOPPLER_PROJECT`                           | Compose | ai-runtime | braid-mcp-\*                | `aishacrm`.                                              |
+| `DOPPLER_CONFIG` / `DOPPLER_CONFIG_STAGING` | Compose | ai-runtime | braid-mcp-\*                | `prd_prd` / `stg_stg`.                                   |
+| `IMAGE_TAG`                                 | Compose | ai-runtime | braid-mcp-\* (staging)      | For pinned smoke tests.                                  |
+| `CRM_BACKEND_URL`                           | Compose | ai-runtime | braid-mcp-\*                | Lane-appropriate backend hostname.                       |
+| `REDIS_URL`                                 | Compose | ai-runtime | braid-mcp-\*                | Lane-appropriate Redis hostname.                         |
+| `MCP_SERVER_URL`                            | Compose | ai-runtime | braid-mcp-1, -2             | Lane-appropriate server hostname.                        |
+| `MCP_ROLE`                                  | Compose | ai-runtime | braid-mcp-\*                | `server` or `node`.                                      |
+| `MCP_NODE_ID`                               | Compose | ai-runtime | braid-mcp-1, -2             | Prod: `"1"`/`"2"`. Staging: `"staging-1"`/`"staging-2"`. |
+
+## ai-infra
+
+| Variable                                    | Type    | Owner    | Consumed by       | Notes                                               |
+| ------------------------------------------- | ------- | -------- | ----------------- | --------------------------------------------------- |
+| `OLLAMA_NUM_CTX`                            | Compose | ai-infra | ollama            | Default 1024.                                       |
+| `OLLAMA_MAX_LOADED_MODELS`                  | Compose | ai-infra | ollama            | Default 1.                                          |
+| `OLLAMA_KEEP_ALIVE`                         | Compose | ai-infra | ollama            | `-1` (keep loaded indefinitely).                    |
+| `OLLAMA_NUM_PARALLEL`                       | Compose | ai-infra | ollama            | Prod 2, staging 1 (lower load).                     |
+| `DOPPLER_TOKEN_*`                           | Compose | ai-infra | litellm           | Bootstrap only; LiteLLM reads its config from file. |
+| `DOPPLER_PROJECT`                           | Compose | ai-infra | litellm           | `aishacrm`.                                         |
+| `DOPPLER_CONFIG` / `DOPPLER_CONFIG_STAGING` | Compose | ai-infra | litellm           | `prd_prd` / `stg_stg`.                              |
+| `IMAGE_TAG`                                 | Compose | ai-infra | litellm (staging) | For pinned smoke tests.                             |
+
+## support-infra
+
+None. Hawser, the landing page, and OpenReplay are not managed from this
+repo and therefore own no variables here.
+
+## Ownership rule of thumb
+
+If changing a variable should force a redeploy of domain X but not domain Y,
+the variable belongs in X. If two domains truly need the same value, define
+it in **both** domains' Coolify secret stores rather than sharing a single
+scope — the short-term duplication is cheaper than the long-term blast
+radius of shared state. The same rule applies across lanes: every `_STAGING`
+variant is a deliberate second-copy, not a shared value.

--- a/tests/deployment/compose-topology.test.js
+++ b/tests/deployment/compose-topology.test.js
@@ -1,0 +1,329 @@
+// tests/deployment/compose-topology.test.js
+//
+// Validates the deploy/coolify/* split for BOTH prod and staging lanes.
+//
+// For each domain we verify:
+//   - services listed are exactly the expected set
+//   - no service leaks between deployment domains
+//   - every compose file declares the expected external network
+//   - staging files use the staging network, staging container prefix, and
+//     do not accidentally bind to prod host ports
+//   - no deprecated or out-of-scope services appear anywhere
+//
+// Runs with plain `node --test` — no new dependencies.
+//
+// Usage:
+//   node --test tests/deployment/compose-topology.test.js
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+// Expected service names by domain. Staging uses the same logical service
+// keys under `services:` — only container_name changes.
+const DOMAINS = {
+  'aisha-app': {
+    prod: ['frontend', 'backend', 'aisha-comms'],
+    staging: ['frontend', 'backend'], // aisha-comms is Phase B (commented out)
+  },
+  'data-support': {
+    prod: ['redis-memory', 'redis-cache'],
+    staging: ['redis-memory', 'redis-cache'],
+  },
+  scheduling: {
+    prod: ['calcom-db', 'calcom'],
+    staging: ['calcom-db', 'calcom'],
+  },
+  'ai-runtime': {
+    prod: ['braid-mcp-server', 'braid-mcp-1', 'braid-mcp-2'],
+    staging: ['braid-mcp-server', 'braid-mcp-1', 'braid-mcp-2'],
+  },
+  'ai-infra': {
+    prod: ['ollama', 'litellm'],
+    staging: ['ollama', 'litellm'],
+  },
+};
+
+const PROD_NETWORK = 'aishanet';
+const STAGING_NETWORK = 'aishanet-staging';
+
+// Prod host ports that must NEVER appear bound in a staging file.
+const PROD_HOST_PORTS = [
+  '4000', // frontend
+  '4001', // backend
+  '6379', // redis-memory (host side)
+  '6380', // redis-cache (host side)
+  '3002', // calcom
+  '8000', // braid-mcp-server (host side)
+  '11434', // ollama (host side)
+  '11436', // dev ollama (host side)
+  '4002', // litellm (host side)
+];
+
+function composePath(domain, lane) {
+  return path.join(
+    repoRoot,
+    'deploy',
+    'coolify',
+    domain,
+    lane === 'staging' ? 'docker-compose.staging.yml' : 'docker-compose.yml',
+  );
+}
+
+// Minimal YAML scanner — top-level service key names under `services:`.
+function extractServiceNames(yaml) {
+  const lines = yaml.split(/\r?\n/);
+  const services = [];
+  let inServices = false;
+  for (const line of lines) {
+    if (/^services:\s*$/.test(line)) {
+      inServices = true;
+      continue;
+    }
+    if (!inServices) continue;
+    // A new top-level block ends the services section.
+    if (/^[A-Za-z_][\w-]*:\s*$/.test(line)) {
+      break;
+    }
+    // Skip commented lines (Phase B aisha-comms block).
+    if (/^\s*#/.test(line)) continue;
+    const match = line.match(/^ {2}([a-zA-Z0-9][a-zA-Z0-9_-]*):\s*$/);
+    if (match) services.push(match[1]);
+  }
+  return services;
+}
+
+function hasExternalNetwork(yaml, name) {
+  const networksIdx = yaml.search(/^networks:\s*$/m);
+  if (networksIdx === -1) return false;
+  const tail = yaml.slice(networksIdx);
+  const nameRe = new RegExp(`^ {2}${name.replace(/-/g, '-')}:\\s*$`, 'm');
+  const nameIdx = tail.search(nameRe);
+  if (nameIdx === -1) return false;
+  const block = tail.slice(nameIdx);
+  const endOfBlock = block.slice(1).search(/^ {2}[a-zA-Z]/m);
+  const slice = endOfBlock === -1 ? block : block.slice(0, endOfBlock + 1);
+  return /^ {4}external:\s*true\s*$/m.test(slice);
+}
+
+// Pull out container_name values (uncommented) to verify the staging prefix.
+function extractContainerNames(yaml) {
+  return [...yaml.matchAll(/^\s*container_name:\s*([A-Za-z0-9._-]+)\s*$/gm)].map((m) => m[1]);
+}
+
+// Pull out published host ports from any `ports:` block entries.
+// Looks for strings like "127.0.0.1:4100:3000" or "4100:3000".
+function extractPublishedHostPorts(yaml) {
+  const ports = [];
+  const re = /^\s*-\s*"([^"]+)"\s*$/gm;
+  let m;
+  while ((m = re.exec(yaml)) !== null) {
+    const spec = m[1];
+    // Strip optional IP prefix.
+    const parts = spec.split(':');
+    let host;
+    if (parts.length === 3)
+      host = parts[1]; // "ip:host:container"
+    else if (parts.length === 2)
+      host = parts[0]; // "host:container"
+    else continue;
+    if (/^\d+$/.test(host)) ports.push(host);
+  }
+  return ports;
+}
+
+// ── prod lane ────────────────────────────────────────────────────────────────
+
+test("[prod] every domain's compose file exists", () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const p = composePath(domain, 'prod');
+    assert.ok(fs.existsSync(p), `missing prod compose at ${p}`);
+  }
+});
+
+test('[prod] each domain declares exactly its services', () => {
+  for (const [domain, expected] of Object.entries(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'prod'), 'utf8');
+    const actual = extractServiceNames(yaml).sort();
+    const want = [...expected.prod].sort();
+    assert.deepEqual(
+      actual,
+      want,
+      `prod "${domain}" has ${JSON.stringify(actual)}, want ${JSON.stringify(want)}`,
+    );
+  }
+});
+
+test('[prod] no service appears in more than one domain', () => {
+  const seen = new Map();
+  for (const [domain, { prod }] of Object.entries(DOMAINS)) {
+    for (const svc of prod) {
+      if (seen.has(svc)) {
+        assert.fail(`service "${svc}" appears in both "${seen.get(domain)}" and "${domain}"`);
+      }
+      seen.set(svc, domain);
+    }
+  }
+});
+
+test('[prod] every compose joins the external aishanet network', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'prod'), 'utf8');
+    assert.ok(
+      hasExternalNetwork(yaml, PROD_NETWORK),
+      `prod "${domain}" missing external ${PROD_NETWORK}`,
+    );
+  }
+});
+
+test('[prod] no domain declares n8n, openreplay, or caddy (out of scope)', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'prod'), 'utf8');
+    const services = extractServiceNames(yaml);
+    for (const forbidden of ['n8n', 'n8n-proxy', 'openreplay', 'caddy', 'caddy-proxy']) {
+      assert.ok(!services.includes(forbidden), `prod "${domain}" must not declare "${forbidden}"`);
+    }
+  }
+});
+
+// ── staging lane ─────────────────────────────────────────────────────────────
+
+test("[staging] every domain's staging compose file exists", () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const p = composePath(domain, 'staging');
+    assert.ok(fs.existsSync(p), `missing staging compose at ${p}`);
+  }
+});
+
+test('[staging] each domain declares exactly its services', () => {
+  for (const [domain, expected] of Object.entries(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    const actual = extractServiceNames(yaml).sort();
+    const want = [...expected.staging].sort();
+    assert.deepEqual(
+      actual,
+      want,
+      `staging "${domain}" has ${JSON.stringify(actual)}, want ${JSON.stringify(want)}`,
+    );
+  }
+});
+
+test('[staging] every compose joins the external aishanet-staging network', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    assert.ok(
+      hasExternalNetwork(yaml, STAGING_NETWORK),
+      `staging "${domain}" missing external ${STAGING_NETWORK}`,
+    );
+  }
+});
+
+test('[staging] every container_name uses the staging prefix', () => {
+  const allowedPrefixes = ['aishacrm-staging-', 'braid-mcp-staging-'];
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    const names = extractContainerNames(yaml);
+    assert.ok(names.length > 0, `staging "${domain}" has no container_name set`);
+    for (const name of names) {
+      const ok = allowedPrefixes.some((p) => name.startsWith(p));
+      assert.ok(
+        ok,
+        `staging "${domain}" container_name "${name}" must start with one of ${JSON.stringify(
+          allowedPrefixes,
+        )}`,
+      );
+    }
+  }
+});
+
+test('[staging] no prod host port is bound by any staging service', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    const hostPorts = extractPublishedHostPorts(yaml);
+    for (const port of hostPorts) {
+      assert.ok(
+        !PROD_HOST_PORTS.includes(port),
+        `staging "${domain}" binds prod host port ${port} — would collide with production`,
+      );
+    }
+  }
+});
+
+test('[staging] no domain declares n8n, openreplay, or caddy', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    const services = extractServiceNames(yaml);
+    for (const forbidden of ['n8n', 'n8n-proxy', 'openreplay', 'caddy', 'caddy-proxy']) {
+      assert.ok(
+        !services.includes(forbidden),
+        `staging "${domain}" must not declare "${forbidden}"`,
+      );
+    }
+  }
+});
+
+test('[staging] staging compose does NOT reference the prod network', () => {
+  for (const domain of Object.keys(DOMAINS)) {
+    const yaml = fs.readFileSync(composePath(domain, 'staging'), 'utf8');
+    // Fail if staging compose attaches any service to the prod `aishanet`
+    // network. Allow the word to appear in comments — match only YAML usage:
+    // either `- aishanet` (network list membership) or `  aishanet:` (network
+    // definition at 2-space indent).
+    const listMatch = /^\s*-\s*aishanet\s*$/m.test(yaml);
+    const defMatch = /^ {2}aishanet:\s*$/m.test(yaml);
+    assert.ok(
+      !listMatch && !defMatch,
+      `staging "${domain}" references the prod network "aishanet" — must use "aishanet-staging"`,
+    );
+  }
+});
+
+// ── cross-lane: prod and staging must not clash on container_name ────────────
+
+test('[cross] prod and staging container_names are disjoint', () => {
+  const prodNames = new Set();
+  const stagingNames = new Set();
+  for (const domain of Object.keys(DOMAINS)) {
+    for (const lane of ['prod', 'staging']) {
+      const yaml = fs.readFileSync(composePath(domain, lane), 'utf8');
+      const target = lane === 'prod' ? prodNames : stagingNames;
+      for (const name of extractContainerNames(yaml)) target.add(name);
+    }
+  }
+  for (const name of prodNames) {
+    assert.ok(
+      !stagingNames.has(name),
+      `container_name "${name}" appears in both prod and staging — will collide on the VPS`,
+    );
+  }
+});
+
+// ── support-infra is README-only ─────────────────────────────────────────────
+
+test('support-infra is README-only (no compose)', () => {
+  const p = path.join(repoRoot, 'deploy', 'coolify', 'support-infra', 'docker-compose.yml');
+  assert.ok(
+    !fs.existsSync(p),
+    `"support-infra" must remain README-only; unexpected compose at ${p}`,
+  );
+  const readme = path.join(repoRoot, 'deploy', 'coolify', 'support-infra', 'README.md');
+  assert.ok(fs.existsSync(readme), `"support-infra" README.md required`);
+});
+
+// ── docs ─────────────────────────────────────────────────────────────────────
+
+test('deployment docs exist', () => {
+  for (const rel of [
+    'docs/deployment/coolify-migration.md',
+    'docs/deployment/env-matrix.md',
+    'deploy/coolify/STAGING.md',
+  ]) {
+    const p = path.join(repoRoot, rel);
+    assert.ok(fs.existsSync(p), `missing: ${rel}`);
+  }
+});


### PR DESCRIPTION
## Summary
Add the initial Coolify deployment split structure and docs across service domains.

## What changed
- Added split deployment compose configs under `deploy/coolify/` for:
  - `aisha-app`
  - `ai-runtime`
  - `ai-infra`
  - `data-support`
  - `scheduling`
  - `observability`
  - `support-infra`
- Added staging variants and env examples where applicable
- Added deployment docs:
  - `docs/deployment/coolify-migration.md`
  - `docs/deployment/env-matrix.md`
- Added topology validation test:
  - `tests/deployment/compose-topology.test.js`

## Validation
- Pre-push checks passed
- Backend test suite passed (0 failures)

## Notes
Draft PR requested since this is not ready for review yet.