### PR TITLE
fix(frontend): stop cache-buster defeating request dedup on hot paths

### DIFF
--- a/src/components/settings/CalendarSync.jsx
+++ b/src/components/settings/CalendarSync.jsx
@@ -134,17 +134,16 @@ export default function CalendarSync({ tenantId }) {
     if (!tenantId) return;
     setLoading(true);
     try {
-      const cacheBust = `_t=${Date.now()}`;
       // Check if tenant has scheduling integration configured
       const res = await apiFetch(
-        `/api/tenantintegrations?tenant_id=${tenantId}&integration_type=calcom&${cacheBust}`,
+        `/api/tenantintegrations?tenant_id=${tenantId}&integration_type=calcom`,
       );
       const json = res.status === 304 ? {} : await res.json().catch(() => ({}));
       let integration = getTenantIntegrationRecord(json);
 
       // Fallback: if filtered query returned no row, load full tenant list and find calcom.
       if (!integration) {
-        const allRes = await apiFetch(`/api/tenantintegrations?tenant_id=${tenantId}&${cacheBust}`);
+        const allRes = await apiFetch(`/api/tenantintegrations?tenant_id=${tenantId}`);
         const allJson = await allRes.json().catch(() => ({}));
         const rows = allJson?.data?.tenantintegrations || allJson?.data || [];
         if (Array.isArray(rows)) {

--- a/src/components/settings/EntityLabelsManager.jsx
+++ b/src/components/settings/EntityLabelsManager.jsx
@@ -97,17 +97,9 @@ export default function EntityLabelsManager({ isTenantAdmin = false }) {
 
       try {
         setLoading(true);
-        // Add cache-busting timestamp to prevent 304 responses
-        const cacheBuster = Date.now();
-        const response = await fetch(
-          `${BACKEND_URL}/api/entity-labels/${selectedTenantId}?_t=${cacheBuster}`,
-          {
-            credentials: 'include',
-            headers: {
-              'Cache-Control': 'no-cache',
-            },
-          },
-        );
+        const response = await fetch(`${BACKEND_URL}/api/entity-labels/${selectedTenantId}`, {
+          credentials: 'include',
+        });
 
         if (response.ok) {
           const data = await response.json();

--- a/src/components/shared/ApiManager.jsx
+++ b/src/components/shared/ApiManager.jsx
@@ -15,7 +15,10 @@ export const ApiProvider = ({ children }) => {
       // options.ttlMs for data that changes rarely (tenant list, module
       // settings) to avoid navigation-triggered refetches.
       const defaultTimeout = import.meta.env.DEV ? 1000 : 2000;
-      const ttl = typeof options.ttlMs === 'number' ? options.ttlMs : defaultTimeout;
+      // Use Number.isFinite so NaN / Infinity fall back to the default.
+      // Otherwise NaN would silently disable caching and Infinity would never
+      // expire — both easy foot-guns for callers passing a computed ttlMs.
+      const ttl = Number.isFinite(options.ttlMs) ? options.ttlMs : defaultTimeout;
 
       if (cacheRef.current.has(cacheKey)) {
         const cached = cacheRef.current.get(cacheKey);
@@ -46,6 +49,18 @@ export const ApiProvider = ({ children }) => {
     [],
   );
 
+  // Synchronous cache peek. Lets callers (e.g., EntityLabelsContext) know
+  // whether a subsequent cachedRequest will resolve from cache so they can
+  // skip UI loading-state flicker on tenant-switch-back within the TTL window.
+  const peek = useCallback((entityName, methodName, params, options = {}) => {
+    const cacheKey = `${entityName}.${methodName}:${JSON.stringify(params)}`;
+    if (!cacheRef.current.has(cacheKey)) return false;
+    const cached = cacheRef.current.get(cacheKey);
+    const defaultTimeout = import.meta.env.DEV ? 1000 : 2000;
+    const ttl = Number.isFinite(options.ttlMs) ? options.ttlMs : defaultTimeout;
+    return Date.now() - cached.timestamp < ttl;
+  }, []);
+
   const clearCache = useCallback((pattern) => {
     if (!pattern) {
       cacheRef.current.clear();
@@ -74,7 +89,7 @@ export const ApiProvider = ({ children }) => {
   );
 
   return (
-    <ApiContext.Provider value={{ cachedRequest, clearCache, clearCacheByKey }}>
+    <ApiContext.Provider value={{ cachedRequest, peek, clearCache, clearCacheByKey }}>
       {children}
     </ApiContext.Provider>
   );

--- a/src/components/shared/ApiManager.jsx
+++ b/src/components/shared/ApiManager.jsx
@@ -7,38 +7,44 @@ export const ApiProvider = ({ children }) => {
   const cacheRef = useRef(new Map());
   const pendingRequestsRef = useRef(new Map());
 
-  const cachedRequest = useCallback(async (entityName, methodName, params, fetcher) => {
-    const cacheKey = `${entityName}.${methodName}:${JSON.stringify(params)}`;
+  const cachedRequest = useCallback(
+    async (entityName, methodName, params, fetcher, options = {}) => {
+      const cacheKey = `${entityName}.${methodName}:${JSON.stringify(params)}`;
 
-    // Cache timeout: 1 second in dev, 2 seconds in production (reduced from 2s/5s - app perf improved)
-    const CACHE_TIMEOUT = import.meta.env.DEV ? 1000 : 2000;
+      // Default cache timeout: 1s dev / 2s prod. Callers can override via
+      // options.ttlMs for data that changes rarely (tenant list, module
+      // settings) to avoid navigation-triggered refetches.
+      const defaultTimeout = import.meta.env.DEV ? 1000 : 2000;
+      const ttl = typeof options.ttlMs === 'number' ? options.ttlMs : defaultTimeout;
 
-    if (cacheRef.current.has(cacheKey)) {
-      const cached = cacheRef.current.get(cacheKey);
-      const age = Date.now() - cached.timestamp;
-      if (age < CACHE_TIMEOUT) {
-        return cached.data;
+      if (cacheRef.current.has(cacheKey)) {
+        const cached = cacheRef.current.get(cacheKey);
+        const age = Date.now() - cached.timestamp;
+        if (age < ttl) {
+          return cached.data;
+        }
       }
-    }
 
-    if (pendingRequestsRef.current.has(cacheKey)) {
-      return pendingRequestsRef.current.get(cacheKey);
-    }
+      if (pendingRequestsRef.current.has(cacheKey)) {
+        return pendingRequestsRef.current.get(cacheKey);
+      }
 
-    const promise = fetcher()
-      .then((data) => {
-        cacheRef.current.set(cacheKey, { data, timestamp: Date.now() });
-        pendingRequestsRef.current.delete(cacheKey);
-        return data;
-      })
-      .catch((error) => {
-        pendingRequestsRef.current.delete(cacheKey);
-        throw error;
-      });
+      const promise = fetcher()
+        .then((data) => {
+          cacheRef.current.set(cacheKey, { data, timestamp: Date.now() });
+          pendingRequestsRef.current.delete(cacheKey);
+          return data;
+        })
+        .catch((error) => {
+          pendingRequestsRef.current.delete(cacheKey);
+          throw error;
+        });
 
-    pendingRequestsRef.current.set(cacheKey, promise);
-    return promise;
-  }, []);
+      pendingRequestsRef.current.set(cacheKey, promise);
+      return promise;
+    },
+    [],
+  );
 
   const clearCache = useCallback((pattern) => {
     if (!pattern) {

--- a/src/components/shared/EntityLabelsContext.jsx
+++ b/src/components/shared/EntityLabelsContext.jsx
@@ -2,106 +2,104 @@ import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { BACKEND_URL } from '@/api/entities';
 import { DEFAULT_LABELS, HREF_TO_ENTITY_KEY } from './entityLabelsUtils';
 import { EntityLabelsContext } from './entityLabelsContextDefinition';
+import { useApiManager } from './ApiManager';
+
+// Entity labels change rarely (admin toggles them from Settings). Cache for 5
+// minutes so a superadmin flipping between tenants in the session reuses the
+// cached labels instead of re-fetching on every tenantId change.
+const ENTITY_LABELS_TTL_MS = 5 * 60 * 1000;
 
 export function EntityLabelsProvider({ children, tenantId }) {
-  console.log('[EntityLabelsContext] Provider rendered with tenantId:', tenantId);
   const [labels, setLabels] = useState(DEFAULT_LABELS);
   const [loading, setLoading] = useState(false);
-  const lastFetchedTenantIdRef = useRef(null); // Use ref to persist across strict mode remounts
+  const lastFetchedTenantIdRef = useRef(null);
+  const { cachedRequest, clearCache } = useApiManager();
 
-  const fetchLabels = useCallback(async (tid) => {
-    if (!tid) {
-      console.log('[EntityLabelsContext] No tenant ID, using defaults');
-      setLabels(DEFAULT_LABELS);
-      return;
-    }
-
-    try {
-      setLoading(true);
-      console.log('[EntityLabelsContext] Fetching labels for tenant:', tid);
-      // Add cache-busting timestamp to prevent 304 responses
-      const cacheBuster = Date.now();
-      const response = await fetch(`${BACKEND_URL}/api/entity-labels/${tid}?_t=${cacheBuster}`, {
-        credentials: 'include',
-        headers: {
-          'Cache-Control': 'no-cache',
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        console.log('[EntityLabelsContext] RAW API response for tenant', tid, ':', JSON.stringify(data, null, 2));
-        if (data.status === 'success' && data.data?.labels) {
-          console.log('[EntityLabelsContext] Setting labels for', tid, ':', JSON.stringify(data.data.labels));
-          console.log('[EntityLabelsContext] Customized entities:', data.data.customized);
-          // Force a new object reference to ensure React detects the change
-          setLabels({ ...data.data.labels });
-        }
-      } else {
-        // Fallback to defaults on error
-        console.warn('[EntityLabelsContext] Failed to fetch labels, using defaults');
+  const fetchLabels = useCallback(
+    async (tid) => {
+      if (!tid) {
         setLabels(DEFAULT_LABELS);
+        return;
       }
-    } catch (error) {
-      console.error('[EntityLabelsContext] Error fetching entity labels:', error);
-      setLabels(DEFAULT_LABELS);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+
+      try {
+        setLoading(true);
+        const data = await cachedRequest(
+          'EntityLabels',
+          'get',
+          { tenantId: tid },
+          async () => {
+            const response = await fetch(`${BACKEND_URL}/api/entity-labels/${tid}`, {
+              credentials: 'include',
+            });
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+          },
+          { ttlMs: ENTITY_LABELS_TTL_MS },
+        );
+
+        if (data?.status === 'success' && data.data?.labels) {
+          setLabels({ ...data.data.labels });
+        } else {
+          setLabels(DEFAULT_LABELS);
+        }
+      } catch (error) {
+        console.error('[EntityLabelsContext] Error fetching entity labels:', error);
+        setLabels(DEFAULT_LABELS);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [cachedRequest],
+  );
 
   useEffect(() => {
     if (tenantId && tenantId !== lastFetchedTenantIdRef.current) {
-      console.log('[EntityLabelsContext] Tenant changed, fetching labels for:', tenantId);
       lastFetchedTenantIdRef.current = tenantId;
       fetchLabels(tenantId);
     } else if (!tenantId && lastFetchedTenantIdRef.current) {
-      // Tenant cleared, reset to defaults
-      console.log('[EntityLabelsContext] Tenant cleared, resetting to defaults');
       setLabels(DEFAULT_LABELS);
       lastFetchedTenantIdRef.current = null;
     }
   }, [tenantId, fetchLabels]);
 
-  /**
-   * Get the plural label for an entity
-   * @param {string} entityKey - e.g., 'leads', 'accounts'
-   * @returns {string} - e.g., 'Prospects' or 'Leads'
-   */
-  const getLabel = useCallback((entityKey) => {
-    const key = entityKey?.toLowerCase();
-    return labels[key]?.plural || DEFAULT_LABELS[key]?.plural || entityKey;
-  }, [labels]);
+  const getLabel = useCallback(
+    (entityKey) => {
+      const key = entityKey?.toLowerCase();
+      return labels[key]?.plural || DEFAULT_LABELS[key]?.plural || entityKey;
+    },
+    [labels],
+  );
 
-  /**
-   * Get the singular label for an entity
-   * @param {string} entityKey - e.g., 'leads', 'accounts'
-   * @returns {string} - e.g., 'Prospect' or 'Lead'
-   */
-  const getLabelSingular = useCallback((entityKey) => {
-    const key = entityKey?.toLowerCase();
-    return labels[key]?.singular || DEFAULT_LABELS[key]?.singular || entityKey;
-  }, [labels]);
+  const getLabelSingular = useCallback(
+    (entityKey) => {
+      const key = entityKey?.toLowerCase();
+      return labels[key]?.singular || DEFAULT_LABELS[key]?.singular || entityKey;
+    },
+    [labels],
+  );
 
-  /**
-   * Get the label for a navigation href
-   * @param {string} href - e.g., 'Leads', 'BizDevSources'
-   * @returns {string} - custom label or original
-   */
-  const getNavLabel = useCallback((href) => {
-    const entityKey = HREF_TO_ENTITY_KEY[href];
-    if (entityKey) {
-      return getLabel(entityKey);
-    }
-    return null; // Return null if not a customizable entity
-  }, [getLabel]);
+  const getNavLabel = useCallback(
+    (href) => {
+      const entityKey = HREF_TO_ENTITY_KEY[href];
+      if (entityKey) {
+        return getLabel(entityKey);
+      }
+      return null;
+    },
+    [getLabel],
+  );
 
+  // Force a refresh by invalidating the cached entry, then refetching.
+  // Used after EntityLabelsManager save/reset so nav labels update immediately.
   const refresh = useCallback(() => {
-    console.log('[EntityLabelsContext] refresh() called, tenantId:', tenantId);
+    clearCache('EntityLabels');
+    lastFetchedTenantIdRef.current = null;
     if (tenantId) {
+      lastFetchedTenantIdRef.current = tenantId;
       fetchLabels(tenantId);
     }
-  }, [tenantId, fetchLabels]);
+  }, [tenantId, fetchLabels, clearCache]);
 
   const value = {
     labels,
@@ -112,11 +110,5 @@ export function EntityLabelsProvider({ children, tenantId }) {
     refresh,
   };
 
-  return (
-    <EntityLabelsContext.Provider value={value}>
-      {children}
-    </EntityLabelsContext.Provider>
-  );
+  return <EntityLabelsContext.Provider value={value}>{children}</EntityLabelsContext.Provider>;
 }
-
-

--- a/src/components/shared/EntityLabelsContext.jsx
+++ b/src/components/shared/EntityLabelsContext.jsx
@@ -13,7 +13,7 @@ export function EntityLabelsProvider({ children, tenantId }) {
   const [labels, setLabels] = useState(DEFAULT_LABELS);
   const [loading, setLoading] = useState(false);
   const lastFetchedTenantIdRef = useRef(null);
-  const { cachedRequest, clearCache } = useApiManager();
+  const { cachedRequest, peek, clearCache } = useApiManager();
 
   const fetchLabels = useCallback(
     async (tid) => {
@@ -22,8 +22,15 @@ export function EntityLabelsProvider({ children, tenantId }) {
         return;
       }
 
+      // Skip the loading-state flicker when cachedRequest will resolve from
+      // cache synchronously — the common case for superadmins flipping back
+      // to a previously-viewed tenant within the TTL window.
+      const willHitCache = peek
+        ? peek('EntityLabels', 'get', { tenantId: tid }, { ttlMs: ENTITY_LABELS_TTL_MS })
+        : false;
+
       try {
-        setLoading(true);
+        if (!willHitCache) setLoading(true);
         const data = await cachedRequest(
           'EntityLabels',
           'get',
@@ -47,10 +54,10 @@ export function EntityLabelsProvider({ children, tenantId }) {
         console.error('[EntityLabelsContext] Error fetching entity labels:', error);
         setLabels(DEFAULT_LABELS);
       } finally {
-        setLoading(false);
+        if (!willHitCache) setLoading(false);
       }
     },
-    [cachedRequest],
+    [cachedRequest, peek],
   );
 
   useEffect(() => {

--- a/src/components/shared/__tests__/ApiManager.ttl.test.jsx
+++ b/src/components/shared/__tests__/ApiManager.ttl.test.jsx
@@ -77,7 +77,7 @@ describe('ApiManager.cachedRequest per-key TTL override', () => {
       expect(hit).toBe('tenants-list');
       expect(fetcher).toHaveBeenCalledTimes(1);
 
-      // 5 min + 1s later — beyond the override TTL
+      // 5 min later from here (5 min 10s total since caching) — beyond the override TTL
       await act(async () => {
         await vi.advanceTimersByTimeAsync(300000);
       });
@@ -109,6 +109,65 @@ describe('ApiManager.cachedRequest per-key TTL override', () => {
 
       expect(longFetcher).toHaveBeenCalledTimes(1);
       expect(shortFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('NaN and Infinity ttlMs fall back to the default TTL', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest } = makeHarness();
+      const fetcher = vi.fn().mockResolvedValue('v1');
+
+      // NaN should be treated as invalid and fall back to default (1-2s)
+      await cachedRequest('Ent', 'x', {}, fetcher, { ttlMs: Number.NaN });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // 5s later — default TTL has definitely expired, so fetcher should re-run
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      fetcher.mockResolvedValue('v2');
+      const after = await cachedRequest('Ent', 'x', {}, fetcher, { ttlMs: Number.NaN });
+      expect(after).toBe('v2');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+
+      // Infinity should also fall back — otherwise cache would never expire
+      const key2Fetcher = vi.fn().mockResolvedValue('inf-1');
+      await cachedRequest('Ent', 'y', {}, key2Fetcher, { ttlMs: Number.POSITIVE_INFINITY });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      key2Fetcher.mockResolvedValue('inf-2');
+      const inf = await cachedRequest('Ent', 'y', {}, key2Fetcher, {
+        ttlMs: Number.POSITIVE_INFINITY,
+      });
+      expect(inf).toBe('inf-2');
+      expect(key2Fetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('peek(name, method, params, {ttlMs}) returns true iff cache is fresh', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest, peek } = makeHarness();
+
+      // Cache miss before any request
+      expect(peek('Tenant', 'list', {}, { ttlMs: 300000 })).toBe(false);
+
+      await cachedRequest('Tenant', 'list', {}, async () => 'hit', { ttlMs: 300000 });
+
+      // Fresh entry within TTL — hit
+      expect(peek('Tenant', 'list', {}, { ttlMs: 300000 })).toBe(true);
+
+      // Advance past TTL — miss
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(301000);
+      });
+      expect(peek('Tenant', 'list', {}, { ttlMs: 300000 })).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/src/components/shared/__tests__/ApiManager.ttl.test.jsx
+++ b/src/components/shared/__tests__/ApiManager.ttl.test.jsx
@@ -1,0 +1,137 @@
+/**
+ * Tests for the per-key TTL override on ApiManager.cachedRequest.
+ *
+ * Motivation: Tenant.list() and ModuleSettings.list() data changes rarely
+ * mid-session. The global 1-2s TTL causes superadmins to refetch these on
+ * every page navigation, inflating request count. A per-call ttlMs override
+ * lets callers opt into a longer cache window without changing the global
+ * default (which is intentionally short to avoid serving stale mutation
+ * results after saves elsewhere).
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { ApiProvider, useApiManager } from '../ApiManager.jsx';
+
+function makeHarness() {
+  const ref = { current: null };
+  function Probe() {
+    ref.current = useApiManager();
+    return null;
+  }
+  render(
+    <ApiProvider>
+      <Probe />
+    </ApiProvider>,
+  );
+  return ref.current;
+}
+
+describe('ApiManager.cachedRequest per-key TTL override', () => {
+  it('default TTL still applies when no override is provided', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest } = makeHarness();
+      const fetcher = vi.fn().mockResolvedValue('fresh');
+
+      const first = await cachedRequest('Ent', 'list', {}, fetcher);
+      expect(first).toBe('fresh');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // Well within default TTL (1s dev / 2s prod) — cache hit, no new fetch
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      const second = await cachedRequest('Ent', 'list', {}, fetcher);
+      expect(second).toBe('fresh');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // Past the default TTL — triggers a fresh fetch
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      fetcher.mockResolvedValue('fresher');
+      const third = await cachedRequest('Ent', 'list', {}, fetcher);
+      expect(third).toBe('fresher');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('custom ttlMs extends the cache window beyond the default', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest } = makeHarness();
+      const fetcher = vi.fn().mockResolvedValue('tenants-list');
+
+      await cachedRequest('Tenant', 'list', {}, fetcher, { ttlMs: 300000 });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // 10 seconds later — would miss the default TTL but stays within 5-min override
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000);
+      });
+      const hit = await cachedRequest('Tenant', 'list', {}, fetcher, { ttlMs: 300000 });
+      expect(hit).toBe('tenants-list');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // 5 min + 1s later — beyond the override TTL
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300000);
+      });
+      fetcher.mockResolvedValue('tenants-list-refreshed');
+      const miss = await cachedRequest('Tenant', 'list', {}, fetcher, { ttlMs: 300000 });
+      expect(miss).toBe('tenants-list-refreshed');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('different keys can have independent TTLs in the same session', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest } = makeHarness();
+      const longFetcher = vi.fn().mockResolvedValue('long');
+      const shortFetcher = vi.fn().mockResolvedValue('short');
+
+      await cachedRequest('Tenant', 'list', {}, longFetcher, { ttlMs: 300000 });
+      await cachedRequest('Entity', 'other', {}, shortFetcher); // default TTL
+
+      // 10s later — long-TTL key still cached, default-TTL key expired
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000);
+      });
+      await cachedRequest('Tenant', 'list', {}, longFetcher, { ttlMs: 300000 });
+      await cachedRequest('Entity', 'other', {}, shortFetcher);
+
+      expect(longFetcher).toHaveBeenCalledTimes(1);
+      expect(shortFetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clearCache invalidates entries regardless of their TTL override', async () => {
+    vi.useFakeTimers();
+    try {
+      const { cachedRequest, clearCache } = makeHarness();
+      const fetcher = vi.fn().mockResolvedValue('v1');
+
+      await cachedRequest('Tenant', 'list', {}, fetcher, { ttlMs: 300000 });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+
+      // Mutating the tenants elsewhere should allow explicit invalidation
+      clearCache('Tenant');
+
+      fetcher.mockResolvedValue('v2');
+      const after = await cachedRequest('Tenant', 'list', {}, fetcher, { ttlMs: 300000 });
+      expect(after).toBe('v2');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/shared/__tests__/EntityLabelsContext.dedup.test.jsx
+++ b/src/components/shared/__tests__/EntityLabelsContext.dedup.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * Tests that EntityLabelsProvider:
+ * 1. does NOT include a cache-buster query param (was bypassing all dedup),
+ * 2. routes the fetch through ApiManager.cachedRequest so a re-mount or
+ *    tenant-switch-back within the TTL window reuses the cached labels.
+ *
+ * Prior bug: every mount issued `GET /api/entity-labels/{tid}?_t=<Date.now()>`.
+ * Superadmins switching tenants during a session thus bypassed both browser
+ * HTTP cache and the in-memory cachedRequest dedup, adding a fresh request
+ * to every tenant switch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { ApiProvider } from '../ApiManager.jsx';
+import { EntityLabelsProvider } from '../EntityLabelsContext.jsx';
+
+vi.mock('@/api/entities', () => ({
+  BACKEND_URL: 'http://api.test.local',
+}));
+
+describe('EntityLabelsProvider request dedup', () => {
+  let originalFetch;
+  let fetchMock;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        status: 'success',
+        data: { labels: { leads: { plural: 'Leads', singular: 'Lead' } }, customized: [] },
+      }),
+    });
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('issues a fetch WITHOUT a cache-busting query parameter', async () => {
+    render(
+      <ApiProvider>
+        <EntityLabelsProvider tenantId="tenant-abc">
+          <div>child</div>
+        </EntityLabelsProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const calledUrl = fetchMock.mock.calls[0][0];
+    expect(calledUrl).toContain('/api/entity-labels/tenant-abc');
+    expect(calledUrl).not.toMatch(/[?&]_t=/);
+  });
+
+  it('a second mount for the same tenant within TTL reuses the cache (no second fetch)', async () => {
+    const { rerender, unmount } = render(
+      <ApiProvider>
+        <EntityLabelsProvider tenantId="tenant-abc">
+          <div>child</div>
+        </EntityLabelsProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Simulate the superadmin flipping to another tenant and then flipping
+    // back to the original within the TTL window — must not refetch.
+    rerender(
+      <ApiProvider>
+        <EntityLabelsProvider tenantId="tenant-other">
+          <div>child</div>
+        </EntityLabelsProvider>
+      </ApiProvider>,
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    rerender(
+      <ApiProvider>
+        <EntityLabelsProvider tenantId="tenant-abc">
+          <div>child</div>
+        </EntityLabelsProvider>
+      </ApiProvider>,
+    );
+
+    // Give any pending effects a chance to run, then assert no additional fetch
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    unmount();
+  });
+
+  it('sends credentials: include with the request (unchanged behavior)', async () => {
+    render(
+      <ApiProvider>
+        <EntityLabelsProvider tenantId="tenant-abc">
+          <div>child</div>
+        </EntityLabelsProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init).toBeDefined();
+    expect(init.credentials).toBe('include');
+  });
+});

--- a/src/pages/Layout.jsx
+++ b/src/pages/Layout.jsx
@@ -2399,8 +2399,12 @@ export default function LayoutWrapper({ children, currentPageName }) {
         <QueryClientProvider client={queryClient}>
           <ApiOptimizerProvider>
             <TenantProvider>
-              <EntityLabelsWrapper>
-                <ApiProvider>
+              {/* ApiProvider must be ABOVE EntityLabelsWrapper because
+                   EntityLabelsProvider now consumes cachedRequest via
+                   useApiManager(). Order: TenantProvider (for tenantId) →
+                   ApiProvider (for cachedRequest) → EntityLabelsWrapper. */}
+              <ApiProvider>
+                <EntityLabelsWrapper>
                   <TimezoneProvider>
                     <EmployeeScopeProvider>
                       <LoggerProvider>
@@ -2410,8 +2414,8 @@ export default function LayoutWrapper({ children, currentPageName }) {
                       </LoggerProvider>
                     </EmployeeScopeProvider>
                   </TimezoneProvider>
-                </ApiProvider>
-              </EntityLabelsWrapper>
+                </EntityLabelsWrapper>
+              </ApiProvider>
             </TenantProvider>
           </ApiOptimizerProvider>
         </QueryClientProvider>


### PR DESCRIPTION
## Context

Follow-up to #541. Production logs showed 35+ simultaneous requests on page reload from a single superadmin client, tripping Cloudflare's bot-block heuristic. An external recommendation was to add request coalescing at the fetch wrapper, but code investigation showed coalescing **already exists** ([ApiManager.jsx:10-41](src/components/shared/ApiManager.jsx#L10-L41) in-flight promise cache; [fetchWithBackoff.js:33-51](src/utils/fetchWithBackoff.js#L33-L51) auth-refresh mutex).

The real bug is that three files bypass it with a `?_t=${Date.now()}` cache-buster query parameter. Every call generates a unique URL, so:
- Browser HTTP cache: defeated (intentional)
- Backend cache middleware: defeated (unintentional)
- Any URL-keyed in-flight dedup: **cannot possibly work** (unintentional)

Ironically, the externally-proposed dedup would also fail to catch these.

## Why superadmins feel it worst

A superadmin flipping between tenants during a session re-fires the EntityLabels fetch uncached on every switch because the cache-buster makes every URL unique. Regular users hit it once per login.

## Changes

### Load-bearing

- **`ApiManager.jsx`** — `cachedRequest` accepts an `options.ttlMs` override. Default stays 1-2s (short, avoids serving stale mutation results). Callers opt in to a longer window for data that rarely changes mid-session.
- **`EntityLabelsContext.jsx`** — refactored to route the GET through `cachedRequest` with a **5-min TTL and no cache-buster**. A superadmin flipping A → B → A in one session now reuses the cached A response. `refresh()` invalidates the cache before refetching (called by EntityLabelsManager save/reset so nav labels update).
- **`EntityLabelsManager.jsx`** and **`CalendarSync.jsx`** — cache-busters removed. Both are Settings-tab paths; the original 304-avoidance rationale no longer applies because the save path already invalidates via `refreshGlobalLabels()`.

### Not in this PR (evaluated and deferred)

- **Stabilizing `effectiveTenantId` derivation in [Layout.jsx:359-396](src/pages/Layout.jsx#L359-L396)** — already memoized on `[user, selectedTenantId]`. Transitions during init are bounded to 1-2 and now absorbed by the 5-min EntityLabels TTL. Speculative change; deferred.
- **Adding dedup to the low-level fetch wrapper** (the external recommendation). Existing `ApiManager` infrastructure is sufficient once callers stop bypassing it with cache-busters. Adding a third dedup layer would be redundant; also GET-only dedup at the lowest level risks breaking mutations if implemented carelessly.

## Test plan

- [x] **TDD — RED, GREEN, REFACTOR on all new logic**
- [x] 4 new tests in [`ApiManager.ttl.test.jsx`](src/components/shared/__tests__/ApiManager.ttl.test.jsx) — default TTL preserved, custom `ttlMs` extends window, independent keys with different TTLs, `clearCache` invalidates regardless of TTL override
- [x] 3 new tests in [`EntityLabelsContext.dedup.test.jsx`](src/components/shared/__tests__/EntityLabelsContext.dedup.test.jsx) — URL contains no `_t=`, tenant-switch-back reuses cache (no second fetch), `credentials: 'include'` preserved
- [x] Full frontend suite: 667 pass, 2 pre-existing failures unchanged (`AishaEntityChatModal`, `SuggestionQueue` — predate this change; verified by running the suite on `origin/main` before my changes)
- [x] Layout smoke tests: all 18 green
- [ ] **Production verification after deploy**: open Network tab on reload. Expected request count < 20 (down from 35+). Look for absence of `/api/entity-labels/...?_t=` URLs.

## Rollback

Single atomic commit. `git revert <hash>` restores prior behavior completely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)