### PR TITLE
feat: add prod MCP Coolify build target

### DIFF
--- a/prod/02-mcp/README.md
+++ b/prod/02-mcp/README.md
@@ -1,0 +1,79 @@
+# prod/02-mcp — Coolify-native MCP/Braid on Hetzner
+
+Controlled-production migration of the Braid MCP cluster from the legacy
+GHCR/manual-compose runtime into a Coolify-native build target.
+
+Pattern intentionally mirrors `prod/01-litellm`.
+
+## Provisioning
+
+In Coolify dashboard → New Resource → Docker Compose:
+
+- Name: `prod-mcp`
+- Server: `hetzner-prod`
+- Source: Gitea (`https://gitea.aishacrm.com/aishacrm/aishacrm-2.git`)
+- Branch: `main`
+- Compose file: `/prod/02-mcp/docker-compose.yml`
+- Domains: leave empty (internal-only service)
+- Env vars:
+  - `DOPPLER_TOKEN` = prd_prd-scoped service token
+- Auto deploy: OFF
+
+## IMPORTANT: Alias collision rule
+
+This stack claims the stable Docker DNS aliases:
+
+- `braid-mcp-server`
+- `braid-mcp-1`
+- `braid-mcp-2`
+
+The legacy MCP containers currently running on Hetzner already claim those
+aliases on `aishanet`.
+
+Do NOT deploy this Coolify app while the legacy containers are still running,
+or Docker DNS will round-robin between old/new MCP containers.
+
+## Pre-deploy cutover
+
+On Hetzner:
+
+```bash
+docker stop braid-mcp-server braid-mcp-1 braid-mcp-2
+```
+
+Do not remove them yet.
+
+## Verification
+
+```bash
+# Inventory
+ssh root@<hetzner> 'docker ps --format "table {{.Names}}\t{{.Status}}"'
+
+# MCP health
+ssh root@<hetzner> 'docker exec aishacrm-backend \
+  wget -qO- http://braid-mcp-server:8000/health'
+```
+
+Expected:
+
+```json
+{"status":"ok"}
+```
+
+## Rollback
+
+```bash
+# Stop Coolify MCP containers
+# (names are Coolify-generated; inspect with docker ps)
+docker stop $(docker ps --format '{{.Names}}' | grep -Ei 'mcp|braid')
+
+# Restore legacy containers
+docker start braid-mcp-server braid-mcp-1 braid-mcp-2
+```
+
+Then verify:
+
+```bash
+docker exec aishacrm-backend \
+  wget -qO- http://braid-mcp-server:8000/health
+```

--- a/prod/02-mcp/docker-compose.yml
+++ b/prod/02-mcp/docker-compose.yml
@@ -1,0 +1,148 @@
+# Prod MCP / Braid — Coolify-native build target on Hetzner.
+#
+# Phase 2 controlled-promotion migration for the MCP/Braid service group.
+# Mirrors the proven prod/01-litellm pattern:
+#   - Coolify clones the repo from the Gitea mirror onto Hetzner
+#   - Docker Compose builds locally on Hetzner
+#   - the service joins the existing external aishanet network
+#   - stable Docker DNS aliases are used because Coolify changes container names
+#
+# Deploy model:
+#   - Coolify Application "prod-mcp" on the Prod / Hetzner server points at
+#     the Gitea mirror (https://gitea.aishacrm.com/aishacrm/aishacrm-2.git)
+#     with this compose file as the docker_compose_location.
+#   - Branch: main
+#   - Compose file: /prod/02-mcp/docker-compose.yml
+#   - Domains: empty / internal-only
+#   - Env vars: DOPPLER_TOKEN = prd_prd-scoped token
+#   - Auto deploy: OFF unless explicitly approved in a production release ticket
+#
+# Cutover model:
+#   - Backend already uses BRAID_MCP_URL=http://braid-mcp-server:8000.
+#   - This stack claims the same stable DNS aliases on aishanet.
+#   - Stop the legacy braid-mcp containers immediately before first deployment,
+#     or run a deliberate side-by-side soak using non-conflicting aliases.
+#
+# Coolify v4 path rule:
+#   Build context is `braid-mcp-node-server` because Coolify invokes compose
+#   with the cloned repo root as --project-directory. Do not use ../../ paths.
+
+services:
+  braid-mcp-server:
+    image: aishacrm-mcp:coolify
+    build:
+      context: braid-mcp-node-server
+      dockerfile: Dockerfile
+    container_name: prod-braid-mcp-server
+    restart: unless-stopped
+    cgroup_parent: aishacrm.slice
+    mem_limit: 512m
+    mem_reservation: 256m
+    environment:
+      - NODE_ENV=production
+      - MCP_ROLE=server
+      - PORT=8000
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - CRM_BACKEND_URL=http://aishacrm-backend:3001
+      - REDIS_URL=redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 120s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      aishanet:
+        aliases:
+          - braid-mcp-server
+
+  braid-mcp-1:
+    image: aishacrm-mcp:coolify
+    build:
+      context: braid-mcp-node-server
+      dockerfile: Dockerfile
+    container_name: prod-braid-mcp-1
+    restart: unless-stopped
+    cgroup_parent: aishacrm.slice
+    mem_limit: 384m
+    mem_reservation: 192m
+    depends_on:
+      braid-mcp-server:
+        condition: service_healthy
+    environment:
+      - NODE_ENV=production
+      - MCP_ROLE=node
+      - MCP_NODE_ID=prod-1
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - MCP_SERVER_URL=http://braid-mcp-server:8000
+      - CRM_BACKEND_URL=http://aishacrm-backend:3001
+      - REDIS_URL=redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 120s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      aishanet:
+        aliases:
+          - braid-mcp-1
+
+  braid-mcp-2:
+    image: aishacrm-mcp:coolify
+    build:
+      context: braid-mcp-node-server
+      dockerfile: Dockerfile
+    container_name: prod-braid-mcp-2
+    restart: unless-stopped
+    cgroup_parent: aishacrm.slice
+    mem_limit: 384m
+    mem_reservation: 192m
+    depends_on:
+      braid-mcp-server:
+        condition: service_healthy
+    environment:
+      - NODE_ENV=production
+      - MCP_ROLE=node
+      - MCP_NODE_ID=prod-2
+      - DOPPLER_TOKEN=${DOPPLER_TOKEN:-${DOPPLER_TOKEN_PROD:-}}
+      - DOPPLER_PROJECT=${DOPPLER_PROJECT:-aishacrm}
+      - DOPPLER_CONFIG=${DOPPLER_CONFIG:-prd_prd}
+      - MCP_SERVER_URL=http://braid-mcp-server:8000
+      - CRM_BACKEND_URL=http://aishacrm-backend:3001
+      - REDIS_URL=redis://aishacrm-redis-memory:6379
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/health"]
+      interval: 120s
+      timeout: 3s
+      retries: 3
+      start_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      aishanet:
+        aliases:
+          - braid-mcp-2
+
+networks:
+  # External production network shared with docker-compose.prod.yml and the
+  # existing prod-litellm Coolify app. Coolify must NOT recreate this network.
+  aishanet:
+    external: true


### PR DESCRIPTION
## Summary



- Add Coolify-native production MCP/Braid compose target

- Add prod MCP deployment/runbook documentation

- Mirror the proven prod LiteLLM local-build pattern



## Deployment / Infrastructure Impact



- [x] Production deployment required

- [x] Coolify configuration changed

- [x] Docker Compose changed

- [ ] Environment variables changed

- [ ] Cloudflare / ingress changed



## Validation



- [x] Existing backend to legacy MCP health verified

- [x] Compose follows prod LiteLLM Coolify-native pattern

- [ ] Deploy prod-mcp in Coolify after merge + Gitea mirror



## Rollback Plan



- Stop Coolify-managed MCP containers

- Restart legacy braid-mcp containers

- Verify backend to MCP health endpoint



## Related



- Linear: 4VD-12