### PR TITLE
feat(docuseal): Send Document parity on Lead/Account/Opportunity panels (4VD-6)

### DIFF
--- a/src/components/accounts/AccountDetailPanel.jsx
+++ b/src/components/accounts/AccountDetailPanel.jsx
@@ -1,6 +1,41 @@
+import { useState, useEffect, useCallback } from 'react';
 import UniversalDetailPanel from '../shared/UniversalDetailPanel';
+import { FileSignature, FileText } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import SendDocumentDialog from '../docuseal/SendDocumentDialog';
 import { CustomFieldsDisplay } from '../shared/CustomFieldsDisplay';
 import ErrorBoundary from '../shared/ErrorBoundary';
+import { getAuthorizationHeader } from '@/api/functions';
+import { getBackendUrl } from '@/api/backendUrl';
+
+// Mirror of ContactDetailPanel's status palette so the Document Signatures
+// section looks identical across Contact / Lead / Account / Opportunity (4VD-6).
+const DOCUSEAL_STATUS_BADGE_CLASS = {
+  pending: 'bg-blue-100 text-blue-800 border border-blue-200',
+  sent: 'bg-blue-100 text-blue-800 border border-blue-200',
+  viewed: 'bg-amber-100 text-amber-800 border border-amber-200',
+  signed: 'bg-green-100 text-green-800 border border-green-200',
+  completed: 'bg-green-100 text-green-800 border border-green-200',
+  declined: 'bg-red-100 text-red-800 border border-red-200',
+  expired: 'bg-red-100 text-red-800 border border-red-200',
+  failed: 'bg-red-100 text-red-800 border border-red-200',
+};
+
+function getDocuSealStatusClass(status) {
+  return (
+    DOCUSEAL_STATUS_BADGE_CLASS[String(status || '').toLowerCase()] ||
+    'bg-slate-100 text-slate-800 border border-slate-200'
+  );
+}
+
+function formatDocuSealDate(value) {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return String(value);
+  }
+}
 
 export default function AccountDetailPanel({
   account,
@@ -11,37 +46,187 @@ export default function AccountDetailPanel({
   onDelete,
   user,
 }) {
+  const [showSendDocDialog, setShowSendDocDialog] = useState(false);
+  const [submissions, setSubmissions] = useState([]);
+  const [submissionsLoading, setSubmissionsLoading] = useState(false);
+
+  const accountId = account?.id;
+
+  const loadSubmissions = useCallback(async () => {
+    if (!accountId) return;
+    try {
+      const BACKEND_URL = getBackendUrl();
+      const headers = { 'Content-Type': 'application/json' };
+      const authHeader = await getAuthorizationHeader();
+      if (authHeader) {
+        headers['Authorization'] = authHeader;
+      }
+      const tenantId =
+        typeof localStorage !== 'undefined'
+          ? localStorage.getItem('selected_tenant_id') || localStorage.getItem('tenant_id') || ''
+          : '';
+      if (tenantId) {
+        headers['x-tenant-id'] = tenantId;
+      }
+
+      const url = `${BACKEND_URL}/api/docuseal/submissions?related_to=account&related_id=${encodeURIComponent(
+        accountId,
+      )}`;
+      const resp = await fetch(url, { headers, credentials: 'include' });
+      if (!resp.ok) {
+        return;
+      }
+      const json = await resp.json().catch(() => ({}));
+      const list = Array.isArray(json) ? json : json?.data || json?.submissions || [];
+      setSubmissions(Array.isArray(list) ? list : []);
+    } catch (err) {
+      console.error('Error loading DocuSeal submissions:', err);
+    }
+  }, [accountId]);
+
+  useEffect(() => {
+    if (!open || !accountId) return undefined;
+    let cancelled = false;
+    setSubmissionsLoading(true);
+    (async () => {
+      await loadSubmissions();
+      if (!cancelled) setSubmissionsLoading(false);
+    })();
+    const interval = setInterval(loadSubmissions, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [open, accountId, loadSubmissions]);
+
   if (!account) {
     return null;
   }
 
+  // Accounts don't always have a single primary contact email — Contact panel
+  // pre-fills from contact.email, but for Accounts we fall back to whatever
+  // the account record carries (often empty), and SendDocumentDialog requires
+  // the user to fill in the recipient email manually before sending.
+  const accountEmail = account.email || account.primary_email || account.billing_email || '';
+  const accountDisplayName = account.name || 'Account';
+
+  const customActions = [
+    {
+      label: 'Send Document',
+      icon: <FileSignature className="w-4 h-4" />,
+      onClick: () => setShowSendDocDialog(true),
+    },
+  ];
+
+  const documentSignaturesSection = (
+    <div className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-3">
+      {submissionsLoading && submissions.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">Loading documents...</p>
+      ) : submissions.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">No documents sent yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {submissions.map((s) => {
+            const status = String(s.status || 'pending').toLowerCase();
+            const templateName =
+              s.template_name || s.template_title || s.template_id || 'Document';
+            const recipient = s.recipient_email || s.recipient_name || '';
+            const sentAt = s.sent_at || s.created_at || s.created_date;
+            const signedHref = s.mirror_url || s.signed_document_url;
+            const showSigned = (status === 'completed' || status === 'signed') && signedHref;
+            return (
+              <li
+                key={s.id || `${s.template_id}-${sentAt}`}
+                className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <FileText className="w-4 h-4 text-slate-400 shrink-0" />
+                    <span className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
+                      {templateName}
+                    </span>
+                  </div>
+                  {recipient && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 ml-6 truncate">
+                      {recipient}
+                    </p>
+                  )}
+                  {sentAt && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 ml-6">
+                      Sent {formatDocuSealDate(sentAt)}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 ml-6 sm:ml-0 mt-1 sm:mt-0">
+                  <Badge className={getDocuSealStatusClass(status)}>{status}</Badge>
+                  {showSigned && (
+                    <a
+                      href={signedHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-500 hover:text-blue-400 hover:underline"
+                    >
+                      View signed PDF
+                    </a>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+
   return (
-    <ErrorBoundary variant="inline" label={`AccountDetailPanel[id=${account?.id}]`}>
-      <UniversalDetailPanel
-        entity={account}
-        entityType="account"
-        open={open}
-        onOpenChange={onOpenChange}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        user={user}
-        displayData={{
-          'Assigned To': (
-            <p className="text-slate-200 font-medium mt-1">
-              {assignedUserName || account.assigned_to || 'Unassigned'}
-            </p>
-          ),
-        }}
-        customActions={[]}
-        showNotes={true}
-        customSections={[
-          {
-            content: (
-              <CustomFieldsDisplay entityType="Account" metadata={account.metadata} showHeader />
+    <>
+      <ErrorBoundary variant="inline" label={`AccountDetailPanel[id=${account?.id}]`}>
+        <UniversalDetailPanel
+          entity={account}
+          entityType="account"
+          open={open}
+          onOpenChange={onOpenChange}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          user={user}
+          displayData={{
+            'Assigned To': (
+              <p className="text-slate-200 font-medium mt-1">
+                {assignedUserName || account.assigned_to || 'Unassigned'}
+              </p>
             ),
-          },
-        ]}
+          }}
+          customActions={customActions}
+          showNotes={true}
+          customSections={[
+            {
+              content: (
+                <CustomFieldsDisplay entityType="Account" metadata={account.metadata} showHeader />
+              ),
+            },
+            {
+              title: 'Document signatures',
+              icon: <FileSignature className="w-4 h-4" />,
+              content: documentSignaturesSection,
+            },
+          ]}
+        />
+      </ErrorBoundary>
+
+      <SendDocumentDialog
+        open={showSendDocDialog}
+        onOpenChange={setShowSendDocDialog}
+        relatedTo="account"
+        relatedId={account.id}
+        defaultRecipientName={accountDisplayName}
+        defaultRecipientEmail={accountEmail}
+        onSent={(submission) => {
+          if (submission && typeof submission === 'object') {
+            setSubmissions((prev) => [submission, ...prev]);
+          }
+          loadSubmissions();
+        }}
       />
-    </ErrorBoundary>
+    </>
   );
 }

--- a/src/components/leads/LeadDetailPanel.jsx
+++ b/src/components/leads/LeadDetailPanel.jsx
@@ -1,9 +1,49 @@
+import { useState, useEffect, useCallback } from 'react';
 import UniversalDetailPanel from '../shared/UniversalDetailPanel';
-import { Building2, UserCheck, CalendarCheck } from 'lucide-react';
+import {
+  Building2,
+  UserCheck,
+  CalendarCheck,
+  FileSignature,
+  FileText,
+} from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 import AssignmentHistory from './AssignmentHistory';
 import BookingWidget from '../scheduling/BookingWidget';
+import SendDocumentDialog from '../docuseal/SendDocumentDialog';
 import { CustomFieldsDisplay } from '../shared/CustomFieldsDisplay';
 import ErrorBoundary from '../shared/ErrorBoundary';
+import { getAuthorizationHeader } from '@/api/functions';
+import { getBackendUrl } from '@/api/backendUrl';
+
+// Mirror of ContactDetailPanel's status palette so the Document Signatures
+// section looks identical across Contact / Lead / Account / Opportunity (4VD-6).
+const DOCUSEAL_STATUS_BADGE_CLASS = {
+  pending: 'bg-blue-100 text-blue-800 border border-blue-200',
+  sent: 'bg-blue-100 text-blue-800 border border-blue-200',
+  viewed: 'bg-amber-100 text-amber-800 border border-amber-200',
+  signed: 'bg-green-100 text-green-800 border border-green-200',
+  completed: 'bg-green-100 text-green-800 border border-green-200',
+  declined: 'bg-red-100 text-red-800 border border-red-200',
+  expired: 'bg-red-100 text-red-800 border border-red-200',
+  failed: 'bg-red-100 text-red-800 border border-red-200',
+};
+
+function getDocuSealStatusClass(status) {
+  return (
+    DOCUSEAL_STATUS_BADGE_CLASS[String(status || '').toLowerCase()] ||
+    'bg-slate-100 text-slate-800 border border-slate-200'
+  );
+}
+
+function formatDocuSealDate(value) {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return String(value);
+  }
+}
 
 export default function LeadDetailPanel({
   lead,
@@ -16,6 +56,60 @@ export default function LeadDetailPanel({
   user,
   associatedAccountName,
 }) {
+  const [showSendDocDialog, setShowSendDocDialog] = useState(false);
+  const [submissions, setSubmissions] = useState([]);
+  const [submissionsLoading, setSubmissionsLoading] = useState(false);
+
+  const leadId = lead?.id;
+
+  const loadSubmissions = useCallback(async () => {
+    if (!leadId) return;
+    try {
+      const BACKEND_URL = getBackendUrl();
+      const headers = { 'Content-Type': 'application/json' };
+      const authHeader = await getAuthorizationHeader();
+      if (authHeader) {
+        headers['Authorization'] = authHeader;
+      }
+      const tenantId =
+        typeof localStorage !== 'undefined'
+          ? localStorage.getItem('selected_tenant_id') || localStorage.getItem('tenant_id') || ''
+          : '';
+      if (tenantId) {
+        headers['x-tenant-id'] = tenantId;
+      }
+
+      const url = `${BACKEND_URL}/api/docuseal/submissions?related_to=lead&related_id=${encodeURIComponent(
+        leadId,
+      )}`;
+      const resp = await fetch(url, { headers, credentials: 'include' });
+      if (!resp.ok) {
+        // Silent on poll errors so we don't toast-spam.
+        return;
+      }
+      const json = await resp.json().catch(() => ({}));
+      const list = Array.isArray(json) ? json : json?.data || json?.submissions || [];
+      setSubmissions(Array.isArray(list) ? list : []);
+    } catch (err) {
+      console.error('Error loading DocuSeal submissions:', err);
+    }
+  }, [leadId]);
+
+  useEffect(() => {
+    if (!open || !leadId) return undefined;
+    let cancelled = false;
+    setSubmissionsLoading(true);
+    (async () => {
+      await loadSubmissions();
+      if (!cancelled) setSubmissionsLoading(false);
+    })();
+    const interval = setInterval(loadSubmissions, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [open, leadId, loadSubmissions]);
+
   if (!lead) {
     return null;
   }
@@ -33,16 +127,23 @@ export default function LeadDetailPanel({
   // { label, icon, onClick }. Passing JSX elements here previously caused an empty
   // button to render because UniversalDetailPanel would try to read .label/.icon
   // from a React element object (both undefined).
-  const customActions =
-    lead.status !== 'converted'
-      ? [
-          {
-            label: 'Convert to Contact',
-            icon: <UserCheck className="w-4 h-4" />,
-            onClick: () => onConvert(lead),
-          },
-        ]
-      : [];
+  const customActions = [];
+
+  if (lead.status !== 'converted') {
+    customActions.push({
+      label: 'Convert to Contact',
+      icon: <UserCheck className="w-4 h-4" />,
+      onClick: () => onConvert(lead),
+    });
+  }
+
+  // Send Document is available regardless of lead status — sales workflows
+  // routinely require an NDA or contract before conversion is possible.
+  customActions.push({
+    label: 'Send Document',
+    icon: <FileSignature className="w-4 h-4" />,
+    onClick: () => setShowSendDocDialog(true),
+  });
 
   const detailDisplayData = {
     'Associated Account': associatedAccountName ? (
@@ -61,40 +162,126 @@ export default function LeadDetailPanel({
     ),
   };
 
+  const documentSignaturesSection = (
+    <div className="rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 p-3">
+      {submissionsLoading && submissions.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">Loading documents...</p>
+      ) : submissions.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">No documents sent yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {submissions.map((s) => {
+            const status = String(s.status || 'pending').toLowerCase();
+            const templateName =
+              s.template_name || s.template_title || s.template_id || 'Document';
+            const recipient = s.recipient_email || s.recipient_name || '';
+            const sentAt = s.sent_at || s.created_at || s.created_date;
+            // Prefer the durable Supabase Storage mirror (`mirror_url`,
+            // populated by the webhook step 8b mirror) over DocuSeal's hosted
+            // URL (`signed_document_url`). Falls back to the DocuSeal URL
+            // if the mirror hasn't run yet.
+            const signedHref = s.mirror_url || s.signed_document_url;
+            const showSigned = (status === 'completed' || status === 'signed') && signedHref;
+            return (
+              <li
+                key={s.id || `${s.template_id}-${sentAt}`}
+                className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <FileText className="w-4 h-4 text-slate-400 shrink-0" />
+                    <span className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
+                      {templateName}
+                    </span>
+                  </div>
+                  {recipient && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 ml-6 truncate">
+                      {recipient}
+                    </p>
+                  )}
+                  {sentAt && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 ml-6">
+                      Sent {formatDocuSealDate(sentAt)}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 ml-6 sm:ml-0 mt-1 sm:mt-0">
+                  <Badge className={getDocuSealStatusClass(status)}>{status}</Badge>
+                  {showSigned && (
+                    <a
+                      href={signedHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-blue-500 hover:text-blue-400 hover:underline"
+                    >
+                      View signed PDF
+                    </a>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+
   return (
-    <ErrorBoundary variant="inline" label={`LeadDetailPanel[id=${lead?.id}]`}>
-      <UniversalDetailPanel
-        entity={lead}
-        entityType="lead"
-        open={open}
-        onOpenChange={onOpenChange}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        user={user}
-        displayData={detailDisplayData}
-        customActions={customActions}
-        showNotes={true}
-        customSections={[
-          {
-            content: <CustomFieldsDisplay entityType="Lead" metadata={lead.metadata} showHeader />,
-          },
-          {
-            title: 'Session Booking',
-            icon: <CalendarCheck className="w-4 h-4" />,
-            content: (
-              <BookingWidget
-                contactName={`${lead.first_name || ''} ${lead.last_name || ''}`.trim()}
-                contactEmail={lead.email}
-                leadId={lead.id}
-                tenantId={lead.tenant_id || user?.tenant_id}
-                assignedTo={lead.assigned_to}
-                fallbackLinkedUserId={user?.id || user?.user_id}
-                fallbackUserEmail={user?.email}
-              />
-            ),
-          },
-        ]}
+    <>
+      <ErrorBoundary variant="inline" label={`LeadDetailPanel[id=${lead?.id}]`}>
+        <UniversalDetailPanel
+          entity={lead}
+          entityType="lead"
+          open={open}
+          onOpenChange={onOpenChange}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          user={user}
+          displayData={detailDisplayData}
+          customActions={customActions}
+          showNotes={true}
+          customSections={[
+            {
+              content: <CustomFieldsDisplay entityType="Lead" metadata={lead.metadata} showHeader />,
+            },
+            {
+              title: 'Session Booking',
+              icon: <CalendarCheck className="w-4 h-4" />,
+              content: (
+                <BookingWidget
+                  contactName={`${lead.first_name || ''} ${lead.last_name || ''}`.trim()}
+                  contactEmail={lead.email}
+                  leadId={lead.id}
+                  tenantId={lead.tenant_id || user?.tenant_id}
+                  assignedTo={lead.assigned_to}
+                  fallbackLinkedUserId={user?.id || user?.user_id}
+                  fallbackUserEmail={user?.email}
+                />
+              ),
+            },
+            {
+              title: 'Document signatures',
+              icon: <FileSignature className="w-4 h-4" />,
+              content: documentSignaturesSection,
+            },
+          ]}
+        />
+      </ErrorBoundary>
+
+      <SendDocumentDialog
+        open={showSendDocDialog}
+        onOpenChange={setShowSendDocDialog}
+        relatedTo="lead"
+        relatedId={lead.id}
+        defaultRecipientName={`${lead.first_name || ''} ${lead.last_name || ''}`.trim()}
+        defaultRecipientEmail={lead.email || ''}
+        onSent={(submission) => {
+          if (submission && typeof submission === 'object') {
+            setSubmissions((prev) => [submission, ...prev]);
+          }
+          loadSubmissions();
+        }}
       />
-    </ErrorBoundary>
+    </>
   );
 }

--- a/src/components/opportunities/OpportunityDetailPanel.jsx
+++ b/src/components/opportunities/OpportunityDetailPanel.jsx
@@ -1,9 +1,12 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { CustomFieldsDisplay } from '../shared/CustomFieldsDisplay';
 import ErrorBoundary from '../shared/ErrorBoundary';
+import SendDocumentDialog from '../docuseal/SendDocumentDialog';
+import { getAuthorizationHeader } from '@/api/functions';
+import { getBackendUrl } from '@/api/backendUrl';
 
 import {
   DropdownMenu,
@@ -28,6 +31,7 @@ import {
   Mail,
   CheckCircle,
   FileText,
+  FileSignature,
   Presentation,
   ExternalLink,
   ChevronDown,
@@ -40,6 +44,35 @@ import { createPageUrl } from '@/utils';
 import { Link } from 'react-router-dom';
 import StatusHelper from '../shared/StatusHelper'; // New import
 import { useStatusCardPreferences } from '@/hooks/useStatusCardPreferences';
+
+// Mirror of ContactDetailPanel's status palette so the Document Signatures
+// section looks identical across Contact / Lead / Account / Opportunity (4VD-6).
+const DOCUSEAL_STATUS_BADGE_CLASS = {
+  pending: 'bg-blue-100 text-blue-800 border border-blue-200',
+  sent: 'bg-blue-100 text-blue-800 border border-blue-200',
+  viewed: 'bg-amber-100 text-amber-800 border border-amber-200',
+  signed: 'bg-green-100 text-green-800 border border-green-200',
+  completed: 'bg-green-100 text-green-800 border border-green-200',
+  declined: 'bg-red-100 text-red-800 border border-red-200',
+  expired: 'bg-red-100 text-red-800 border border-red-200',
+  failed: 'bg-red-100 text-red-800 border border-red-200',
+};
+
+function getDocuSealStatusClass(status) {
+  return (
+    DOCUSEAL_STATUS_BADGE_CLASS[String(status || '').toLowerCase()] ||
+    'bg-slate-100 text-slate-800 border border-slate-200'
+  );
+}
+
+function formatDocuSealDate(value) {
+  if (!value) return '';
+  try {
+    return new Date(value).toLocaleString();
+  } catch {
+    return String(value);
+  }
+}
 
 export default function OpportunityDetailPanel({
   opportunity,
@@ -57,7 +90,56 @@ export default function OpportunityDetailPanel({
   const [relatedActivities, setRelatedActivities] = useState([]);
   const [loadingActivities, setLoadingActivities] = useState(false);
   const [creatingActivity, setCreatingActivity] = useState(false);
+  const [showSendDocDialog, setShowSendDocDialog] = useState(false);
+  const [submissions, setSubmissions] = useState([]);
+  const [submissionsLoading, setSubmissionsLoading] = useState(false);
   const { getCardLabel } = useStatusCardPreferences();
+
+  // Load DocuSeal submissions tied to this opportunity (4VD-6).
+  const loadSubmissions = useCallback(async () => {
+    if (!localOpportunity?.id) return;
+    try {
+      const BACKEND_URL = getBackendUrl();
+      const headers = { 'Content-Type': 'application/json' };
+      const authHeader = await getAuthorizationHeader();
+      if (authHeader) {
+        headers['Authorization'] = authHeader;
+      }
+      const tenantId =
+        typeof localStorage !== 'undefined'
+          ? localStorage.getItem('selected_tenant_id') || localStorage.getItem('tenant_id') || ''
+          : '';
+      if (tenantId) {
+        headers['x-tenant-id'] = tenantId;
+      }
+
+      const url = `${BACKEND_URL}/api/docuseal/submissions?related_to=opportunity&related_id=${encodeURIComponent(
+        localOpportunity.id,
+      )}`;
+      const resp = await fetch(url, { headers, credentials: 'include' });
+      if (!resp.ok) return;
+      const json = await resp.json().catch(() => ({}));
+      const list = Array.isArray(json) ? json : json?.data || json?.submissions || [];
+      setSubmissions(Array.isArray(list) ? list : []);
+    } catch (err) {
+      console.error('Error loading DocuSeal submissions:', err);
+    }
+  }, [localOpportunity?.id]);
+
+  useEffect(() => {
+    if (!localOpportunity?.id) return undefined;
+    let cancelled = false;
+    setSubmissionsLoading(true);
+    (async () => {
+      await loadSubmissions();
+      if (!cancelled) setSubmissionsLoading(false);
+    })();
+    const interval = setInterval(loadSubmissions, 30000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [localOpportunity?.id, loadSubmissions]);
 
   const stageToCardId = {
     closed_won: 'opportunity_won',
@@ -354,6 +436,16 @@ export default function OpportunityDetailPanel({
               Edit
             </Button>
 
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowSendDocDialog(true)}
+              className="border-slate-600 text-slate-300 hover:bg-slate-700"
+            >
+              <FileSignature className="w-4 h-4 mr-2" />
+              Send Document
+            </Button>
+
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
@@ -570,6 +662,78 @@ export default function OpportunityDetailPanel({
             </CardContent>
           </Card>
 
+          {/* Document Signatures (4VD-6) — DocuSeal lifecycle for documents
+              sent against this opportunity. Mirror of the Contact panel
+              section so the timeline + status badges are consistent. */}
+          <Card className="bg-slate-700/50 border-slate-600">
+            <CardHeader>
+              <CardTitle className="text-slate-200 flex items-center gap-2">
+                <FileSignature className="w-5 h-5 text-blue-400" />
+                Document Signatures ({submissions.length})
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {submissionsLoading && submissions.length === 0 ? (
+                <div className="text-center py-4 text-slate-400 text-sm">
+                  Loading documents...
+                </div>
+              ) : submissions.length === 0 ? (
+                <div className="text-center py-4 text-slate-400 text-sm">
+                  No documents sent yet.
+                </div>
+              ) : (
+                <ul className="space-y-3">
+                  {submissions.map((s) => {
+                    const status = String(s.status || 'pending').toLowerCase();
+                    const templateName =
+                      s.template_name || s.template_title || s.template_id || 'Document';
+                    const recipient = s.recipient_email || s.recipient_name || '';
+                    const sentAt = s.sent_at || s.created_at || s.created_date;
+                    const signedHref = s.mirror_url || s.signed_document_url;
+                    const showSigned =
+                      (status === 'completed' || status === 'signed') && signedHref;
+                    return (
+                      <li
+                        key={s.id || `${s.template_id}-${sentAt}`}
+                        className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between"
+                      >
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <FileText className="w-4 h-4 text-slate-400 shrink-0" />
+                            <span className="text-sm font-medium text-slate-200 truncate">
+                              {templateName}
+                            </span>
+                          </div>
+                          {recipient && (
+                            <p className="text-xs text-slate-400 ml-6 truncate">{recipient}</p>
+                          )}
+                          {sentAt && (
+                            <p className="text-xs text-slate-400 ml-6">
+                              Sent {formatDocuSealDate(sentAt)}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2 ml-6 sm:ml-0 mt-1 sm:mt-0">
+                          <Badge className={getDocuSealStatusClass(status)}>{status}</Badge>
+                          {showSigned && (
+                            <a
+                              href={signedHref}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-xs text-blue-400 hover:text-blue-300 hover:underline"
+                            >
+                              View signed PDF
+                            </a>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
           {/* Description */}
           {localOpportunity.description && (
             <Card className="bg-slate-700/50 border-slate-600">
@@ -672,6 +836,35 @@ export default function OpportunityDetailPanel({
           </Card>
         </div>
       </div>
+
+      <SendDocumentDialog
+        open={showSendDocDialog}
+        onOpenChange={setShowSendDocDialog}
+        relatedTo="opportunity"
+        relatedId={localOpportunity.id}
+        defaultRecipientName={
+          (() => {
+            const c = contacts?.find((cn) => cn.id === localOpportunity.contact_id);
+            if (c) {
+              return (
+                c.name ||
+                `${c.first_name || ''} ${c.last_name || ''}`.trim() ||
+                ''
+              );
+            }
+            return localOpportunity.name || '';
+          })()
+        }
+        defaultRecipientEmail={
+          contacts?.find((cn) => cn.id === localOpportunity.contact_id)?.email || ''
+        }
+        onSent={(submission) => {
+          if (submission && typeof submission === 'object') {
+            setSubmissions((prev) => [submission, ...prev]);
+          }
+          loadSubmissions();
+        }}
+      />
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
4VD-6: Send Document parity across all four entity detail panels.

MVP only wired Contact. This brings the same Send Document action + Document Signatures lifecycle section to Lead, Account, and Opportunity panels. Same UX everywhere: same status badge palette, same "View signed PDF" link with mirror_url-over-signed_document_url precedence, same 30s polling refresh.

Per-panel notes:
- **Lead**: clean addition. Send Document is available regardless of lead.status (NDAs often pre-date conversion).
- **Account**: pre-fill recipient email falls through `email` -> `primary_email` -> `billing_email` -> empty (operator fills manually if no email on the account record).
- **Opportunity**: panel has a custom layout (677 lines, no UniversalDetailPanel). Send Document button goes in the action row in the header, between Edit and Change Stage. Document Signatures Card lands in the content area before the Description card. Recipient defaults pull from the opportunity's primary contact (`contacts` prop) with a fallback to `opportunity.name` so operators see a recognizable label.

Backend route already supports `related_to=lead|account|opportunity` (verified). Status palette + date formatter duplicated inline across the three new panels rather than extracted to a shared module - three sites is below my centralization threshold, will extract on the 5th.

ESLint clean on all three files. Closes 4VD-6.